### PR TITLE
fix(automation): enhance managed comment rendering and validation

### DIFF
--- a/.github/scripts/raw_log_automation.py
+++ b/.github/scripts/raw_log_automation.py
@@ -40,6 +40,7 @@ DEFAULT_SUMMARY_REFINEMENT_GITHUB_MODELS_MODEL = "openai/gpt-4.1"
 PRIMARY_GITHUB_MODELS_MODEL_ENV = "PRIMARY_GITHUB_MODELS_MODEL"
 ESCALATION_GITHUB_MODELS_MODEL_ENV = "ESCALATION_GITHUB_MODELS_MODEL"
 SUMMARY_REFINEMENT_GITHUB_MODELS_MODEL_ENV = "SUMMARY_REFINEMENT_GITHUB_MODELS_MODEL"
+GITHUB_ISSUE_COMMENT_MAX_LENGTH = 65536
 COMMENT_BODY_LIMIT = 60000
 DETAIL_PREVIEW_LIMIT = 1800
 LLM_DETAIL_EXCERPT_LIMIT = 700
@@ -2907,12 +2908,133 @@ def render_managed_comment(
     redaction_summary = "; ".join(redaction_notes) if redaction_notes else "none"
     deterministic_reasoning = deterministic_draft.get("reasoning_summary", "not available")
     llm_reasoning = (llm_draft or {}).get("reasoning_summary", "")
-    preview_body = render_evidence_issue_body(issue_number, 0, preview_fields).rstrip()
+    body = render_managed_comment_body(
+        issue_number,
+        preview_fields,
+        payload,
+        reply_fields,
+        combined_missing,
+        log_source["mode"],
+        redaction_summary,
+        llm_status,
+        llm_detail,
+        deterministic_reasoning,
+        llm_reasoning,
+        compact=False,
+    )
+    if len(body) <= COMMENT_BODY_LIMIT:
+        return body, payload
 
-    body = "\n".join(
+    compact_payload = build_compact_managed_comment_payload(payload)
+    body = render_managed_comment_body(
+        issue_number,
+        preview_fields,
+        compact_payload,
+        reply_fields,
+        combined_missing,
+        log_source["mode"],
+        redaction_summary,
+        llm_status,
+        llm_detail,
+        deterministic_reasoning,
+        llm_reasoning,
+        compact=True,
+    )
+    if len(body) <= GITHUB_ISSUE_COMMENT_MAX_LENGTH:
+        return body, compact_payload
+
+    compact_preview_fields = compact_preview_evidence_fields(preview_fields)
+    body = render_managed_comment_body(
+        issue_number,
+        compact_preview_fields,
+        compact_payload,
+        reply_fields,
+        combined_missing,
+        log_source["mode"],
+        redaction_summary,
+        llm_status,
+        llm_detail,
+        deterministic_reasoning,
+        llm_reasoning,
+        compact=True,
+    )
+    return body, compact_payload
+
+
+def build_compact_managed_comment_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    parsed_log = payload.get("parsed_log", {})
+    compact_candidates = select_preferred_excerpt_candidates(
+        list(parsed_log.get("log_excerpt_candidates", [])),
+        MAX_SELECTED_EXCERPT_CANDIDATES,
+    )
+    return {
+        "raw_issue": dict(payload.get("raw_issue", {})),
+        "log_source": dict(payload.get("log_source", {})),
+        "redaction_notes": list(payload.get("redaction_notes", [])),
+        "parsed_log": {
+            "latest_observation": parsed_log.get("latest_observation"),
+            "latest_software_office_detail": parsed_log.get("latest_software_office_detail"),
+            "log_excerpt_candidates": compact_candidates,
+            "observation_count": parsed_log.get("observation_count", 0),
+            "detail_count": parsed_log.get("detail_count", 0),
+        },
+        "deterministic_draft": dict(payload.get("deterministic_draft", {})),
+        "llm_draft": dict(payload["llm_draft"]) if isinstance(payload.get("llm_draft"), dict) else None,
+        "combined_missing_user_input": list(payload.get("combined_missing_user_input", [])),
+        "llm_status": payload.get("llm_status", ""),
+        "llm_detail": payload.get("llm_detail", ""),
+    }
+
+
+def compact_preview_evidence_fields(preview_fields: dict[str, str]) -> dict[str, str]:
+    compact = dict(preview_fields)
+    compact["reproduction-conditions"] = truncate_text(compact.get("reproduction-conditions", ""), 600)
+    compact["platform-notes"] = truncate_text(compact.get("platform-notes", ""), 600)
+    compact["other-mods"] = truncate_text(compact.get("other-mods", ""), 600)
+    compact["diagnostic-counters"] = truncate_text(compact.get("diagnostic-counters", ""), 1500)
+    compact["comparison-baseline"] = truncate_text(compact.get("comparison-baseline", ""), 600)
+    compact["confounders"] = truncate_text(compact.get("confounders", ""), 900)
+    compact["analysis-basis"] = truncate_text(compact.get("analysis-basis", ""), 600)
+    compact["notes"] = truncate_text(compact.get("notes", ""), 1200)
+    compact["log-excerpt"] = ""
+    return compact
+
+
+def render_managed_comment_body(
+    issue_number: int,
+    preview_fields: dict[str, str],
+    payload: dict[str, Any],
+    reply_fields: dict[str, str],
+    combined_missing: list[str],
+    raw_log_source_mode: str,
+    redaction_summary: str,
+    llm_status: str,
+    llm_detail: str,
+    deterministic_reasoning: str,
+    llm_reasoning: str,
+    *,
+    compact: bool,
+) -> str:
+    preview_body = render_evidence_issue_body(issue_number, 0, preview_fields).rstrip()
+    reasoning_line = f"- LLM reasoning: `{llm_reasoning if llm_reasoning else 'not used'}`"
+    if compact:
+        if llm_reasoning:
+            reasoning_line = (
+                f"- LLM reasoning: `{llm_reasoning}`"
+                if len(llm_reasoning) <= LLM_REASONING_SUMMARY_MAX_LENGTH
+                else "- LLM reasoning: `see machine payload`"
+            )
+        else:
+            reasoning_line = "- LLM reasoning: `not used`"
+
+    return "\n".join(
         [
             MANAGED_COMMENT_MARKER,
-            f"Raw log triage draft for #{issue_number}. Do not edit this bot comment. Copy the `maintainer_reply` YAML below into a new maintainer comment, edit it there, and add `{PROMOTE_COMMAND}` in that same comment when the evidence issue is ready. Pasting the copied YAML directly is valid; code fences are optional.",
+            (
+                f"Raw log triage draft for #{issue_number}. Do not edit this bot comment. Copy the `maintainer_reply` YAML below into a new maintainer comment, edit it there, and add `{PROMOTE_COMMAND}` in that same comment when the evidence issue is ready. Pasting the copied YAML directly is valid; code fences are optional."
+                if not compact
+                else f"Raw log triage draft for #{issue_number}. Do not edit this bot comment. Copy the `maintainer_reply` YAML into a new maintainer comment and add `{PROMOTE_COMMAND}` there when ready. Plain pasted YAML is accepted."
+            ),
             "",
             "## Draft Evidence Issue Preview",
             f"Draft title: `{preview_fields.get('title', '')}`",
@@ -2922,13 +3044,17 @@ def render_managed_comment(
             f"- LLM status: `{llm_status}`",
             f"- LLM detail: `{llm_detail}`",
             f"- Missing before promote: `{', '.join(combined_missing) if combined_missing else 'none'}`",
-            f"- Raw log source: `{log_source['mode']}`",
-            f"- Redaction notes: `{redaction_summary}`",
+            f"- Raw log source: `{raw_log_source_mode}`" if not compact else "",
+            f"- Redaction notes: `{redaction_summary}`" if not compact else "",
             f"- Deterministic reasoning: `{deterministic_reasoning}`",
-            f"- LLM reasoning: `{llm_reasoning if llm_reasoning else 'not used'}`",
+            reasoning_line,
             "",
             "### Maintainer reply template",
-            f"Copy this YAML into a new comment, edit it there, and add `{PROMOTE_COMMAND}` in that same comment. GitHub's code-block Copy button returns plain YAML text, and that plain YAML is accepted.",
+            (
+                f"Copy this YAML into a new comment, edit it there, and add `{PROMOTE_COMMAND}` in that same comment. GitHub's code-block Copy button returns plain YAML text, and that plain YAML is accepted."
+                if not compact
+                else ""
+            ),
             REPLY_TEMPLATE_START_MARKER,
             "```yaml",
             dump_reply_yaml(reply_fields),
@@ -2948,63 +3074,6 @@ def render_managed_comment(
             PAYLOAD_END_MARKER,
         ]
     ).strip()
-
-    if len(body) > COMMENT_BODY_LIMIT:
-        compact_payload = dict(payload)
-        compact_parsed = dict(payload["parsed_log"])
-        compact_parsed["latest_software_office_detail"] = None
-        compact_parsed["log_excerpt_candidates"] = select_preferred_excerpt_candidates(
-            list(compact_parsed.get("log_excerpt_candidates", [])),
-            2,
-        )
-        compact_parsed["patch_summaries"] = compact_parsed["patch_summaries"][-3:]
-        compact_parsed["phantom_corrections"] = compact_parsed["phantom_corrections"][-3:]
-        compact_payload["parsed_log"] = compact_parsed
-        body = "\n".join(
-            [
-                MANAGED_COMMENT_MARKER,
-                f"Raw log triage draft for #{issue_number}. Do not edit this bot comment. Copy the `maintainer_reply` YAML into a new maintainer comment and add `{PROMOTE_COMMAND}` there when ready. Plain pasted YAML is accepted.",
-                "",
-                "## Draft Evidence Issue Preview",
-                f"Draft title: `{preview_fields.get('title', '')}`",
-                preview_body,
-                "",
-                "### Draft provenance",
-                f"- LLM status: `{llm_status}`",
-                f"- LLM detail: `{llm_detail}`",
-                f"- Missing before promote: `{', '.join(combined_missing) if combined_missing else 'none'}`",
-                f"- Deterministic reasoning: `{deterministic_reasoning}`",
-                (
-                    f"- LLM reasoning: `{llm_reasoning}`"
-                    if llm_reasoning and len(llm_reasoning) <= LLM_REASONING_SUMMARY_MAX_LENGTH
-                    else "- LLM reasoning: `see machine payload`"
-                )
-                if llm_reasoning
-                else "- LLM reasoning: `not used`",
-                "",
-                "### Maintainer reply template",
-                REPLY_TEMPLATE_START_MARKER,
-                "```yaml",
-                dump_reply_yaml(reply_fields),
-                "```",
-                REPLY_TEMPLATE_END_MARKER,
-                "",
-                PAYLOAD_START_MARKER,
-                "<details>",
-                "<summary>Machine payload</summary>",
-                "",
-                "Do not edit this block manually.",
-                "",
-                "```json",
-                json.dumps(compact_payload, ensure_ascii=True, indent=2),
-                "```",
-                "</details>",
-                PAYLOAD_END_MARKER,
-            ]
-        ).strip()
-        payload = compact_payload
-
-    return body, payload
 
 
 def parse_managed_comment(comment_body: str) -> dict[str, Any]:
@@ -3061,6 +3130,7 @@ def get_issue(repo: str, issue_number: int, token: str) -> dict[str, Any]:
 
 
 def create_issue_comment(repo: str, issue_number: int, body: str, token: str) -> dict[str, Any]:
+    validate_issue_comment_body_size(body)
     comments_url = f"{GITHUB_API_BASE_URL}/repos/{repo}/issues/{issue_number}/comments"
     status, payload, raw = http_request("POST", comments_url, token=token, payload={"body": body})
     if status >= 400:
@@ -3069,11 +3139,20 @@ def create_issue_comment(repo: str, issue_number: int, body: str, token: str) ->
 
 
 def update_issue_comment(repo: str, comment_id: int, body: str, token: str) -> dict[str, Any]:
+    validate_issue_comment_body_size(body)
     comment_url = f"{GITHUB_API_BASE_URL}/repos/{repo}/issues/comments/{comment_id}"
     status, payload, raw = http_request("PATCH", comment_url, token=token, payload={"body": body})
     if status >= 400:
         raise AutomationError(f"Failed to update issue comment ({status}): {raw}")
     return payload
+
+
+def validate_issue_comment_body_size(body: str) -> None:
+    if len(body) <= GITHUB_ISSUE_COMMENT_MAX_LENGTH:
+        return
+    raise AutomationError(
+        f"Issue comment body is too long ({len(body)} characters; GitHub limit is {GITHUB_ISSUE_COMMENT_MAX_LENGTH})."
+    )
 
 
 def find_managed_comment(comments: list[dict[str, Any]]) -> dict[str, Any] | None:

--- a/.github/scripts/tests/test_raw_log_automation.py
+++ b/.github/scripts/tests/test_raw_log_automation.py
@@ -683,6 +683,87 @@ class RawLogAutomationTests(unittest.TestCase):
         self.assertIn(f"- LLM reasoning: `{short_reasoning}`", body)
         self.assertNotIn("see machine payload", body)
 
+    def test_render_managed_comment_compacts_large_machine_payload_below_github_limit(self) -> None:
+        issue_fields = automation.parse_issue_form_sections(RAW_ISSUE_BODY)
+        log_source = {"mode": "inline", "url": "", "attachment_urls": [], "text": CURRENT_BRANCH_LOG}
+        parsed_log = automation.parse_log(CURRENT_BRANCH_LOG)
+        bloated_parsed_log = dict(parsed_log)
+        bloated_parsed_log["anchors"] = [
+            {
+                "kind": "observation",
+                "timestamp": f"2026-03-10 15:{index:02d}:00,000",
+                "raw_line": "A" * 3500,
+                "message": "B" * 2500,
+            }
+            for index in range(30)
+        ]
+        bloated_parsed_log["anchor_index"] = {f"anchor_{index}": index for index in range(400)}
+        bloated_parsed_log["selected_snippets"] = [
+            {
+                "kind": "detail_excerpt",
+                "label": f"snippet_{index}",
+                "text": "C" * 1800,
+            }
+            for index in range(20)
+        ]
+        deterministic = automation.build_deterministic_draft(21, issue_fields, bloated_parsed_log, log_source, [])
+        body, payload = automation.render_managed_comment(
+            21,
+            issue_fields,
+            log_source,
+            bloated_parsed_log,
+            deterministic,
+            None,
+            {
+                "scenario_label": "New Seoul",
+                "scenario_type": "existing save",
+                "reproduction_conditions": "Loaded the same save and waited 3 in-game days.",
+                "mod_ref": "",
+                "symptom_classification": deterministic["symptom_classification"],
+                "evidence_summary": deterministic["evidence_summary"],
+                "confounders": deterministic["confounders"],
+                "notes": deterministic["notes"],
+            },
+            [],
+            "skipped",
+            "no eligible observation",
+        )
+        self.assertLessEqual(len(body), automation.GITHUB_ISSUE_COMMENT_MAX_LENGTH)
+        self.assertIn("```yaml", body)
+        self.assertIn("```json", body)
+        self.assertIn("Plain pasted YAML is accepted.", body)
+        self.assertNotIn("A" * 500, body)
+        self.assertNotIn("B" * 500, body)
+        self.assertNotIn("C" * 500, body)
+        self.assertNotIn("anchors", payload["parsed_log"])
+        self.assertNotIn("selected_snippets", payload["parsed_log"])
+        parsed = automation.parse_managed_comment(body)
+        self.assertEqual(parsed["reply_template"]["scenario_label"], "New Seoul")
+        self.assertEqual(parsed["reply_template"]["scenario_type"], "existing save")
+        self.assertEqual(parsed["reply_template"]["evidence_summary"], deterministic["evidence_summary"])
+        self.assertIn("latest_observation", parsed["payload"]["parsed_log"])
+        self.assertEqual(parsed["payload"]["raw_issue"]["number"], 21)
+        self.assertEqual(parsed["payload"]["log_source"]["mode"], "inline")
+        self.assertEqual(parsed["payload"]["parsed_log"]["observation_count"], parsed_log["observation_count"])
+        self.assertEqual(parsed["payload"]["parsed_log"]["detail_count"], parsed_log["detail_count"])
+        self.assertEqual(
+            parsed["payload"]["parsed_log"]["latest_observation"]["observation_window"]["sample_day"],
+            parsed_log["latest_observation"]["observation_window"]["sample_day"],
+        )
+        self.assertEqual(
+            parsed["payload"]["parsed_log"]["latest_software_office_detail"]["values"],
+            parsed_log["latest_software_office_detail"]["values"],
+        )
+        self.assertEqual(
+            [candidate["label"] for candidate in parsed["payload"]["parsed_log"]["log_excerpt_candidates"]],
+            [candidate["label"] for candidate in parsed_log["log_excerpt_candidates"]],
+        )
+        self.assertEqual(parsed["payload"]["deterministic_draft"]["title"], deterministic["title"])
+        self.assertEqual(
+            parsed["payload"]["deterministic_draft"]["log_excerpt"],
+            deterministic["log_excerpt"],
+        )
+
     def test_merge_evidence_fields_and_required_gate(self) -> None:
         issue_fields = automation.parse_issue_form_sections(RAW_ISSUE_BODY)
         log_source = {"mode": "inline", "url": "", "attachment_urls": [], "text": CURRENT_BRANCH_LOG}
@@ -1749,6 +1830,16 @@ class RawLogAutomationTests(unittest.TestCase):
         with mock.patch.object(automation, "http_request", return_value=(500, {"message": "boom"}, "boom")):
             with self.assertRaisesRegex(automation.AutomationError, r"Failed to fetch issue comments \(500\): boom"):
                 automation.get_issue_comments("FennexFox/NoOfficeDemandFix", 30, "token")
+
+    def test_create_issue_comment_rejects_oversized_body(self) -> None:
+        oversized_body = "X" * (automation.GITHUB_ISSUE_COMMENT_MAX_LENGTH + 1)
+        with mock.patch.object(automation, "http_request") as request_mock:
+            with self.assertRaisesRegex(
+                automation.AutomationError,
+                r"Issue comment body is too long",
+            ):
+                automation.create_issue_comment("FennexFox/NoOfficeDemandFix", 30, oversized_body, "token")
+        request_mock.assert_not_called()
 
     def test_http_request_wraps_url_error_in_automation_error(self) -> None:
         with mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("dns fail")):


### PR DESCRIPTION
## What changed
- Added staged compaction for oversized raw-log managed comments so the workflow can shrink the machine payload first and then shrink the preview if needed.
- Kept promotion-critical fields in the compact payload while dropping bulky anchor and snippet data that is not needed for promotion.
- Added a local guard that rejects issue comment bodies above GitHub's 65,536-character limit before POST/PATCH requests are sent.
- Expanded regression coverage for oversized managed comments, including compacted payload integrity and local oversize rejection.

## Why
- Raw-log triage could fail with GitHub `422` responses when a large diagnostics log caused the managed comment body to exceed the issue comment size limit.

## How
- Introduced `GITHUB_ISSUE_COMMENT_MAX_LENGTH` and refactored managed comment rendering into reusable full and compact paths.
- Added compact payload rendering that preserves `latest_observation`, `latest_software_office_detail`, excerpt candidates, counts, and the deterministic/LLM drafts used by promotion.
- Added a final preview-compaction fallback that truncates long preview fields and drops the preview excerpt when required to stay under the GitHub limit.
- No gameplay settings or defaults changed; the new thresholds are automation-only safety limits.
- Save compatibility / migration impact:
  - None.

## Testing
- Build / validation:
  - `python -m unittest discover -s .github/scripts/tests -p "test_*.py"`
- Manual verification:
  - Rendered a managed comment from local log; the generated body dropped from about 498k characters to about 47k characters and stayed below GitHub's 65,536-character limit.
- Settings touched:
  - [x] No settings changed
  - [ ] Defaults changed
  - [ ] Reload required
  - [ ] Restart required

## Risk / Rollback
- Risk areas:
  - Compaction could omit context maintainers expect if a future promotion path starts depending on fields that are currently trimmed.
- Rollback / mitigation:
  - Revert the managed comment compaction and size-guard changes in `.github/scripts/raw_log_automation.py`, then rerun raw-log triage on the affected raw-log issue.

## Reviewer Checklist
- [ ] Linked issue, investigation, or release item when applicable
- [ ] README or docs updated if behavior or defaults changed
- [x] Save compatibility impact called out
- [x] Verification steps are specific enough to reproduce
- [x] Risk and rollback are concrete for shipped behavior

## PR Classification (optional)
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Docs
- [ ] Chore/Maintenance
- [ ] Build/CI
- [ ] Test

Justification:
This pull request prevents raw-log triage from failing when managed comments exceed GitHub's issue comment size limit.
