### PR TITLE
fix(telemetry): align performance sampling with render cadence

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance_telemetry_report.yml
+++ b/.github/ISSUE_TEMPLATE/performance_telemetry_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         <!-- performance-telemetry-report -->
-        Use this form when you want to share coarse performance telemetry and let automation summarize steady-state overhead, stall behavior, and direct-comparison validity.
+        Use this form when you want to share coarse, render-aligned performance telemetry and let automation summarize steady-state overhead, stall behavior, and direct-comparison validity.
         This intake is for performance regression or before/after optimization comparison, not for semantic game-state diagnosis.
         Preferred upload is one `.zip` bundle per run containing `perf_summary.csv` and `perf_stalls.csv`. You can also attach the two CSV files directly or paste both CSV texts inline.
   - type: input
@@ -64,14 +64,14 @@ body:
 
         Inline fallback:
         ```csv
-        # telemetry_schema_version=1
+        # telemetry_schema_version=2
         # telemetry_file_kind=summary
         ...
         run_id,elapsed_sec,...
         ```
 
         ```csv
-        # telemetry_schema_version=1
+        # telemetry_schema_version=2
         # telemetry_file_kind=stalls
         ...
         run_id,stall_id,...

--- a/.github/scripts/perf_telemetry_automation.py
+++ b/.github/scripts/perf_telemetry_automation.py
@@ -67,7 +67,7 @@ PERF_TELEMETRY_REQUIRED_FIELDS = (
     "baseline_bundle",
 )
 
-SUMMARY_FIELDNAMES = [
+SUMMARY_FIELDNAMES_V1 = [
     "run_id",
     "elapsed_sec",
     "simulation_tick",
@@ -84,6 +84,28 @@ SUMMARY_FIELDNAMES = [
     "is_stall_window",
 ]
 
+SUMMARY_FIELDNAMES_V2 = [
+    "run_id",
+    "elapsed_sec",
+    "simulation_tick",
+    "fps_mean",
+    "render_latency_mean_ms",
+    "render_latency_p95_ms",
+    "simulation_update_rate_mean",
+    "simulation_update_interval_mean_ms",
+    "simulation_update_interval_p95_ms",
+    "simulation_step_mean_ms",
+    "pathfind_update_mean_ms",
+    "mod_update_mean_ms",
+    "mod_entities_inspected_count",
+    "mod_repath_requested_count",
+    "path_requests_pending_count",
+    "path_queue_len_max",
+    "is_stall_window",
+]
+
+SUMMARY_FIELDNAMES = SUMMARY_FIELDNAMES_V2
+
 STALL_FIELDNAMES = [
     "run_id",
     "stall_id",
@@ -97,7 +119,10 @@ STALL_FIELDNAMES = [
     "stall_mod_entities_inspected_count",
 ]
 
-SUMMARY_HEADER = ",".join(SUMMARY_FIELDNAMES)
+SUMMARY_HEADER_V1 = ",".join(SUMMARY_FIELDNAMES_V1)
+SUMMARY_HEADER_V2 = ",".join(SUMMARY_FIELDNAMES_V2)
+SUMMARY_HEADER = SUMMARY_HEADER_V2
+SUMMARY_HEADERS = {SUMMARY_HEADER_V1, SUMMARY_HEADER_V2}
 STALL_HEADER = ",".join(STALL_FIELDNAMES)
 
 
@@ -135,6 +160,9 @@ class SummaryRow:
     fps_mean: float
     render_latency_mean_ms: float
     render_latency_p95_ms: float
+    simulation_update_rate_mean: float
+    simulation_update_interval_mean_ms: float
+    simulation_update_interval_p95_ms: float
     simulation_step_mean_ms: float
     pathfind_update_mean_ms: float
     mod_update_mean_ms: float
@@ -821,7 +849,7 @@ def split_csv_fragments(block: str) -> list[str]:
 
 
 def classify_header(line: str) -> str | None:
-    if line == SUMMARY_HEADER:
+    if line in SUMMARY_HEADERS:
         return SUMMARY_FILE_KIND
     if line == STALL_HEADER:
         return STALLS_FILE_KIND
@@ -863,7 +891,7 @@ def parse_summary_document(document_text: str, field_label: str) -> tuple[Teleme
     metadata_values, csv_text = split_metadata_and_csv(document_text)
     metadata = build_metadata(metadata_values)
     warnings = validate_metadata_contract(metadata, expected_file_kind=SUMMARY_FILE_KIND, field_label=field_label)
-    rows = parse_csv_rows(csv_text, SUMMARY_FIELDNAMES, parse_summary_row)
+    rows = parse_csv_rows(csv_text, select_summary_fieldnames(csv_text), parse_summary_row)
 
     if metadata.run_id and any(row.run_id and row.run_id != metadata.run_id for row in rows):
         warnings.append(f"{field_label} summary rows include a run_id that does not match metadata.")
@@ -967,11 +995,12 @@ def validate_metadata_contract(
     field_label: str,
 ) -> list[str]:
     warnings: list[str] = []
-    if not metadata.telemetry_schema_version:
+    schema_version = metadata.telemetry_schema_version.strip()
+    if not schema_version:
         warnings.append(f"{field_label} is missing `telemetry_schema_version`; parsed with v1 compatibility rules.")
-    elif metadata.telemetry_schema_version != "1":
+    elif schema_version not in {"1", "2"}:
         warnings.append(
-            f"{field_label} uses `telemetry_schema_version={metadata.telemetry_schema_version}`; parsed with v1 compatibility rules."
+            f"{field_label} uses `telemetry_schema_version={schema_version}`; parsed with supported compatibility rules."
         )
 
     if not metadata.telemetry_file_kind:
@@ -1025,6 +1054,27 @@ def parse_csv_rows(
     return rows
 
 
+def select_summary_fieldnames(csv_text: str) -> list[str]:
+    header = get_csv_header_line(csv_text)
+    if header == SUMMARY_HEADER_V2:
+        return SUMMARY_FIELDNAMES_V2
+    if header == SUMMARY_HEADER_V1:
+        return SUMMARY_FIELDNAMES_V1
+    raise AutomationError(
+        "Unexpected telemetry CSV header. "
+        f"Expected `{SUMMARY_HEADER_V1}` or `{SUMMARY_HEADER_V2}` but got `{header}`."
+    )
+
+
+def get_csv_header_line(csv_text: str) -> str:
+    for line in csv_text.replace("\r\n", "\n").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("# "):
+            continue
+        return stripped
+    return ""
+
+
 def parse_summary_row(raw_row: dict[str, str]) -> SummaryRow:
     return SummaryRow(
         run_id=(raw_row.get("run_id") or "").strip(),
@@ -1033,6 +1083,9 @@ def parse_summary_row(raw_row: dict[str, str]) -> SummaryRow:
         fps_mean=parse_float(raw_row.get("fps_mean")),
         render_latency_mean_ms=parse_float(raw_row.get("render_latency_mean_ms")),
         render_latency_p95_ms=parse_float(raw_row.get("render_latency_p95_ms")),
+        simulation_update_rate_mean=parse_float(raw_row.get("simulation_update_rate_mean")),
+        simulation_update_interval_mean_ms=parse_float(raw_row.get("simulation_update_interval_mean_ms")),
+        simulation_update_interval_p95_ms=parse_float(raw_row.get("simulation_update_interval_p95_ms")),
         simulation_step_mean_ms=parse_float(raw_row.get("simulation_step_mean_ms")),
         pathfind_update_mean_ms=parse_float(raw_row.get("pathfind_update_mean_ms")),
         mod_update_mean_ms=parse_float(raw_row.get("mod_update_mean_ms")),

--- a/.github/scripts/perf_telemetry_automation.py
+++ b/.github/scripts/perf_telemetry_automation.py
@@ -121,9 +121,6 @@ STALL_FIELDNAMES = [
 
 SUMMARY_HEADER_V1 = ",".join(SUMMARY_FIELDNAMES_V1)
 SUMMARY_HEADER_V2 = ",".join(SUMMARY_FIELDNAMES_V2)
-SUMMARY_HEADER = SUMMARY_HEADER_V2
-SUMMARY_HEADERS = {SUMMARY_HEADER_V1, SUMMARY_HEADER_V2}
-STALL_HEADER = ",".join(STALL_FIELDNAMES)
 
 
 @dataclass
@@ -849,9 +846,10 @@ def split_csv_fragments(block: str) -> list[str]:
 
 
 def classify_header(line: str) -> str | None:
-    if line in SUMMARY_HEADERS:
+    header_tokens = normalize_csv_header_tokens(line)
+    if header_tokens in (SUMMARY_FIELDNAMES_V1, SUMMARY_FIELDNAMES_V2):
         return SUMMARY_FILE_KIND
-    if line == STALL_HEADER:
+    if header_tokens == STALL_FIELDNAMES:
         return STALLS_FILE_KIND
     return None
 
@@ -890,8 +888,21 @@ def merge_documents(
 def parse_summary_document(document_text: str, field_label: str) -> tuple[TelemetryRunMetadata, list[SummaryRow], list[str]]:
     metadata_values, csv_text = split_metadata_and_csv(document_text)
     metadata = build_metadata(metadata_values)
-    warnings = validate_metadata_contract(metadata, expected_file_kind=SUMMARY_FILE_KIND, field_label=field_label)
-    rows = parse_csv_rows(csv_text, select_summary_fieldnames(csv_text), parse_summary_row)
+    summary_fieldnames, detected_schema_version = select_summary_schema(csv_text)
+    warnings = validate_metadata_contract(
+        metadata,
+        expected_file_kind=SUMMARY_FILE_KIND,
+        field_label=field_label,
+        detected_schema_version=detected_schema_version,
+    )
+    metadata_schema_version = metadata.telemetry_schema_version.strip()
+    if metadata_schema_version and metadata_schema_version != detected_schema_version:
+        warnings.append(
+            f"{field_label} metadata says `telemetry_schema_version={metadata_schema_version}` "
+            f"but the summary header matches schema v{detected_schema_version}; using the header-derived schema."
+        )
+    metadata.telemetry_schema_version = detected_schema_version
+    rows = parse_csv_rows(csv_text, summary_fieldnames, parse_summary_row)
 
     if metadata.run_id and any(row.run_id and row.run_id != metadata.run_id for row in rows):
         warnings.append(f"{field_label} summary rows include a run_id that does not match metadata.")
@@ -993,11 +1004,18 @@ def validate_metadata_contract(
     *,
     expected_file_kind: str,
     field_label: str,
+    detected_schema_version: str | None = None,
 ) -> list[str]:
     warnings: list[str] = []
     schema_version = metadata.telemetry_schema_version.strip()
     if not schema_version:
-        warnings.append(f"{field_label} is missing `telemetry_schema_version`; parsed with v1 compatibility rules.")
+        if detected_schema_version:
+            warnings.append(
+                f"{field_label} is missing `telemetry_schema_version`; inferred schema v{detected_schema_version} "
+                "from the CSV header."
+            )
+        else:
+            warnings.append(f"{field_label} is missing `telemetry_schema_version`; parsed with supported compatibility rules.")
     elif schema_version not in {"1", "2"}:
         warnings.append(
             f"{field_label} uses `telemetry_schema_version={schema_version}`; parsed with supported compatibility rules."
@@ -1036,7 +1054,7 @@ def parse_csv_rows(
     expected_fieldnames: list[str],
     row_parser,
 ) -> list[Any]:
-    reader = csv.DictReader(io.StringIO(csv_text))
+    reader = csv.DictReader(io.StringIO(csv_text), skipinitialspace=True)
     actual_fieldnames = [field.strip() for field in (reader.fieldnames or [])]
     if actual_fieldnames != expected_fieldnames:
         raise AutomationError(
@@ -1050,19 +1068,19 @@ def parse_csv_rows(
             continue
         if not any((value or "").strip() for value in raw_row.values()):
             continue
-        rows.append(row_parser(raw_row))
+        rows.append(row_parser(normalize_csv_row(raw_row)))
     return rows
 
 
-def select_summary_fieldnames(csv_text: str) -> list[str]:
-    header = get_csv_header_line(csv_text)
-    if header == SUMMARY_HEADER_V2:
-        return SUMMARY_FIELDNAMES_V2
-    if header == SUMMARY_HEADER_V1:
-        return SUMMARY_FIELDNAMES_V1
+def select_summary_schema(csv_text: str) -> tuple[list[str], str]:
+    header_tokens = get_csv_header_tokens(csv_text)
+    if header_tokens == SUMMARY_FIELDNAMES_V2:
+        return SUMMARY_FIELDNAMES_V2, "2"
+    if header_tokens == SUMMARY_FIELDNAMES_V1:
+        return SUMMARY_FIELDNAMES_V1, "1"
     raise AutomationError(
         "Unexpected telemetry CSV header. "
-        f"Expected `{SUMMARY_HEADER_V1}` or `{SUMMARY_HEADER_V2}` but got `{header}`."
+        f"Expected `{SUMMARY_HEADER_V1}` or `{SUMMARY_HEADER_V2}` but got `{','.join(header_tokens)}`."
     )
 
 
@@ -1073,6 +1091,22 @@ def get_csv_header_line(csv_text: str) -> str:
             continue
         return stripped
     return ""
+
+
+def get_csv_header_tokens(csv_text: str) -> list[str]:
+    return normalize_csv_header_tokens(get_csv_header_line(csv_text))
+
+
+def normalize_csv_header_tokens(line: str) -> list[str]:
+    try:
+        header_row = next(csv.reader([line], skipinitialspace=True), [])
+    except csv.Error:
+        return [line.strip()]
+    return [token.strip() for token in header_row]
+
+
+def normalize_csv_row(raw_row: dict[str | None, str | None]) -> dict[str, str]:
+    return {(key or "").strip(): value or "" for key, value in raw_row.items() if key is not None}
 
 
 def parse_summary_row(raw_row: dict[str, str]) -> SummaryRow:
@@ -1242,6 +1276,20 @@ def compare_runs(baseline: RunAnalysis, comparison: RunAnalysis) -> ComparisonAn
 
     baseline_metadata = baseline.metadata
     comparison_metadata = comparison.metadata
+    baseline_schema_version = baseline_metadata.telemetry_schema_version.strip() or "unknown"
+    comparison_schema_version = comparison_metadata.telemetry_schema_version.strip() or "unknown"
+
+    if (
+        baseline_schema_version != "unknown"
+        and comparison_schema_version != "unknown"
+        and baseline_schema_version != comparison_schema_version
+    ):
+        directly_comparable = False
+        warnings.append(
+            "telemetry_schema_version mismatch: "
+            f"`{baseline_schema_version}` vs `{comparison_schema_version}`; "
+            "direct comparison is not allowed across schema versions."
+        )
 
     save_names_known = is_known_save_name(baseline_metadata.save_name) and is_known_save_name(comparison_metadata.save_name)
     scenario_ids_known = is_known_scenario_id(baseline_metadata.scenario_id) and is_known_scenario_id(comparison_metadata.scenario_id)

--- a/.github/scripts/tests/test_perf_telemetry_automation.py
+++ b/.github/scripts/tests/test_perf_telemetry_automation.py
@@ -27,6 +27,7 @@ def make_metadata(
     *,
     run_id: str,
     file_kind: str,
+    schema_version: str = "1",
     save_name: str = "New Seoul",
     scenario_id: str = "map_a",
     game_version: str = "1.5.xf1",
@@ -36,7 +37,7 @@ def make_metadata(
     fix_flags: tuple[bool | None, bool | None, bool | None, bool | None] = (True, True, True, True),
 ) -> str:
     lines = [
-        "# telemetry_schema_version=1",
+        f"# telemetry_schema_version={schema_version}",
         f"# telemetry_file_kind={file_kind}",
         f"# run_id={run_id}",
         "# run_start_utc=2026-03-23T00:00:00.0000000Z",
@@ -59,6 +60,9 @@ def make_metadata(
     return "\n".join(lines)
 
 
+SUMMARY_HEADER_V2 = ",".join(automation.SUMMARY_FIELDNAMES_V2)
+
+
 BASELINE_SUMMARY_CSV = textwrap.dedent(
     f"""
     {make_metadata(run_id='baseline-run', file_kind='summary')}
@@ -74,6 +78,44 @@ BASELINE_STALLS_CSV = textwrap.dedent(
     {make_metadata(run_id='baseline-run', file_kind='stalls')}
     run_id,stall_id,stall_start_sec,stall_end_sec,stall_duration_sec,stall_peak_render_latency_ms,stall_p95_render_latency_ms,stall_peak_path_queue_len,stall_mod_repath_requested_count,stall_mod_entities_inspected_count
     baseline-run,1,2,6,4,400,380,120,8,50
+    """
+).strip()
+
+BASELINE_V2_SUMMARY_CSV = textwrap.dedent(
+    f"""
+    {make_metadata(run_id='baseline-run', file_kind='summary', schema_version='2')}
+    {SUMMARY_HEADER_V2}
+    baseline-run,1,100,60,16,18,240,4.0,4.4,3,1,0.20,10,1,1,2,false
+    baseline-run,2,200,58,17,19,238,4.1,4.5,3.2,1.1,0.25,12,0,2,4,false
+    baseline-run,3,300,4,350,400,16,62.5,70.0,20,25,2.0,50,8,80,120,true
+    """
+).strip()
+
+BASELINE_V2_STALLS_CSV = textwrap.dedent(
+    f"""
+    {make_metadata(run_id='baseline-run', file_kind='stalls', schema_version='2')}
+    run_id,stall_id,stall_start_sec,stall_end_sec,stall_duration_sec,stall_peak_render_latency_ms,stall_p95_render_latency_ms,stall_peak_path_queue_len,stall_mod_repath_requested_count,stall_mod_entities_inspected_count
+    baseline-run,1,2,6,4,400,380,120,8,50
+    """
+).strip()
+
+COMPARISON_V2_SUMMARY_CSV = textwrap.dedent(
+    f"""
+    {make_metadata(run_id='comparison-run', file_kind='summary', schema_version='2')}
+    {SUMMARY_HEADER_V2}
+    comparison-run,1,100,55,18,20,236,4.2,4.8,3.5,1.3,0.60,10,1,1,3,false
+    comparison-run,2,200,54,20,22,234,4.3,4.9,3.7,1.6,0.70,12,1,2,6,false
+    comparison-run,3,300,3,500,540,15,66.0,72.0,25,35,4.0,80,15,120,220,true
+    comparison-run,4,400,3,520,560,14,71.0,78.0,28,37,4.3,90,20,150,260,true
+    """
+).strip()
+
+COMPARISON_V2_STALLS_CSV = textwrap.dedent(
+    f"""
+    {make_metadata(run_id='comparison-run', file_kind='stalls', schema_version='2')}
+    run_id,stall_id,stall_start_sec,stall_end_sec,stall_duration_sec,stall_peak_render_latency_ms,stall_p95_render_latency_ms,stall_peak_path_queue_len,stall_mod_repath_requested_count,stall_mod_entities_inspected_count
+    comparison-run,1,2,8,6,540,520,220,15,80
+    comparison-run,2,9,16,7,560,550,260,20,90
     """
 ).strip()
 
@@ -249,6 +291,13 @@ INLINE_COMPARISON_BUNDLE = (
     "```csv\n" + COMPARISON_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_STALLS_CSV + "\n```"
 )
 
+INLINE_BASELINE_BUNDLE_V2 = (
+    "```csv\n" + BASELINE_V2_SUMMARY_CSV + "\n```\n\n```csv\n" + BASELINE_V2_STALLS_CSV + "\n```"
+)
+INLINE_COMPARISON_BUNDLE_V2 = (
+    "```csv\n" + COMPARISON_V2_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_V2_STALLS_CSV + "\n```"
+)
+
 PERF_ISSUE_BODY = textwrap.dedent(
     f"""
     <!-- performance-telemetry-report -->
@@ -271,10 +320,10 @@ PERF_ISSUE_BODY = textwrap.dedent(
     none known
 
     ### Baseline telemetry bundle
-    {INLINE_BASELINE_BUNDLE}
+    {INLINE_BASELINE_BUNDLE_V2}
 
     ### Comparison telemetry bundle
-    {INLINE_COMPARISON_BUNDLE}
+    {INLINE_COMPARISON_BUNDLE_V2}
     """
 ).strip()
 
@@ -285,7 +334,7 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         self.assertEqual(parsed["game_version"], "1.5.xf1")
         self.assertEqual(parsed["save_or_city_label"], "New Seoul")
         self.assertIn("experimental buyer-pass optimization", parsed["what_changed"])
-        self.assertIn("telemetry_schema_version=1", parsed["baseline_bundle"])
+        self.assertIn("telemetry_schema_version=2", parsed["baseline_bundle"])
 
     def test_is_performance_telemetry_issue_accepts_issue_form(self) -> None:
         self.assertTrue(automation.is_performance_telemetry_issue(PERF_ISSUE_BODY, "[Performance Telemetry] test"))
@@ -296,6 +345,17 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         self.assertEqual(warnings, [])
         self.assertIn("run_id,elapsed_sec", documents["summary"])
         self.assertIn("run_id,stall_id", documents["stalls"])
+
+    def test_parse_summary_document_supports_v2_columns(self) -> None:
+        metadata, rows, warnings = automation.parse_summary_document(BASELINE_V2_SUMMARY_CSV, "Baseline telemetry bundle")
+
+        self.assertEqual(warnings, [])
+        self.assertEqual(metadata.telemetry_schema_version, "2")
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0].simulation_update_rate_mean, 240.0)
+        self.assertEqual(rows[0].simulation_update_interval_mean_ms, 4.0)
+        self.assertEqual(rows[0].simulation_update_interval_p95_ms, 4.4)
+        self.assertEqual(rows[2].fps_mean, 4.0)
 
     def test_build_triage_analysis_supports_baseline_only(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)

--- a/.github/scripts/tests/test_perf_telemetry_automation.py
+++ b/.github/scripts/tests/test_perf_telemetry_automation.py
@@ -61,6 +61,7 @@ def make_metadata(
 
 
 SUMMARY_HEADER_V2 = ",".join(automation.SUMMARY_FIELDNAMES_V2)
+SUMMARY_HEADER_V2_WITH_WHITESPACE = " , ".join(automation.SUMMARY_FIELDNAMES_V2)
 
 
 BASELINE_SUMMARY_CSV = textwrap.dedent(
@@ -85,6 +86,16 @@ BASELINE_V2_SUMMARY_CSV = textwrap.dedent(
     f"""
     {make_metadata(run_id='baseline-run', file_kind='summary', schema_version='2')}
     {SUMMARY_HEADER_V2}
+    baseline-run,1,100,60,16,18,240,4.0,4.4,3,1,0.20,10,1,1,2,false
+    baseline-run,2,200,58,17,19,238,4.1,4.5,3.2,1.1,0.25,12,0,2,4,false
+    baseline-run,3,300,4,350,400,16,62.5,70.0,20,25,2.0,50,8,80,120,true
+    """
+).strip()
+
+BASELINE_V2_SUMMARY_WITH_SPACED_HEADER_CSV = textwrap.dedent(
+    f"""
+    {make_metadata(run_id='baseline-run', file_kind='summary', schema_version='2')}
+    {SUMMARY_HEADER_V2_WITH_WHITESPACE}
     baseline-run,1,100,60,16,18,240,4.0,4.4,3,1,0.20,10,1,1,2,false
     baseline-run,2,200,58,17,19,238,4.1,4.5,3.2,1.1,0.25,12,0,2,4,false
     baseline-run,3,300,4,350,400,16,62.5,70.0,20,25,2.0,50,8,80,120,true
@@ -118,6 +129,50 @@ COMPARISON_V2_STALLS_CSV = textwrap.dedent(
     comparison-run,2,9,16,7,560,550,260,20,90
     """
 ).strip()
+
+SINGLE_TOGGLE_COMPARISON_V2_SUMMARY_CSV = COMPARISON_V2_SUMMARY_CSV.replace(
+    "# enable_virtual_office_resource_buyer_fix=true",
+    "# enable_virtual_office_resource_buyer_fix=false",
+    1,
+)
+SINGLE_TOGGLE_COMPARISON_V2_STALLS_CSV = COMPARISON_V2_STALLS_CSV.replace(
+    "# enable_virtual_office_resource_buyer_fix=true",
+    "# enable_virtual_office_resource_buyer_fix=false",
+    1,
+)
+MULTI_TOGGLE_COMPARISON_V2_SUMMARY_CSV = (
+    COMPARISON_V2_SUMMARY_CSV.replace("# enable_phantom_vacancy_fix=true", "# enable_phantom_vacancy_fix=false", 1)
+    .replace(
+        "# enable_virtual_office_resource_buyer_fix=true",
+        "# enable_virtual_office_resource_buyer_fix=false",
+        1,
+    )
+)
+MULTI_TOGGLE_COMPARISON_V2_STALLS_CSV = (
+    COMPARISON_V2_STALLS_CSV.replace("# enable_phantom_vacancy_fix=true", "# enable_phantom_vacancy_fix=false", 1)
+    .replace(
+        "# enable_virtual_office_resource_buyer_fix=true",
+        "# enable_virtual_office_resource_buyer_fix=false",
+        1,
+    )
+)
+UNKNOWN_TOGGLE_COMPARISON_V2_SUMMARY_CSV = COMPARISON_V2_SUMMARY_CSV.replace(
+    "# enable_virtual_office_resource_buyer_fix=true\n",
+    "",
+    1,
+)
+UNKNOWN_TOGGLE_COMPARISON_V2_STALLS_CSV = COMPARISON_V2_STALLS_CSV.replace(
+    "# enable_virtual_office_resource_buyer_fix=true\n",
+    "",
+    1,
+)
+SAVE_NAME_MISMATCH_V2_SUMMARY_CSV = COMPARISON_V2_SUMMARY_CSV.replace("# save_name=New Seoul", "# save_name=Other City", 1)
+SCENARIO_ID_MISMATCH_V2_SUMMARY_CSV = COMPARISON_V2_SUMMARY_CSV.replace("# scenario_id=map_a", "# scenario_id=map_b", 1)
+BOTH_IDENTITY_MISMATCH_V2_SUMMARY_CSV = SAVE_NAME_MISMATCH_V2_SUMMARY_CSV.replace(
+    "# scenario_id=map_a",
+    "# scenario_id=map_b",
+    1,
+)
 
 COMPARISON_SUMMARY_CSV = textwrap.dedent(
     f"""
@@ -257,6 +312,14 @@ MISMATCHED_STALLS_CSV = textwrap.dedent(
     """
 ).strip()
 
+MISMATCHED_V2_STALLS_CSV = textwrap.dedent(
+    f"""
+    {make_metadata(run_id='wrong-run', file_kind='stalls', schema_version='2', save_name='Wrong City', scenario_id='map_z')}
+    run_id,stall_id,stall_start_sec,stall_end_sec,stall_duration_sec,stall_peak_render_latency_ms,stall_p95_render_latency_ms,stall_peak_path_queue_len,stall_mod_repath_requested_count,stall_mod_entities_inspected_count
+    wrong-run,1,2,8,6,540,520,220,15,80
+    """
+).strip()
+
 ZERO_QUEUE_PRESSURE_SUMMARY_CSV = textwrap.dedent(
     f"""
     {make_metadata(run_id='baseline-run', file_kind='summary')}
@@ -357,6 +420,31 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         self.assertEqual(rows[0].simulation_update_interval_p95_ms, 4.4)
         self.assertEqual(rows[2].fps_mean, 4.0)
 
+    def test_parse_summary_document_accepts_whitespace_only_header_variation(self) -> None:
+        metadata, rows, warnings = automation.parse_summary_document(
+            BASELINE_V2_SUMMARY_WITH_SPACED_HEADER_CSV,
+            "Baseline telemetry bundle",
+        )
+
+        self.assertEqual(warnings, [])
+        self.assertEqual(metadata.telemetry_schema_version, "2")
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0].simulation_update_rate_mean, 240.0)
+        self.assertEqual(rows[1].path_requests_pending_count, 2)
+
+    def test_parse_summary_document_prefers_header_schema_over_mislabelled_metadata(self) -> None:
+        mislabelled_summary = BASELINE_V2_SUMMARY_CSV.replace(
+            "# telemetry_schema_version=2",
+            "# telemetry_schema_version=1",
+            1,
+        )
+
+        metadata, rows, warnings = automation.parse_summary_document(mislabelled_summary, "Baseline telemetry bundle")
+
+        self.assertEqual(metadata.telemetry_schema_version, "2")
+        self.assertEqual(len(rows), 3)
+        self.assertIn("metadata says `telemetry_schema_version=1`", " ".join(warnings))
+
     def test_build_triage_analysis_supports_baseline_only(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = ""
@@ -406,10 +494,28 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         self.assertIn("stall_frequency_elevated", triage.anomaly_flags)
         self.assertIn("queue_pressure_during_stalls", triage.anomaly_flags)
 
+    def test_build_triage_analysis_blocks_direct_comparison_across_schema_versions(self) -> None:
+        issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
+        issue_fields["comparison_bundle"] = (
+            "```csv\n" + COMPARISON_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_STALLS_CSV + "\n```"
+        )
+
+        triage = automation.build_triage_analysis(21, issue_fields)
+        comparison = require_not_none(triage.comparison)
+        comparison_analysis = require_not_none(triage.comparison_analysis)
+
+        self.assertEqual(comparison.metadata.telemetry_schema_version, "1")
+        self.assertFalse(comparison_analysis.directly_comparable)
+        self.assertIsNone(comparison_analysis.steady_state_mod_update_delta_ms)
+        self.assertIn("telemetry_schema_version mismatch", " ".join(comparison_analysis.warnings))
+        self.assertIn("across schema versions", " ".join(comparison_analysis.warnings))
+        self.assertIn("capture a paired comparison with matching save/settings/threshold", triage.follow_up_suggestions)
+        self.assertNotIn("steady_state_mod_overhead_elevated", triage.anomaly_flags)
+
     def test_build_triage_analysis_allows_same_scenario_when_save_names_differ(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
-            "```csv\n" + SAVE_NAME_MISMATCH_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_STALLS_CSV + "\n```"
+            "```csv\n" + SAVE_NAME_MISMATCH_V2_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_V2_STALLS_CSV + "\n```"
         )
 
         triage = automation.build_triage_analysis(21, issue_fields)
@@ -422,7 +528,7 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
     def test_build_triage_analysis_allows_same_save_when_scenario_ids_differ(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
-            "```csv\n" + SCENARIO_ID_MISMATCH_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_STALLS_CSV + "\n```"
+            "```csv\n" + SCENARIO_ID_MISMATCH_V2_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_V2_STALLS_CSV + "\n```"
         )
 
         triage = automation.build_triage_analysis(21, issue_fields)
@@ -436,9 +542,9 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
             "```csv\n"
