### PR TITLE
fix(systems): Load settings before registering in options UI

### DIFF
--- a/NoOfficeDemandFix/Mod.cs
+++ b/NoOfficeDemandFix/Mod.cs
@@ -40,11 +40,12 @@ namespace NoOfficeDemandFix
             updateSystem.UpdateBefore<VirtualOfficeResourceBuyerFixSystem, ResourceBuyerSystem>(SystemUpdatePhase.GameSimulation);
 
             m_Setting = new Setting(this);
-            m_Setting.RegisterInOptionsUI();
-            GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(m_Setting));
+            AssetDatabase.global.LoadSettings(nameof(NoOfficeDemandFix), m_Setting, new Setting(this));
             Settings = m_Setting;
 
-            AssetDatabase.global.LoadSettings(nameof(NoOfficeDemandFix), m_Setting, new Setting(this));
+            GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(m_Setting));
+            m_Setting.RegisterInOptionsUI();
+
             BootstrapHarmonyPatchesIfNeeded();
         }
 


### PR DESCRIPTION
## What changed
- Load settings prior to registering in the options UI.
- Ensure settings are correctly initialized before use.

## Why
- This change addresses the issue of settings not being available when the options UI is registered.

## How
- The loading of settings occurs before the registration call to ensure proper initialization.
- No significant defaults or thresholds changed; no reload or restart required.
- Save compatibility / migration impact: None.

## Testing
- Build / validation:
  - Successfully built and validated the changes.
- Manual verification:
  - Verified that settings load correctly in the options UI.
- Settings touched:
  - [ ] No settings changed
  - [ ] Defaults changed
  - [ ] Reload required
  - [ ] Restart required

## Risk / Rollback
- Risk areas:
  - Potential issues with settings not loading correctly if the order is not maintained.
- Rollback / mitigation:
  - Revert to the previous implementation if issues arise.

## Reviewer Checklist
- [ ] Linked issue, investigation, or release item when applicable
- [ ] README or docs updated if behavior or defaults changed
- [ ] Save compatibility impact called out
- [ ] Verification steps are specific enough to reproduce
- [ ] Risk and rollback are concrete for shipped behavior

## PR Classification (optional)
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Docs
- [ ] Chore/Maintenance
- [ ] Build/CI
- [ ] Test

Justification: This change fixes a bug related to the order of operations in loading settings.

