### PR TITLE
fix(infra): preserve role-aware excerpt selection

### DIFF
--- a/.github/scripts/raw_log_automation.py
+++ b/.github/scripts/raw_log_automation.py
@@ -107,7 +107,7 @@ LLM_CONTEXT_VARIANTS = (
         "anchor_detail_limit": 320,
         "snippet_limit": 2,
         "snippet_text_limit": 320,
-        "candidate_limit": 1,
+        "candidate_limit": 2,
         "candidate_lines_per_item": 1,
         "candidate_line_limit": 220,
         "style_example_limit": 0,
@@ -937,6 +937,69 @@ def build_anchor_index(anchors: list[dict[str, Any]]) -> dict[str, int]:
     return index
 
 
+def excerpt_candidate_role(candidate: dict[str, Any]) -> str:
+    label = str(candidate.get("label", ""))
+    if label.startswith("consumer_"):
+        return "consumer"
+    if label.startswith("producer_"):
+        return "producer"
+
+    title = str(candidate.get("title", "")).lower()
+    if "consumer" in title:
+        return "consumer"
+    if "producer" in title:
+        return "producer"
+
+    lines = "\n".join(str(line) for line in candidate.get("lines", []))
+    if "role=consumer" in lines:
+        return "consumer"
+    if "role=producer" in lines:
+        return "producer"
+    return ""
+
+
+def select_preferred_excerpt_candidates(
+    candidates: list[dict[str, Any]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    if limit <= 0 or not candidates:
+        return []
+
+    grouped = {
+        "consumer": [candidate for candidate in candidates if excerpt_candidate_role(candidate) == "consumer"],
+        "producer": [candidate for candidate in candidates if excerpt_candidate_role(candidate) == "producer"],
+    }
+
+    selected: list[dict[str, Any]] = []
+    selected_ids: set[int] = set()
+
+    def append_candidate(candidate: dict[str, Any]) -> None:
+        candidate_id = id(candidate)
+        if candidate_id in selected_ids or len(selected) >= limit:
+            return
+        selected.append(candidate)
+        selected_ids.add(candidate_id)
+
+    rank = 0
+    while len(selected) < limit:
+        added = False
+        for role in ("consumer", "producer"):
+            role_candidates = grouped[role]
+            if rank < len(role_candidates):
+                append_candidate(role_candidates[-(rank + 1)])
+                added = True
+        if not added:
+            break
+        rank += 1
+
+    for candidate in reversed(candidates):
+        append_candidate(candidate)
+        if len(selected) >= limit:
+            break
+
+    return selected
+
+
 def build_selected_snippets(
     log_excerpt_candidates: list[dict[str, Any]],
     patch_summaries: list[str],
@@ -944,8 +1007,11 @@ def build_selected_snippets(
 ) -> list[dict[str, Any]]:
     snippets: list[dict[str, Any]] = []
 
-    recent_candidates = log_excerpt_candidates[-MAX_SELECTED_EXCERPT_CANDIDATES:]
-    for candidate in recent_candidates:
+    preferred_candidates = select_preferred_excerpt_candidates(
+        log_excerpt_candidates,
+        MAX_SELECTED_EXCERPT_CANDIDATES,
+    )
+    for candidate in preferred_candidates:
         snippets.append(
             {
                 "label": candidate.get("label", ""),
@@ -1249,8 +1315,11 @@ def compact_office_snapshot(observation: dict[str, Any] | None) -> str:
 
 
 def build_deterministic_log_excerpt(parsed_log: dict[str, Any]) -> str:
-    recent_candidates = parsed_log.get("log_excerpt_candidates", [])[-MAX_DETERMINISTIC_EXCERPT_CANDIDATES:]
-    blocks = [candidate["markdown"] for candidate in recent_candidates if candidate.get("markdown")]
+    preferred_candidates = select_preferred_excerpt_candidates(
+        list(parsed_log.get("log_excerpt_candidates", [])),
+        MAX_DETERMINISTIC_EXCERPT_CANDIDATES,
+    )
+    blocks = [candidate["markdown"] for candidate in preferred_candidates if candidate.get("markdown")]
     return "\n\n".join(blocks)
 
 
@@ -1612,7 +1681,8 @@ def build_summary_refinement_context(
     draft: dict[str, Any],
 ) -> dict[str, Any]:
     excerpt_candidates = build_excerpt_candidates_for_llm(parsed_log)
-    selected_candidate = excerpt_candidates[-1] if excerpt_candidates else {}
+    selected_candidates = select_preferred_excerpt_candidates(excerpt_candidates, 2)
+    selected_candidate = selected_candidates[0] if selected_candidates else {}
     latest_consumer_detail_observation = (
         parsed_log.get("latest_consumer_detail_observation") or parsed_log.get("consumer_peak_observation")
     )
@@ -1630,11 +1700,22 @@ def build_summary_refinement_context(
         ),
         "latest_consumer_detail_observation": summarize_observation_for_llm(latest_consumer_detail_observation),
         "selected_excerpt_candidate": {
+            "label": selected_candidate.get("label", ""),
             "title": selected_candidate.get("title", ""),
             "day": safe_int(selected_candidate.get("day")),
             "sample_index": safe_int(selected_candidate.get("sample_index")),
             "lines": [truncate_text(str(line), 320) for line in selected_candidate.get("lines", [])[:2]],
         },
+        "selected_excerpt_candidates": [
+            {
+                "label": candidate.get("label", ""),
+                "title": candidate.get("title", ""),
+                "day": safe_int(candidate.get("day")),
+                "sample_index": safe_int(candidate.get("sample_index")),
+                "lines": [truncate_text(str(line), 320) for line in candidate.get("lines", [])[:2]],
+            }
+            for candidate in selected_candidates
+        ],
         "semantic_facts": build_llm_semantic_facts(parsed_log)[:6],
     }
 
@@ -1684,7 +1765,7 @@ def compact_excerpt_candidates_for_llm(
     compacted: list[dict[str, Any]] = []
     if candidate_limit <= 0:
         return compacted
-    for candidate in candidates[-candidate_limit:]:
+    for candidate in select_preferred_excerpt_candidates(candidates, candidate_limit):
         compact = dict(candidate)
         compact["observation_window"] = truncate_text(
             str(compact.get("observation_window", "")),
@@ -2872,7 +2953,10 @@ def render_managed_comment(
         compact_payload = dict(payload)
         compact_parsed = dict(payload["parsed_log"])
         compact_parsed["latest_software_office_detail"] = None
-        compact_parsed["log_excerpt_candidates"] = compact_parsed.get("log_excerpt_candidates", [])[-2:]
+        compact_parsed["log_excerpt_candidates"] = select_preferred_excerpt_candidates(
+            list(compact_parsed.get("log_excerpt_candidates", [])),
+            2,
+        )
         compact_parsed["patch_summaries"] = compact_parsed["patch_summaries"][-3:]
         compact_parsed["phantom_corrections"] = compact_parsed["phantom_corrections"][-3:]
         compact_payload["parsed_log"] = compact_parsed

--- a/.github/scripts/tests/test_raw_log_automation.py
+++ b/.github/scripts/tests/test_raw_log_automation.py
@@ -20,7 +20,7 @@ CURRENT_BRANCH_LOG = textwrap.dedent(
     [2026-03-10 14:28:15,189] [INFO]  Office resource storage patch applied for the current load. Outside connections: 6, cargo stations: 28.
     [2026-03-10 14:30:41,511] [INFO]  Signature phantom vacancy guard corrected office property 394316:1 prefab="EE_OfficeSignature02" (36377:1) removed=[PropertyOnMarket]
     [2026-03-10 15:28:36,542] [INFO]  softwareEvidenceDiagnostics observation_window(session_id=20260310T052953590Z, run_id=1, start_day=22, end_day=22, start_sample_index=153, end_sample_index=153, sample_day=22, sample_index=153, sample_slot=1, samples_per_day=2, sample_count=1, observation_kind=scheduled, skipped_sample_slots=0, clock_source=runtime_time_system, trigger=suspicious_state); environment(settings=EnableTradePatch:True,EnablePhantomVacancyFix:True,EnableDemandDiagnostics:True,DiagnosticsSamplesPerDay:2,CaptureStableEvidence:True,VerboseLogging:True, patch_state=debug-build); diagnostic_counters(officeDemand(building=100, company=14196, emptyBuildings=150, buildingDemand=0); freeOfficeProperties(total=0, software=0, inOccupiedBuildings=0, softwareInOccupiedBuildings=0); onMarketOfficeProperties(total=0, activelyVacant=0, occupied=0, staleRenterOnly=0); phantomVacancy(signatureOccupiedOnMarketOffice=0, signatureOccupiedOnMarketIndustrial=0, signatureOccupiedToBeOnMarket=0, nonSignatureOccupiedOnMarketOffice=0, nonSignatureOccupiedOnMarketIndustrial=0, guardCorrections=0); software(resourceProduction=925211, resourceDemand=411328, companies=27, propertyless=1); electronics(resourceProduction=109125, resourceDemand=351810, companies=11, propertyless=2); softwareProducerOffices(total=27, propertyless=1, efficiencyZero=10, lackResourcesZero=10); softwareConsumerOffices(total=28, propertyless=3, efficiencyZero=0, lackResourcesZero=0, softwareInputZero=0)); diagnostic_context(topFactors=[EmptyBuildings=150, Taxes=100, LocalDemand=58, EducatedWorkforce=30])
-    [2026-03-10 15:28:36,542] [INFO]  softwareEvidenceDiagnostics detail(session_id=20260310T052953590Z, run_id=1, observation_end_day=22, observation_end_sample_index=153, detail_type=softwareOfficeStates, values=role=producer, company=524397:1, prefab="Office_SoftwareCompany" (364:1), property=276428:1, output=Software, outputStock=0, input1=Electronics(stock=0, buyCost=0.89), efficiency=0, lackResources=0)
+    [2026-03-10 15:28:36,542] [INFO]  softwareEvidenceDiagnostics detail(session_id=20260310T052953590Z, run_id=1, observation_end_day=22, observation_end_sample_index=153, detail_type=softwareOfficeStates, values=role=producer, company=524397:1, prefab="Office_SoftwareCompany" (364:1), property=276428:1, output=Software, outputStock=0, input1=Electronics(stock=0), efficiency=0, lackResources=0)
     """
 ).strip()
 
@@ -391,6 +391,76 @@ class RawLogAutomationTests(unittest.TestCase):
         summary = automation.build_deterministic_summary(parsed_log, "software_demand_mismatch")
         self.assertIn("softwareConsumerBuyerState(noBuyerDespiteNeed=24, buyerActive=0)", summary)
         self.assertIn("officeDemand(building=100", summary)
+
+    def test_build_summary_refinement_context_keeps_latest_consumer_and_producer(self) -> None:
+        issue_fields = automation.parse_issue_form_sections(RAW_ISSUE_BODY)
+        parsed_log = automation.parse_log(RECENT_MIXED_HISTORY_LOG)
+        deterministic = automation.build_deterministic_draft(
+            21,
+            issue_fields,
+            parsed_log,
+            {"mode": "inline", "url": "", "attachment_urls": [], "text": RECENT_MIXED_HISTORY_LOG},
+            [],
+        )
+        context = automation.build_summary_refinement_context(
+            issue_fields,
+            parsed_log,
+            deterministic,
+            {"title": deterministic["title"], "evidence_summary": deterministic["evidence_summary"]},
+        )
+        self.assertEqual(
+            [candidate["label"] for candidate in context["selected_excerpt_candidates"]],
+            ["consumer_latest", "producer_latest"],
+        )
+        self.assertEqual(context["selected_excerpt_candidate"]["label"], "consumer_latest")
+        self.assertIn("role=consumer", "\n".join(context["selected_excerpt_candidates"][0]["lines"]))
+        self.assertIn("role=producer", "\n".join(context["selected_excerpt_candidates"][1]["lines"]))
+
+    def test_build_summary_refinement_context_keeps_consumer_excerpt_when_no_producer_exists(self) -> None:
+        issue_fields = automation.parse_issue_form_sections(RAW_ISSUE_BODY)
+        parsed_log = automation.parse_log(BUYER_STATE_ONLY_LOG)
+        deterministic = automation.build_deterministic_draft(
+            21,
+            issue_fields,
+            parsed_log,
+            {"mode": "inline", "url": "", "attachment_urls": [], "text": BUYER_STATE_ONLY_LOG},
+            [],
+        )
+        context = automation.build_summary_refinement_context(
+            issue_fields,
+            parsed_log,
+            deterministic,
+            {"title": deterministic["title"], "evidence_summary": deterministic["evidence_summary"]},
+        )
+        self.assertEqual(
+            [candidate["label"] for candidate in context["selected_excerpt_candidates"]],
+            ["consumer_latest"],
+        )
+        self.assertEqual(context["selected_excerpt_candidate"]["label"], "consumer_latest")
+        self.assertIn("role=consumer", "\n".join(context["selected_excerpt_candidates"][0]["lines"]))
+
+    def test_build_summary_refinement_context_keeps_producer_excerpt_when_no_consumer_exists(self) -> None:
+        issue_fields = automation.parse_issue_form_sections(RAW_ISSUE_BODY)
+        parsed_log = automation.parse_log(CURRENT_BRANCH_LOG)
+        deterministic = automation.build_deterministic_draft(
+            21,
+            issue_fields,
+            parsed_log,
+            {"mode": "inline", "url": "", "attachment_urls": [], "text": CURRENT_BRANCH_LOG},
+            [],
+        )
+        context = automation.build_summary_refinement_context(
+            issue_fields,
+            parsed_log,
+            deterministic,
+            {"title": deterministic["title"], "evidence_summary": deterministic["evidence_summary"]},
+        )
+        self.assertEqual(
+            [candidate["label"] for candidate in context["selected_excerpt_candidates"]],
+            ["producer_latest"],
+        )
+        self.assertEqual(context["selected_excerpt_candidate"]["label"], "producer_latest")
+        self.assertIn("role=producer", "\n".join(context["selected_excerpt_candidates"][0]["lines"]))
 
     def test_managed_comment_round_trip_preserves_override_block(self) -> None:
         issue_fields = automation.parse_issue_form_sections(RAW_ISSUE_BODY)
@@ -867,9 +937,17 @@ class RawLogAutomationTests(unittest.TestCase):
         )
         context = automation.build_llm_context(issue_fields, parsed_log, deterministic, [])
         variants = automation.build_llm_context_variants(context)
+        # Excerpt candidate ordering strategy:
+        # - For variants[0], we include both latest and previous samples, and order them
+        #   by time first (latest before previous) while interleaving consumer/producer
+        #   within each time grouping:
+        #   ["consumer_latest", "producer_latest", "consumer_previous", "producer_previous"].
+        # - For variants[1] and variants[2], we intentionally keep only the latest
+        #   consumer/producer samples and drop previous samples to prioritize the most
+        #   recent context in downstream LLM calls.
         self.assertEqual(
             [candidate["label"] for candidate in variants[0]["excerpt_candidates"]],
-            ["consumer_previous", "producer_previous", "consumer_latest", "producer_latest"],
+            ["consumer_latest", "producer_latest", "consumer_previous", "producer_previous"],
         )
         self.assertEqual(
             [candidate["label"] for candidate in variants[1]["excerpt_candidates"]],
@@ -877,7 +955,7 @@ class RawLogAutomationTests(unittest.TestCase):
         )
         self.assertEqual(
             [candidate["label"] for candidate in variants[2]["excerpt_candidates"]],
-            ["producer_latest"],
+            ["consumer_latest", "producer_latest"],
         )
 
     def test_has_unsupported_reasoning_summary_format_rejects_double_question_mark(self) -> None:

--- a/.github/software-evidence-schema.md
+++ b/.github/software-evidence-schema.md
@@ -69,7 +69,7 @@ Required:
 
 Optional:
 
-- `log_excerpt`: only short excerpts or references to attached logs, including relevant `softwareEvidenceDiagnostics detail(...)` lines when office-level state matters; prefer copied anchored detail lines from the newest relevant sample, plus the immediately previous distinct sample only when short chronology matters
+- `log_excerpt`: only short excerpts or references to attached logs, including relevant `softwareEvidenceDiagnostics detail(...)` lines when office-level state matters; when both roles exist, prefer the latest anchored consumer excerpt plus the latest anchored producer excerpt, then, when short chronology matters, also include the immediately previous distinct sample for each role (one older consumer excerpt and one older producer excerpt)
 - `artifacts`: links or filenames for logs, saves, screenshots, or videos; may include relevant `softwareEvidenceDiagnostics detail(...)` lines such as `detail_type=softwareOfficeStates`, which now cover both producer-side and consumer-side office states and may include trade-cost-entry, active-buyer, trip-needed, current-trading, and path-state cues
 - `analysis_basis`: when code reading influenced interpretation, note whether the reasoning came from vanilla decompiled game code, this mod's code, or both, and what each source established
 - `notes`: anything useful that does not fit the structured fields

--- a/.github/software-investigation-workflow.md
+++ b/.github/software-investigation-workflow.md
@@ -66,9 +66,10 @@ Capture guidance:
 - if runtime emits `patch_state=unknown`, keep that value unless you can replace it with an exact known local deviation set
 - when differentiating upstream input pressure from downstream software-consumer shortage or office-resource trade and storage gating, prefer preserving `electronics(...)`, `software(...)`, `softwareProducerOffices(...)`, `softwareConsumerOffices(...)`, and any relevant `detail_type=softwareOfficeStates` lines together
 - when the active question is why zero-software consumers keep empty buyer state, preserve `softwareConsumerBuyerState(...)` together with the relevant `softwareNeed(...)`, `softwareTradeCost(...)`, `softwareBuyerState(...)`, and `softwareTrace(...)` detail blocks
+- keep the concise producer `input1(...)` / `input2(...)` formatter stock-only by default; if producer-side trade-cost metadata becomes part of the active question, add or use a separate verbose diagnostic path instead of re-expanding the concise formatter
 - treat `sample_count` as emitted `softwareEvidenceDiagnostics observation_window(...)` density inside the current run, not as a replacement for the day fields
 - treat `skipped_sample_slots` as scheduled sample slots that were missed and honestly reported rather than backfilled
-- if raw-log automation produced multiple detail excerpts for one role, treat the latest anchored sample as the default excerpt and include at most one older anchored sample only when it preserves short local chronology that materially improves interpretation
+- if raw-log automation preserved both consumer-side and producer-side detail, treat the latest anchored consumer excerpt plus the latest anchored producer excerpt as the default pair and include older anchored samples only when they preserve short local chronology that materially improves interpretation
 - treat changes to the machine-parsed log prefixes as parser-contract changes; when those prefixes are centralized in `NoOfficeDemandFix/MachineParsedLogContract.cs`, update the Python parser constants and fixtures in the same diff
 
 The current diagnostics vocabulary is:

--- a/LOG_REPORTING.md
+++ b/LOG_REPORTING.md
@@ -29,7 +29,7 @@ Current setting defaults are documented in [README.md](./README.md).
 - read the raw log
 - redact obvious local filesystem paths before optional GitHub Models drafting
 - extract the latest `softwareEvidenceDiagnostics observation_window(...)`
-- preserve recent anchored `softwareEvidenceDiagnostics detail(...)` lines, using the newest relevant sample for each role as the default excerpt and adding at most one immediately previous distinct sample only when short chronology materially affects interpretation
+- preserve recent anchored `softwareEvidenceDiagnostics detail(...)` lines, using the latest consumer excerpt plus the latest producer excerpt as the default pair when both roles exist and adding at most one immediately previous distinct sample only when short chronology materially affects interpretation
 - post a managed triage comment with a normalized draft and a copy-ready
   `maintainer_reply` YAML block
 
@@ -68,8 +68,10 @@ until later evidence synthesis reviews the counters and excerpts together.
   paste the YAML directly or wrap it in fences, edit it there, and include
   `/promote-evidence` in that same comment
 - when the managed triage comment shows multiple excerpt candidates, prefer the
-  newest anchored excerpt unless the immediately previous sample adds important
-  chronology for the final evidence entry (for example, when it shows the onset of a condition that persists in the latest sample)
+  latest anchored consumer excerpt plus the latest anchored producer excerpt
+  when both exist; use an immediately previous sample only when it adds
+  important chronology for the final evidence entry (for example, when it
+  shows the onset of a condition that persists in the latest sample)
 - keep the copied observation window, counters, and selected detail excerpts aligned; do not swap in older detail lines unless the chronology is explicitly the point of the final evidence entry
 - the automation creates a plain-Markdown `Software evidence` issue, links it
   back to the raw-log issue, and closes the raw-log intake issue

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -34,10 +34,11 @@ Promotion flow:
 
 Review defaults:
 
-- treat the latest bounded observation plus the newest anchored detail excerpt as the default evidence view
+- treat the latest bounded observation plus the latest anchored consumer excerpt and latest anchored producer excerpt as the default evidence view when both roles exist
 - include at most the immediately previous distinct sample when short chronology materially improves the evidence entry
 - treat copied observation anchors, counters, and selected detail excerpts as the hard evidence
 - keep `patch_state=unknown` unless you can replace it with an exact known local deviation set
+- treat missing producer-side trade-cost fields in the concise `input1(...)` / `input2(...)` formatter as intentional unless the change explicitly adds a separate verbose diagnostic path; see [LOG_REPORTING.md](./LOG_REPORTING.md) for formatter and diagnostic-path conventions
 
 Detailed capture rules, interpretation rules, and comparison checkpoints live in
 [LOG_REPORTING.md](./LOG_REPORTING.md),


### PR DESCRIPTION
## What changed
- Updated raw-log automation to prefer the latest consumer excerpt plus the latest producer excerpt when both roles are present instead of tail-slicing only the newest detail lines.
- Applied the same role-aware selection rule to deterministic excerpts, LLM context variants, summary refinement, and compact managed-comment payload trimming.
- Added regression coverage for mixed-role, consumer-only, and producer-only summary-refinement cases.
- Updated maintainer-facing docs to describe the paired-excerpt default and to keep the concise producer formatter stock-only unless a separate verbose path is added.

## Why
- The active software-track investigation needs both latest consumer and producer evidence preserved together when both roles are present, while still behaving predictably when only one role exists.
- Previous tail-slicing could drop one role from low-budget contexts and make triage comments less reusable for later evidence promotion.
- Refs: #29

## How
- Added a role-aware excerpt selector that ranks latest consumer and latest producer first, then falls back to older same-role excerpts only if space remains.
- Reused that selector across deterministic excerpt building, summary refinement, compact LLM variants, and oversized managed-comment payload trimming.
- Kept the parser fallback semantic-neutral and left the current runtime diagnostics contract unchanged.
- Save compatibility / migration impact:
  - none; this changes automation, tests, and maintainer guidance only

## Testing
- Build / validation:
  - `python -m pytest -q`
- Manual verification:
  - reviewed the updated excerpt-selection behavior against mixed-role, consumer-only, and producer-only fixtures
  - verified the maintainer docs now match the current concise producer formatter contract
- Settings touched:
  - [x] No settings changed
  - [ ] Defaults changed
  - [ ] Reload required
  - [ ] Restart required
- Runtime build was not rerun because this diff does not change C# or shipped mod binaries.

## Risk / Rollback
- Risk areas:
  - managed triage comments and draft evidence excerpts may change ordering compared with older automation output
- Rollback / mitigation:
  - revert this PR to restore the previous tail-slicing behavior if the paired-excerpt selection proves noisier than expected

## Reviewer Checklist
- [x] Linked issue, investigation, or release item when applicable
- [x] README or docs updated if behavior or defaults changed
- [x] Save compatibility impact called out
- [x] Verification steps are specific enough to reproduce
- [x] Risk and rollback are concrete for shipped behavior

## PR Classification (optional)
- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore/Maintenance
- [ ] Build/CI
- [ ] Test

Justification:
This PR corrects raw-log triage behavior so both roles are preserved in the default evidence view when both are available, without changing the runtime diagnostics contract.