-            + SINGLE_TOGGLE_COMPARISON_SUMMARY_CSV
+            + SINGLE_TOGGLE_COMPARISON_V2_SUMMARY_CSV
             + "\n```\n\n```csv\n"
-            + SINGLE_TOGGLE_COMPARISON_STALLS_CSV
+            + SINGLE_TOGGLE_COMPARISON_V2_STALLS_CSV
             + "\n```"
         )
 
@@ -461,9 +567,9 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
             "```csv\n"
-            + MULTI_TOGGLE_COMPARISON_SUMMARY_CSV
+            + MULTI_TOGGLE_COMPARISON_V2_SUMMARY_CSV
             + "\n```\n\n```csv\n"
-            + MULTI_TOGGLE_COMPARISON_STALLS_CSV
+            + MULTI_TOGGLE_COMPARISON_V2_STALLS_CSV
             + "\n```"
         )
 
@@ -479,9 +585,9 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
             "```csv\n"
-            + UNKNOWN_TOGGLE_COMPARISON_SUMMARY_CSV
+            + UNKNOWN_TOGGLE_COMPARISON_V2_SUMMARY_CSV
             + "\n```\n\n```csv\n"
-            + UNKNOWN_TOGGLE_COMPARISON_STALLS_CSV
+            + UNKNOWN_TOGGLE_COMPARISON_V2_STALLS_CSV
             + "\n```"
         )
 
@@ -495,7 +601,7 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
     def test_build_triage_analysis_rejects_runs_when_save_and_scenario_both_differ(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
-            "```csv\n" + BOTH_IDENTITY_MISMATCH_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_STALLS_CSV + "\n```"
+            "```csv\n" + BOTH_IDENTITY_MISMATCH_V2_SUMMARY_CSV + "\n```\n\n```csv\n" + COMPARISON_V2_STALLS_CSV + "\n```"
         )
 
         triage = automation.build_triage_analysis(21, issue_fields)
@@ -549,7 +655,7 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
     def test_mismatched_stall_file_is_ignored_for_run_summary(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
         issue_fields["comparison_bundle"] = (
-            "```csv\n" + COMPARISON_SUMMARY_CSV + "\n```\n\n```csv\n" + MISMATCHED_STALLS_CSV + "\n```"
+            "```csv\n" + COMPARISON_V2_SUMMARY_CSV + "\n```\n\n```csv\n" + MISMATCHED_V2_STALLS_CSV + "\n```"
         )
 
         triage = automation.build_triage_analysis(21, issue_fields)
@@ -564,7 +670,7 @@ class PerfTelemetryAutomationTests(unittest.TestCase):
 
     def test_missing_comparison_stall_file_suppresses_stall_deltas(self) -> None:
         issue_fields = automation.parse_issue_form_sections(PERF_ISSUE_BODY)
-        issue_fields["comparison_bundle"] = "```csv\n" + COMPARISON_SUMMARY_CSV + "\n```"
+        issue_fields["comparison_bundle"] = "```csv\n" + COMPARISON_V2_SUMMARY_CSV + "\n```"
 
         triage = automation.build_triage_analysis(21, issue_fields)
         comparison = require_not_none(triage.comparison)

--- a/.github/scripts/tests/test_run_perf_telemetry_triage.py
+++ b/.github/scripts/tests/test_run_perf_telemetry_triage.py
@@ -36,11 +36,11 @@ PERF_ISSUE_BODY = textwrap.dedent(
 
     ### Baseline telemetry bundle
     ```csv
-    # telemetry_schema_version=1
+    # telemetry_schema_version=2
     # telemetry_file_kind=summary
     # run_id=baseline-run
-    run_id,elapsed_sec,simulation_tick,fps_mean,render_latency_mean_ms,render_latency_p95_ms,simulation_step_mean_ms,pathfind_update_mean_ms,mod_update_mean_ms,mod_entities_inspected_count,mod_repath_requested_count,path_requests_pending_count,path_queue_len_max,is_stall_window
-    baseline-run,1,100,60,16,18,3,1,0.2,10,1,1,2,false
+    run_id,elapsed_sec,simulation_tick,fps_mean,render_latency_mean_ms,render_latency_p95_ms,simulation_update_rate_mean,simulation_update_interval_mean_ms,simulation_update_interval_p95_ms,simulation_step_mean_ms,pathfind_update_mean_ms,mod_update_mean_ms,mod_entities_inspected_count,mod_repath_requested_count,path_requests_pending_count,path_queue_len_max,is_stall_window
+    baseline-run,1,100,60,16,18,240,4.0,4.4,3,1,0.2,10,1,1,2,false
     ```
 
     ### Comparison telemetry bundle

--- a/NoOfficeDemandFix/Mod.cs
+++ b/NoOfficeDemandFix/Mod.cs
@@ -46,11 +46,7 @@ namespace NoOfficeDemandFix
             updateSystem.UpdateAfter<OfficeDemandDiagnosticsSystem, IndustrialDemandSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<VirtualOfficeResourceBuyerFixSystem, BuyingCompanySystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateBefore<VirtualOfficeResourceBuyerFixSystem, ResourceBuyerSystem>(SystemUpdatePhase.GameSimulation);
-            updateSystem.UpdateAfter<PerformanceTelemetrySystem, SignaturePropertyMarketGuardSystem>(SystemUpdatePhase.GameSimulation);
-            updateSystem.UpdateAfter<PerformanceTelemetrySystem, OfficeAIHotfixSystem>(SystemUpdatePhase.GameSimulation);
-            updateSystem.UpdateAfter<PerformanceTelemetrySystem, VirtualOfficeResourceBuyerFixSystem>(SystemUpdatePhase.GameSimulation);
-            updateSystem.UpdateAfter<PerformanceTelemetrySystem, PathfindSetupSystem>(SystemUpdatePhase.GameSimulation);
-            updateSystem.UpdateAfter<PerformanceTelemetrySystem, PathfindQueueSystem>(SystemUpdatePhase.GameSimulation);
+            updateSystem.UpdateAfter<PerformanceTelemetrySystem, SimulationSystem>(SystemUpdatePhase.LateUpdate);
 
             m_Setting = new Setting(this);
             AssetDatabase.global.LoadSettings(nameof(NoOfficeDemandFix), m_Setting, new Setting(this));

--- a/NoOfficeDemandFix/Mod.cs
+++ b/NoOfficeDemandFix/Mod.cs
@@ -46,6 +46,8 @@ namespace NoOfficeDemandFix
             updateSystem.UpdateAfter<OfficeDemandDiagnosticsSystem, IndustrialDemandSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<VirtualOfficeResourceBuyerFixSystem, BuyingCompanySystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateBefore<VirtualOfficeResourceBuyerFixSystem, ResourceBuyerSystem>(SystemUpdatePhase.GameSimulation);
+            // Run performance telemetry in LateUpdate so metrics are captured after simulation completes,
+            // aligned with the rendered frame rather than the main GameSimulation step.
             updateSystem.UpdateAfter<PerformanceTelemetrySystem, SimulationSystem>(SystemUpdatePhase.LateUpdate);
 
             m_Setting = new Setting(this);

--- a/NoOfficeDemandFix/Patches/PerformanceTelemetryTimingPatches.cs
+++ b/NoOfficeDemandFix/Patches/PerformanceTelemetryTimingPatches.cs
@@ -17,7 +17,9 @@ namespace NoOfficeDemandFix.Patches
         {
             if (__state != 0L)
             {
-                PerformanceTelemetryCollector.RecordSimulationUpdateElapsedTicks(System.Diagnostics.Stopwatch.GetTimestamp() - __state);
+                long now = System.Diagnostics.Stopwatch.GetTimestamp();
+                PerformanceTelemetryCollector.RecordSimulationUpdateElapsedTicks(now - __state);
+                PerformanceTelemetryCollector.RecordSimulationUpdateTimestamp(now);
             }
         }
     }

--- a/NoOfficeDemandFix/Properties/PublishConfiguration.xml
+++ b/NoOfficeDemandFix/Properties/PublishConfiguration.xml
@@ -16,6 +16,7 @@ No Office Demand Fix currently ships confirmed office-demand fixes plus a narrow
 - Software import seller fallback: a narrow fallback that appends additional outside connections for office virtual-resource imports when vanilla seller selection is too restrictive.
 - Software import buyer fallback: a narrow corrective pass for zero-weight office inputs that remain below threshold without a buyer, path, trip, or current trading state.
 - Diagnostics: optional logs for office demand, phantom vacancy, and software office state; disabled by default until you turn them on for troubleshooting.
+- Performance telemetry: optional coarse, render-aligned summary and stall CSV output for before/after comparisons; disabled by default until you turn it on.
 
 Current release status:
 
@@ -23,6 +24,7 @@ Current release status:
 - fixes the vanilla office AI chunk-iteration abort on low stock
 - restores the pre-hotfix office-demand baseline for comparability via a direct Harmony patch
 - includes refined experimental software import seller and buyer fallbacks by default, with diagnostics available but disabled by default
+- keeps optional render-aligned performance telemetry available for before/after comparisons
 - keeps broader software-related office stalls under investigation
 - keeps non-signature phantom vacancy under observation
 	</LongDescription>
@@ -33,14 +35,14 @@ Current release status:
 	<!--Link to the forum post where the mod can be discussed-->
 	<ForumLink Value="https://forum.paradoxplaza.com/forum/threads/no-office-demand-fix-discussion-thread.1906822/" />
 	<!--Version of the mod-->
-	<ModVersion Value="0.2.2" />
+	<ModVersion Value="0.2.3" />
 	<!--Recommended version of the base game to use the mod-->
 	<GameVersion Value="1.5.*" />
 	<!--Change log for new version. Single line or multi line. Supports minimal markdown subset-->
 <ChangeLog>
-- Improved occupied Signature property market cleanup while keeping the shipped office-demand baseline rollback and software-track release wording aligned with the current release.
-- Refined software diagnostics and troubleshooting output for the current investigation track, including clearer release-facing wording for the experimental seller and buyer fallbacks.
-- Added optional coarse performance telemetry capture and reporting, including more reliable queue sampling and clearer before/after comparison triage.
+- Aligned performance telemetry sampling with rendered-frame cadence so `fps_mean` and render-latency summaries no longer mirror `GameSimulation` cadence.
+- Added telemetry schema v2 summary fields for explicit simulation update rate and interval metrics while keeping telemetry comparison tooling aligned with the new header.
+- Hardened path queue reflection sampling so unsupported internal queue-field shapes no longer zero all queue metrics on affected builds.
 </ChangeLog>
 	<!--External link, can be set multiple times. supported types are "discord", "github", "youtube", "twitch", "x", "paypal", "patreon", "buymeacoffee", "kofi", "crowdin", "gitlab", "gofundme"-->
 	<ExternalLink Type="github" Url="https://github.com/FennexFox/NoOfficeDemandFix" />

--- a/NoOfficeDemandFix/Setting.cs
+++ b/NoOfficeDemandFix/Setting.cs
@@ -133,7 +133,7 @@ namespace NoOfficeDemandFix
                 { m_Setting.GetOptionDescLocaleID(nameof(Setting.PerformanceTelemetrySamplingIntervalSec)), "Controls the coarse wall-clock summary window for performance telemetry. Lower values produce denser CSV output and slightly more telemetry overhead. Default is 1.00 seconds." },
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.PerformanceTelemetryStallThresholdMs)), "Stall threshold (ms)" },
-                { m_Setting.GetOptionDescLocaleID(nameof(Setting.PerformanceTelemetryStallThresholdMs)), "Defines the render-latency threshold used to start and end coarse stall-event tracking. Default is 250 ms." },
+                { m_Setting.GetOptionDescLocaleID(nameof(Setting.PerformanceTelemetryStallThresholdMs)), "Defines the render-frame latency threshold used to start and end coarse stall-event tracking. Default is 250 ms." },
             };
         }
 

--- a/NoOfficeDemandFix/Setting.cs
+++ b/NoOfficeDemandFix/Setting.cs
@@ -127,10 +127,10 @@ namespace NoOfficeDemandFix
                 { m_Setting.GetOptionDescLocaleID(nameof(Setting.VerboseLogging)), "Takes effect immediately for ongoing diagnostics and phantom-vacancy corrections, forces diagnostics output at the configured cadence, and adds noisier correction and office-trade detail traces. Use it only when you want detailed troubleshooting logs." },
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.EnablePerformanceTelemetry)), "Enable performance telemetry" },
-                { m_Setting.GetOptionDescLocaleID(nameof(Setting.EnablePerformanceTelemetry)), "Captures coarse in-memory performance summaries and stall events, then writes them to CSV when the current session ends. Keeps observer overhead low by avoiding frequent text logs and raw per-frame traces." },
+                { m_Setting.GetOptionDescLocaleID(nameof(Setting.EnablePerformanceTelemetry)), "Captures coarse, render-aligned performance summaries and stall events, then writes them to CSV when the current session ends. Keeps observer overhead low by avoiding frequent text logs and raw per-frame traces." },
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.PerformanceTelemetrySamplingIntervalSec)), "Telemetry sampling interval (sec)" },
-                { m_Setting.GetOptionDescLocaleID(nameof(Setting.PerformanceTelemetrySamplingIntervalSec)), "Controls the coarse wall-clock summary window for performance telemetry. Lower values produce denser CSV output and slightly more telemetry overhead. Default is 1.00 seconds." },
+                { m_Setting.GetOptionDescLocaleID(nameof(Setting.PerformanceTelemetrySamplingIntervalSec)), "Controls the coarse render-aligned summary window for performance telemetry. Lower values produce denser CSV output and slightly more telemetry overhead. Default is 1.00 seconds." },
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.PerformanceTelemetryStallThresholdMs)), "Stall threshold (ms)" },
                 { m_Setting.GetOptionDescLocaleID(nameof(Setting.PerformanceTelemetryStallThresholdMs)), "Defines the render-frame latency threshold used to start and end coarse stall-event tracking. Default is 250 ms." },

--- a/NoOfficeDemandFix/Systems/PerformanceTelemetrySystem.cs
+++ b/NoOfficeDemandFix/Systems/PerformanceTelemetrySystem.cs
@@ -29,6 +29,8 @@ namespace NoOfficeDemandFix.Systems
 
         public override int GetUpdateInterval(SystemUpdatePhase phase)
         {
+            // Use LateUpdate so telemetry is aligned with rendering and measures full frame
+            // latency (simulation + render), matching the render-aligned metrics in Mod.cs.
             if (phase == SystemUpdatePhase.LateUpdate)
             {
                 return 1;

--- a/NoOfficeDemandFix/Systems/PerformanceTelemetrySystem.cs
+++ b/NoOfficeDemandFix/Systems/PerformanceTelemetrySystem.cs
@@ -29,7 +29,7 @@ namespace NoOfficeDemandFix.Systems
 
         public override int GetUpdateInterval(SystemUpdatePhase phase)
         {
-            if (phase == SystemUpdatePhase.GameSimulation)
+            if (phase == SystemUpdatePhase.LateUpdate)
             {
                 return 1;
             }

--- a/NoOfficeDemandFix/Telemetry/PerformanceTelemetryCollector.cs
+++ b/NoOfficeDemandFix/Telemetry/PerformanceTelemetryCollector.cs
@@ -629,6 +629,8 @@ namespace NoOfficeDemandFix.Telemetry
             return new StreamWriter(path, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), 65536);
         }
 
+        // Telemetry schema v2 adds simulation_update_rate_mean, simulation_update_interval_mean_ms,
+        // and simulation_update_interval_p95_ms columns to the summary CSV.
         private static void WriteMetadataBlock(TextWriter writer, string fileKind)
         {
             WriteMetadataLine(writer, "telemetry_schema_version", kTelemetrySchemaVersion);

--- a/NoOfficeDemandFix/Telemetry/PerformanceTelemetryCollector.cs
+++ b/NoOfficeDemandFix/Telemetry/PerformanceTelemetryCollector.cs
@@ -14,6 +14,7 @@ namespace NoOfficeDemandFix.Telemetry
     internal static class PerformanceTelemetryCollector
     {
         private const int kStallDebounceFrames = 1;
+        private const string kTelemetrySchemaVersion = "2";
         private const string kUnknownScenarioId = "unknown";
         private const string kUnsavedName = "unsaved";
 
@@ -35,6 +36,7 @@ namespace NoOfficeDemandFix.Telemetry
         private static readonly List<PerformanceSummaryRow> s_SummaryRows = new List<PerformanceSummaryRow>();
         private static readonly List<PerformanceStallRow> s_StallRows = new List<PerformanceStallRow>();
         private static readonly List<float> s_WindowLatencySamplesMs = new List<float>(128);
+        private static readonly List<float> s_WindowSimulationUpdateIntervalSamplesMs = new List<float>(128);
         private static readonly List<float> s_StallLatencySamplesMs = new List<float>(512);
 
         private static PerformanceRunMetadata s_RunMetadata;
@@ -50,6 +52,8 @@ namespace NoOfficeDemandFix.Telemetry
         private static int s_ConsecutiveAboveThreshold;
         private static int s_ConsecutiveBelowThreshold;
         private static int s_NextStallId;
+        private static bool s_HasSimulationUpdateTimestamp;
+        private static long s_LastSimulationUpdateTimestamp;
 
         private static long s_FrameSimulationTicks;
         private static long s_FramePathfindTicks;
@@ -61,6 +65,7 @@ namespace NoOfficeDemandFix.Telemetry
         private static FieldInfo[] s_PathfindActionFields;
         private static FieldInfo[] s_PathfindActionItemsFields;
         private static FieldInfo[] s_PathfindActionNextIndexFields;
+        private static PropertyInfo[] s_PathfindActionCountProperties;
         private static bool s_PathfindReflectionInitialized;
         private static bool s_PathfindReflectionUnavailableLogged;
 
@@ -176,6 +181,29 @@ namespace NoOfficeDemandFix.Telemetry
             }
         }
 
+        public static void RecordSimulationUpdateTimestamp(long timestamp)
+        {
+            if (!IsCollecting || timestamp <= 0L)
+            {
+                return;
+            }
+
+            if (s_HasSimulationUpdateTimestamp)
+            {
+                long intervalTicks = timestamp - s_LastSimulationUpdateTimestamp;
+                if (intervalTicks > 0L)
+                {
+                    float intervalMs = (float)(intervalTicks * 1000d / Stopwatch.Frequency);
+                    s_Window.SimulationUpdateSampleCount++;
+                    s_Window.TotalSimulationUpdateIntervalMs += intervalMs;
+                    s_WindowSimulationUpdateIntervalSamplesMs.Add(intervalMs);
+                }
+            }
+
+            s_LastSimulationUpdateTimestamp = timestamp;
+            s_HasSimulationUpdateTimestamp = true;
+        }
+
         public static void RecordPathfindUpdateElapsedTicks(long elapsedTicks)
         {
             if (IsCollecting && elapsedTicks > 0)
@@ -230,7 +258,13 @@ namespace NoOfficeDemandFix.Telemetry
                 int total = 0;
                 for (int i = 0; i < s_PathfindActionFields.Length; i++)
                 {
-                    object actionList = s_PathfindActionFields[i].GetValue(pathfindQueueSystem);
+                    FieldInfo actionField = s_PathfindActionFields[i];
+                    if (actionField == null)
+                    {
+                        continue;
+                    }
+
+                    object actionList = actionField.GetValue(pathfindQueueSystem);
                     if (actionList == null)
                     {
                         continue;
@@ -439,6 +473,12 @@ namespace NoOfficeDemandFix.Telemetry
             double fpsMean = s_Window.TotalRenderLatencyMs > 0d
                 ? (s_Window.FrameCount * 1000d) / s_Window.TotalRenderLatencyMs
                 : 0d;
+            double simulationUpdateRateMean = s_Window.TotalSimulationUpdateIntervalMs > 0d
+                ? (s_Window.SimulationUpdateSampleCount * 1000d) / s_Window.TotalSimulationUpdateIntervalMs
+                : 0d;
+            double simulationUpdateIntervalMeanMs = s_Window.SimulationUpdateSampleCount > 0
+                ? s_Window.TotalSimulationUpdateIntervalMs / s_Window.SimulationUpdateSampleCount
+                : 0d;
 
             s_SummaryRows.Add(new PerformanceSummaryRow
             {
@@ -448,6 +488,9 @@ namespace NoOfficeDemandFix.Telemetry
                 FpsMean = fpsMean,
                 RenderLatencyMeanMs = s_Window.TotalRenderLatencyMs / s_Window.FrameCount,
                 RenderLatencyP95Ms = CalculatePercentile(s_WindowLatencySamplesMs, 0.95d),
+                SimulationUpdateRateMean = simulationUpdateRateMean,
+                SimulationUpdateIntervalMeanMs = simulationUpdateIntervalMeanMs,
+                SimulationUpdateIntervalP95Ms = CalculatePercentile(s_WindowSimulationUpdateIntervalSamplesMs, 0.95d),
                 SimulationStepMeanMs = s_Window.TotalSimulationStepMs / s_Window.FrameCount,
                 PathfindUpdateMeanMs = s_Window.TotalPathfindUpdateMs / s_Window.FrameCount,
                 ModUpdateMeanMs = s_Window.TotalModUpdateMs / s_Window.FrameCount,
@@ -463,6 +506,7 @@ namespace NoOfficeDemandFix.Telemetry
 
             s_Window = default;
             s_WindowLatencySamplesMs.Clear();
+            s_WindowSimulationUpdateIntervalSamplesMs.Clear();
         }
 
         private static bool ShouldEmitTrailingSummaryRow()
@@ -508,7 +552,7 @@ namespace NoOfficeDemandFix.Telemetry
             using (StreamWriter writer = CreateWriter(summaryPath))
             {
                 WriteMetadataBlock(writer, "summary");
-                writer.WriteLine("run_id,elapsed_sec,simulation_tick,fps_mean,render_latency_mean_ms,render_latency_p95_ms,simulation_step_mean_ms,pathfind_update_mean_ms,mod_update_mean_ms,mod_entities_inspected_count,mod_repath_requested_count,path_requests_pending_count,path_queue_len_max,is_stall_window");
+                writer.WriteLine("run_id,elapsed_sec,simulation_tick,fps_mean,render_latency_mean_ms,render_latency_p95_ms,simulation_update_rate_mean,simulation_update_interval_mean_ms,simulation_update_interval_p95_ms,simulation_step_mean_ms,pathfind_update_mean_ms,mod_update_mean_ms,mod_entities_inspected_count,mod_repath_requested_count,path_requests_pending_count,path_queue_len_max,is_stall_window");
                 for (int i = 0; i < s_SummaryRows.Count; i++)
                 {
                     PerformanceSummaryRow row = s_SummaryRows[i];
@@ -523,6 +567,12 @@ namespace NoOfficeDemandFix.Telemetry
                     writer.Write(FormatDouble(row.RenderLatencyMeanMs));
                     writer.Write(',');
                     writer.Write(FormatDouble(row.RenderLatencyP95Ms));
+                    writer.Write(',');
+                    writer.Write(FormatDouble(row.SimulationUpdateRateMean));
+                    writer.Write(',');
+                    writer.Write(FormatDouble(row.SimulationUpdateIntervalMeanMs));
+                    writer.Write(',');
+                    writer.Write(FormatDouble(row.SimulationUpdateIntervalP95Ms));
                     writer.Write(',');
                     writer.Write(FormatDouble(row.SimulationStepMeanMs));
                     writer.Write(',');
@@ -581,7 +631,7 @@ namespace NoOfficeDemandFix.Telemetry
 
         private static void WriteMetadataBlock(TextWriter writer, string fileKind)
         {
-            WriteMetadataLine(writer, "telemetry_schema_version", "1");
+            WriteMetadataLine(writer, "telemetry_schema_version", kTelemetrySchemaVersion);
             WriteMetadataLine(writer, "telemetry_file_kind", SanitizeMetadataValue(fileKind));
             WriteMetadataLine(writer, "run_id", SanitizeMetadataValue(s_RunMetadata.RunId));
             WriteMetadataLine(writer, "run_start_utc", s_RunMetadata.RunStartUtc.ToString("O", CultureInfo.InvariantCulture));
@@ -611,7 +661,8 @@ namespace NoOfficeDemandFix.Telemetry
             {
                 return s_PathfindActionFields != null &&
                     s_PathfindActionItemsFields != null &&
-                    s_PathfindActionNextIndexFields != null;
+                    s_PathfindActionNextIndexFields != null &&
+                    s_PathfindActionCountProperties != null;
             }
 
             s_PathfindReflectionInitialized = true;
@@ -622,31 +673,52 @@ namespace NoOfficeDemandFix.Telemetry
             s_PathfindActionFields = new FieldInfo[s_PathfindActionFieldNames.Length];
             s_PathfindActionItemsFields = new FieldInfo[s_PathfindActionFieldNames.Length];
             s_PathfindActionNextIndexFields = new FieldInfo[s_PathfindActionFieldNames.Length];
+            s_PathfindActionCountProperties = new PropertyInfo[s_PathfindActionFieldNames.Length];
+            List<string> unsupportedFieldNames = null;
+            int boundFieldCount = 0;
             for (int i = 0; i < s_PathfindActionFieldNames.Length; i++)
             {
                 s_PathfindActionFields[i] = pathfindQueueType.GetField(s_PathfindActionFieldNames[i], flags);
-                if (s_PathfindActionFields[i] != null)
+                if (s_PathfindActionFields[i] == null)
                 {
-                    s_PathfindActionItemsFields[i] = s_PathfindActionFields[i].FieldType.GetField("m_Items", flags);
-                    s_PathfindActionNextIndexFields[i] = s_PathfindActionFields[i].FieldType.GetField("m_NextIndex", flags);
+                    (unsupportedFieldNames ??= new List<string>()).Add($"{s_PathfindActionFieldNames[i]} (missing)");
+                    continue;
                 }
+
+                Type fieldType = s_PathfindActionFields[i].FieldType;
+                s_PathfindActionItemsFields[i] = fieldType.GetField("m_Items", flags);
+                s_PathfindActionNextIndexFields[i] = fieldType.GetField("m_NextIndex", flags);
+                s_PathfindActionCountProperties[i] = GetCountProperty(fieldType, flags);
+
+                if (s_PathfindActionNextIndexFields[i] != null ||
+                    s_PathfindActionItemsFields[i] != null ||
+                    s_PathfindActionCountProperties[i] != null)
+                {
+                    boundFieldCount++;
+                    continue;
+                }
+
+                (unsupportedFieldNames ??= new List<string>()).Add(s_PathfindActionFieldNames[i]);
             }
 
-            bool valid = true;
-            for (int i = 0; i < s_PathfindActionFields.Length; i++)
-            {
-                valid &= s_PathfindActionFields[i] != null &&
-                    (s_PathfindActionItemsFields[i] != null || s_PathfindActionNextIndexFields[i] != null);
-            }
-
-            if (!valid && !s_PathfindReflectionUnavailableLogged)
+            if (boundFieldCount <= 0)
             {
                 DisablePathfindReflectionSampling();
-                Mod.log.Error("Performance telemetry could not bind PathfindQueueSystem fields. Path queue metrics will stay at 0.");
-                s_PathfindReflectionUnavailableLogged = true;
+                if (!s_PathfindReflectionUnavailableLogged)
+                {
+                    Mod.log.Error("Performance telemetry could not bind PathfindQueueSystem fields. Path queue metrics will stay at 0.");
+                    s_PathfindReflectionUnavailableLogged = true;
+                }
+
+                return false;
             }
 
-            return valid;
+            if (unsupportedFieldNames != null && unsupportedFieldNames.Count > 0)
+            {
+                Mod.log.Info($"Performance telemetry will skip unsupported PathfindQueueSystem fields: {string.Join(", ", unsupportedFieldNames)}.");
+            }
+
+            return true;
         }
 
         private static void DisablePathfindReflectionSampling()
@@ -654,6 +726,7 @@ namespace NoOfficeDemandFix.Telemetry
             s_PathfindActionFields = null;
             s_PathfindActionItemsFields = null;
             s_PathfindActionNextIndexFields = null;
+            s_PathfindActionCountProperties = null;
             s_PathfindReflectionInitialized = true;
         }
 
@@ -663,6 +736,16 @@ namespace NoOfficeDemandFix.Telemetry
             if (nextIndexField != null)
             {
                 return Math.Max(0, (int)nextIndexField.GetValue(actionList));
+            }
+
+            PropertyInfo countProperty = s_PathfindActionCountProperties[index];
+            if (countProperty != null)
+            {
+                object countValue = countProperty.GetValue(actionList);
+                if (countValue is int count)
+                {
+                    return Math.Max(0, count);
+                }
             }
 
             FieldInfo itemsField = s_PathfindActionItemsFields[index];
@@ -676,6 +759,20 @@ namespace NoOfficeDemandFix.Telemetry
             }
 
             return 0;
+        }
+
+        private static PropertyInfo GetCountProperty(Type fieldType, BindingFlags flags)
+        {
+            PropertyInfo countProperty = fieldType.GetProperty("Count", flags);
+            if (countProperty != null &&
+                countProperty.CanRead &&
+                countProperty.PropertyType == typeof(int) &&
+                countProperty.GetIndexParameters().Length == 0)
+            {
+                return countProperty;
+            }
+
+            return null;
         }
 
         private static void ResetRunState()
@@ -694,11 +791,14 @@ namespace NoOfficeDemandFix.Telemetry
         {
             s_Window = default;
             s_WindowLatencySamplesMs.Clear();
+            s_WindowSimulationUpdateIntervalSamplesMs.Clear();
             s_ActiveStall = default;
             s_StallLatencySamplesMs.Clear();
             s_PendingStallCandidate = default;
             s_ConsecutiveAboveThreshold = 0;
             s_ConsecutiveBelowThreshold = 0;
+            s_HasSimulationUpdateTimestamp = false;
+            s_LastSimulationUpdateTimestamp = 0L;
             ResetFrameInstrumentation();
         }
 
@@ -747,6 +847,8 @@ namespace NoOfficeDemandFix.Telemetry
             public int FrameCount;
             public double TotalDurationSec;
             public double TotalRenderLatencyMs;
+            public int SimulationUpdateSampleCount;
+            public double TotalSimulationUpdateIntervalMs;
             public double TotalSimulationStepMs;
             public double TotalPathfindUpdateMs;
             public double TotalModUpdateMs;

--- a/NoOfficeDemandFix/Telemetry/PerformanceTelemetryModels.cs
+++ b/NoOfficeDemandFix/Telemetry/PerformanceTelemetryModels.cs
@@ -26,6 +26,9 @@ namespace NoOfficeDemandFix.Telemetry
         public double FpsMean;
         public double RenderLatencyMeanMs;
         public double RenderLatencyP95Ms;
+        public double SimulationUpdateRateMean;
+        public double SimulationUpdateIntervalMeanMs;
+        public double SimulationUpdateIntervalP95Ms;
         public double SimulationStepMeanMs;
         public double PathfindUpdateMeanMs;
         public double ModUpdateMeanMs;

--- a/PERF_REPORTING.md
+++ b/PERF_REPORTING.md
@@ -10,7 +10,7 @@ This intake is for performance comparison. It is not the same as the
 
 Performance telemetry is intended to answer two questions:
 
-- what steady-state overhead the mod adds outside stalls
+- what render-aligned steady-state overhead the mod adds outside stalls
 - how stall frequency, duration, and severity change during stressed periods
 
 The automation summarizes those two views separately and checks whether a
@@ -46,6 +46,7 @@ When multiple telemetry captures feed the same performance question:
 - keep the enabled fix set the same when you want direct before/after deltas
 - if a fix toggle itself is the variable under test, say that explicitly in `What changed`; direct deltas are still allowed when save/scenario, sampling interval, and stall threshold match and telemetry metadata shows exactly one known fix-toggle difference
 - prefer the same save lineage, same game version, and same mod version for direct comparison
+- telemetry bundles should now use `telemetry_schema_version=2`; the summary CSV adds explicit simulation-cadence columns while keeping `fps_mean` and `render_latency_*` aligned to visible frame cadence
 - if you need semantic interpretation later, also capture a matching diagnostics raw log on the same save and settings
 
 ## What To Upload

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Current defaults from [Setting.cs](./NoOfficeDemandFix/Setting.cs):
 | `DiagnosticsSamplesPerDay` | `2` | Sets how many scheduled diagnostic samples run per displayed in-game day while diagnostics are enabled. Higher values produce denser logs. |
 | `CaptureStableEvidence` | `false` | Keeps scheduled software diagnostics running even when the city looks stable. Use it only when you want baseline logs for troubleshooting. |
 | `VerboseLogging` | `false` | Adds noisier correction traces and supplemental office-trade detail lines, and forces diagnostics output at the configured cadence while it is on. Use it only when you want detailed troubleshooting logs. |
-| `EnablePerformanceTelemetry` | `false` | Captures coarse in-memory performance summaries and stall events, then writes `perf_summary.csv` and `perf_stalls.csv` when the current session ends. Keep it off unless you are intentionally measuring performance. |
-| `PerformanceTelemetrySamplingIntervalSec` | `1.0` | Controls the coarse wall-clock summary window for performance telemetry in seconds. Lower values produce denser CSV output and slightly more telemetry overhead. |
-| `PerformanceTelemetryStallThresholdMs` | `250` | Defines the render-latency threshold used to start and end coarse stall-event tracking. |
+| `EnablePerformanceTelemetry` | `false` | Captures coarse, render-aligned performance summaries and stall events, then writes `perf_summary.csv` and `perf_stalls.csv` when the current session ends. Keep it off unless you are intentionally measuring performance. |
+| `PerformanceTelemetrySamplingIntervalSec` | `1.0` | Controls the coarse render-aligned summary window for performance telemetry in seconds. Lower values produce denser CSV output and slightly more telemetry overhead. |
+| `PerformanceTelemetryStallThresholdMs` | `250` | Defines the render-aligned frame-latency threshold used to start and end coarse stall-event tracking. |
 
 ## Implementation
 


### PR DESCRIPTION
## What changed
- Moved `PerformanceTelemetrySystem` sampling to `LateUpdate` so `fps_mean` and render latency reflect rendered-frame cadence instead of simulation cadence.
- Added schema v2 summary columns for simulation update rate and simulation update interval while keeping the stall CSV contract unchanged.
- Hardened path queue reflection sampling so unsupported internal field shapes no longer zero all queue metrics on affected builds.
- Updated telemetry intake automation and tests to parse both v1 and v2 summary headers.
- Updated README, performance reporting docs, and the telemetry issue template to describe render-aligned telemetry and schema v2.

## Why
- `fps_mean` was previously derived from the `GameSimulation` cadence, so reported FPS could diverge from the visible frame rate.
- The new cadence fields keep simulation timing visible without overloading the render-facing columns, and the automation/docs need to accept the new summary header.
- Refs: #105

## How
- Schedule `PerformanceTelemetrySystem` after `SimulationSystem` in `LateUpdate`, and record simulation update timestamps separately from render-latency samples.
- Emit `telemetry_schema_version=2` summary metadata and append `simulation_update_rate_mean`, `simulation_update_interval_mean_ms`, and `simulation_update_interval_p95_ms` to `perf_summary.csv`.
- Fall back across `m_NextIndex`, `Count`, and `m_Items` reflection paths for path queue depth, and skip only unsupported queue fields instead of disabling the whole sampler.
- Save compatibility / migration impact: no save-format change; telemetry summary consumers must handle schema v2, and repo automation now accepts both v1 and v2 headers.
- Settings / defaults: no gameplay settings or defaults changed; only telemetry wording was clarified.

## Testing
- Build / validation:
  - `dotnet build NoOfficeDemandFix.sln -c Release`
  - `py -3 -m unittest discover -s .github\scripts\tests -p "test_*perf_telemetry*.py"`
  - `py -3 -m unittest discover -s .github\scripts\tests -p "test_run_perf_telemetry_triage.py"`
- Repository validation artifact:
  - `#109` captures a schema-v2 hotfix-candidate telemetry bundle with non-zero queue metrics and plausible render-aligned summary values.
  - Treat it as pre-bump hotfix-candidate validation only; the attached CSV metadata still reports `mod_version=0.2.2.0`.
- Manual verification:
  - Not run in-game in this pass.
- Settings touched:
  - [x] No settings changed
  - [ ] Defaults changed
  - [ ] Reload required
  - [ ] Restart required

## Risk / Rollback
- Risk areas:
  - External tooling that assumes the old summary header may reject schema v2 output until updated.
  - Queue-depth sampling still depends on game internals and may under-report on future field-layout changes.
- Rollback / mitigation:
  - Repo automation now accepts both v1 and v2 summary headers, and the sampler skips unsupported queue fields instead of zeroing every queue metric.
  - If render-aligned sampling proves misleading in practice, revert `PerformanceTelemetrySystem` scheduling and the v2 summary columns together.

## Reviewer Checklist
- [x] Linked issue, investigation, or release item when applicable
- [x] README or docs updated if behavior or defaults changed
- [x] Save compatibility impact called out
- [x] Verification steps are specific enough to reproduce
- [x] Risk and rollback are concrete for shipped behavior

## PR Classification (optional)
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Docs
- [ ] Chore/Maintenance
- [ ] Build/CI
- [ ] Test

Justification: This corrects an existing telemetry reporting bug where render-facing FPS metrics were sampled from simulation cadence. The automation and docs changes are supporting work needed to consume the corrected schema safely.
