### PR TITLE
feat(infra): add packetflow_foundry workflow assets

### DIFF
--- a/.agents/skills/draft-release-copy
+++ b/.agents/skills/draft-release-copy
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/draft-release-copy

--- a/.agents/skills/draft-release-copy
+++ b/.agents/skills/draft-release-copy
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/draft-release-copy

--- a/.agents/skills/draft-release-copy/SKILL.md
+++ b/.agents/skills/draft-release-copy/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: draft-release-copy
+description: Draft and validate reusable release-copy updates by collecting release evidence, preparing publish configuration and README updates, and normalizing release-issue create or edit actions. Use when Codex must turn tracked repo state plus release evidence into guarded release-copy edits without encoding project-specific release policy in the retained kernel.
+---
+
+# Draft Release Copy
+
+Thin entrypoint for the foundry retained `draft-release-copy` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/draft-release-copy/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/draft-release-copy/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/draft-release-copy/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/draft-release-copy/SKILL.md
+++ b/.agents/skills/draft-release-copy/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: draft-release-copy
+description: Draft and validate reusable release-copy updates by collecting release evidence, preparing publish configuration and README updates, and normalizing release-issue create or edit actions. Use when Codex must turn tracked repo state plus release evidence into guarded release-copy edits without encoding project-specific release policy in the retained kernel.
+---
+
+# Draft Release Copy
+
+Thin entrypoint for the foundry retained `draft-release-copy` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/draft-release-copy/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/draft-release-copy/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/draft-release-copy/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/draft-release-copy/agents/openai.yaml
+++ b/.agents/skills/draft-release-copy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Draft Release Copy"
+  short_description: "prepare reusable release-copy updates with packet..."
+  default_prompt: "prepare reusable release-copy updates with packet-heavy local synthesis and validator-normalized apply actions"

--- a/.agents/skills/gh-address-review-threads
+++ b/.agents/skills/gh-address-review-threads
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/gh-address-review-threads

--- a/.agents/skills/gh-address-review-threads
+++ b/.agents/skills/gh-address-review-threads
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/gh-address-review-threads

--- a/.agents/skills/gh-address-review-threads/SKILL.md
+++ b/.agents/skills/gh-address-review-threads/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gh-address-review-threads
+description: Inspect unresolved GitHub PR review threads on the open pull request for the current branch, decide whether to accept, reject, defer, or defer outdated threads, post acknowledgement and completion replies with gh CLI, apply accepted fixes, and resolve completed threads. Use when Codex needs to read open PR review threads, summarize the planned direction or rejection, perform the work, then post a completion reply and resolve the finished threads.
+---
+
+# Address Review Threads
+
+Thin entrypoint for the foundry retained `gh-address-review-threads` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/gh-address-review-threads/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/gh-address-review-threads/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/gh-address-review-threads/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/gh-address-review-threads/SKILL.md
+++ b/.agents/skills/gh-address-review-threads/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gh-address-review-threads
+description: Inspect unresolved GitHub PR review threads on the open pull request for the current branch, decide whether to accept, reject, defer, or defer outdated threads, post acknowledgement and completion replies with gh CLI, apply accepted fixes, and resolve completed threads. Use when Codex needs to read open PR review threads, summarize the planned direction or rejection, perform the work, then post a completion reply and resolve the finished threads.
+---
+
+# Address Review Threads
+
+Thin entrypoint for the foundry retained `gh-address-review-threads` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-address-review-threads/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-address-review-threads/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-address-review-threads/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/gh-address-review-threads/agents/openai.yaml
+++ b/.agents/skills/gh-address-review-threads/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: "Address Review Threads"
+  short_description: "Inspect and resolve open GitHub PR review threads"
+  default_prompt: >-
+    Use $gh-address-review-threads to handle unresolved PR review threads on
+    this branch. Collect structured thread packets, keep
+    global_packet.json in view, decide accept/reject/defer/defer-outdated
+    locally, and post acknowledgement and completion replies only after the
+    accepted fix is validated and pushed.

--- a/.agents/skills/gh-create-pr
+++ b/.agents/skills/gh-create-pr
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/gh-create-pr

--- a/.agents/skills/gh-create-pr
+++ b/.agents/skills/gh-create-pr
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/gh-create-pr

--- a/.agents/skills/gh-create-pr/SKILL.md
+++ b/.agents/skills/gh-create-pr/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gh-create-pr
+description: Create a GitHub pull request from an already-pushed branch by collecting repo and PR-template context, drafting a repo-compliant title/body, validating duplicate-PR and stale-snapshot gates, and creating the PR with gh CLI only after the normalized create request passes validation. Use when Codex must open a new PR instead of rewriting an existing one.
+---
+
+# Guarded PR Creation
+
+Thin entrypoint for the foundry retained `gh-create-pr` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-create-pr/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-create-pr/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/gh-create-pr/SKILL.md
+++ b/.agents/skills/gh-create-pr/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gh-create-pr
+description: Create a GitHub pull request from an already-pushed branch by collecting repo and PR-template context, drafting a repo-compliant title/body, validating duplicate-PR and stale-snapshot gates, and creating the PR with gh CLI only after the normalized create request passes validation. Use when Codex must open a new PR instead of rewriting an existing one.
+---
+
+# Guarded PR Creation
+
+Thin entrypoint for the foundry retained `gh-create-pr` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/gh-create-pr/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/gh-create-pr/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/gh-create-pr/agents/openai.yaml
+++ b/.agents/skills/gh-create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gh Create Pr"
+  short_description: "create a guarded GitHub pull request from a pushe..."
+  default_prompt: "create a guarded GitHub pull request from a pushed branch with packet-heavy local synthesis and validator-normalized apply"

--- a/.agents/skills/gh-fix-pr-writeup
+++ b/.agents/skills/gh-fix-pr-writeup
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/gh-fix-pr-writeup

--- a/.agents/skills/gh-fix-pr-writeup
+++ b/.agents/skills/gh-fix-pr-writeup
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/gh-fix-pr-writeup

--- a/.agents/skills/gh-fix-pr-writeup/SKILL.md
+++ b/.agents/skills/gh-fix-pr-writeup/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gh-fix-pr-writeup
+description: Verify and repair a GitHub pull request title and body when the user gives a PR number or asks to audit, rewrite, or fix PR text. Use when Codex must compare a PR's current writeup against repository PR instructions/templates and the actual code changes, then update it with gh CLI if the title/body are missing, truncated, generic, misleading, or unsupported by the diff.
+---
+
+# PR Writeup Repair
+
+Thin entrypoint for the foundry retained `gh-fix-pr-writeup` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/gh-fix-pr-writeup/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/gh-fix-pr-writeup/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/gh-fix-pr-writeup/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/gh-fix-pr-writeup/SKILL.md
+++ b/.agents/skills/gh-fix-pr-writeup/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: gh-fix-pr-writeup
+description: Verify and repair a GitHub pull request title and body when the user gives a PR number or asks to audit, rewrite, or fix PR text. Use when Codex must compare a PR's current writeup against repository PR instructions/templates and the actual code changes, then update it with gh CLI if the title/body are missing, truncated, generic, misleading, or unsupported by the diff.
+---
+
+# PR Writeup Repair
+
+Thin entrypoint for the foundry retained `gh-fix-pr-writeup` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/gh-fix-pr-writeup/agents/openai.yaml
+++ b/.agents/skills/gh-fix-pr-writeup/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: "Fix PR Writeup"
+  short_description: "Audit and repair PR title/body"
+  default_prompt: >-
+    Use $gh-fix-pr-writeup to verify a PR title and body against repository
+    PR rules and the actual change set, then rewrite it only if the new text
+    is materially better. Keep rules_packet.json in view before editing the
+    PR, run validate_pr_writeup_edit.py before any mutation, and use
+    apply_pr_writeup.py only with validator output.

--- a/.agents/skills/git-split-and-commit
+++ b/.agents/skills/git-split-and-commit
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/git-split-and-commit

--- a/.agents/skills/git-split-and-commit
+++ b/.agents/skills/git-split-and-commit
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/git-split-and-commit

--- a/.agents/skills/git-split-and-commit/SKILL.md
+++ b/.agents/skills/git-split-and-commit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: git-split-and-commit
+description: Review the active repository's current working tree, split local changes into logical commits, draft repo-compliant commit messages, and commit automatically when confidence is high. Use when Codex needs to inspect staged, unstaged, and untracked non-ignored changes, decide whether they belong in one or more commits, and apply the commits safely with packetized evidence and targeted validation.
+---
+
+# Git Split And Commit
+
+Thin entrypoint for the foundry retained `git-split-and-commit` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/git-split-and-commit/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/git-split-and-commit/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/git-split-and-commit/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/git-split-and-commit/SKILL.md
+++ b/.agents/skills/git-split-and-commit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: git-split-and-commit
+description: Review the active repository's current working tree, split local changes into logical commits, draft repo-compliant commit messages, and commit automatically when confidence is high. Use when Codex needs to inspect staged, unstaged, and untracked non-ignored changes, decide whether they belong in one or more commits, and apply the commits safely with packetized evidence and targeted validation.
+---
+
+# Git Split And Commit
+
+Thin entrypoint for the foundry retained `git-split-and-commit` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/git-split-and-commit/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/git-split-and-commit/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/git-split-and-commit/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/git-split-and-commit/agents/openai.yaml
+++ b/.agents/skills/git-split-and-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Split And Commit"
+  short_description: "Split working-tree changes into logical commits"
+  default_prompt: "Use $git-split-and-commit to review the current working tree, split it into logical commits, and commit automatically if confidence is high."

--- a/.agents/skills/packet-workflow-skill-builder
+++ b/.agents/skills/packet-workflow-skill-builder
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/packet-workflow-skill-builder

--- a/.agents/skills/packet-workflow-skill-builder
+++ b/.agents/skills/packet-workflow-skill-builder
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/packet-workflow-skill-builder

--- a/.agents/skills/packet-workflow-skill-builder/SKILL.md
+++ b/.agents/skills/packet-workflow-skill-builder/SKILL.md
@@ -10,7 +10,7 @@ Thin entry wiring for the foundry's packet-workflow builder.
 This subtree is intentionally minimal:
 - keep only `SKILL.md` and `agents/openai.yaml` here
 - keep authoritative builder logic and tests in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/`
-- keep authoritative contracts, templates, and default semantics in `../../../core/`
+- keep authoritative contracts, templates, and default semantics in `../../../.codex/vendor/packetflow_foundry/core/`
 - do not reintroduce local copies of contracts, templates, scripts, or tests under this skill subtree
 
 Use this skill only for repo packet workflows that follow `collect -> optional lint -> build packets -> optional validate -> optional apply`.
@@ -20,18 +20,18 @@ Use this skill only for repo packet workflows that follow `collect -> optional l
 1. Ground the target workflow before scaffolding.
 - Inspect the target repo artifacts and existing workflow entrypoints.
 - Decide whether the new skill is `audit-only`, `audit-and-apply`, or `plan-validate-apply`.
-- Read `../../../core/contracts/packet-workflow/pattern-catalog.md` only when you need help mapping the workflow to the packet pattern.
+- Read `../../../.codex/vendor/packetflow_foundry/core/contracts/packet-workflow/pattern-catalog.md` only when you need help mapping the workflow to the packet pattern.
 
 2. Draft a builder spec before generating files.
 - Use `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/builder-contract.md` to lock the `builder-spec.json` fields.
 - Keep the workflow narrow: choose only the packets, scripts, and stop conditions the target workflow actually needs.
 - Add `repo_profile` only for repo-specific path bindings, review-doc lists, and lint toggles.
 - Keep repo profiles declarative and data-only: paths, globs, doc lists, booleans, defaults, and notes only.
-- Choose `orchestrator_profile=standard` by default and use `packet-heavy-orchestrator` only when the workflow needs the packet-heavy common path from `../../../core/contracts/packet-workflow/common-path-contract.md`.
+- Choose `orchestrator_profile=standard` by default and use `packet-heavy-orchestrator` only when the workflow needs the packet-heavy common path from `../../../.codex/vendor/packetflow_foundry/core/contracts/packet-workflow/common-path-contract.md`.
 
 3. Generate the scaffold deterministically.
 - Run `python ../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/scripts/init_packet_skill.py --spec <builder-spec.json> --output-dir <foundry-root>`.
-- The generator consumes templates from `../../../core/templates/packet-workflow/` and defaults from `../../../core/defaults/packet-workflow/`.
+- The generator consumes templates from `../../../.codex/vendor/packetflow_foundry/core/templates/packet-workflow/` and defaults from `../../../.codex/vendor/packetflow_foundry/core/defaults/packet-workflow/`.
 - The generator writes the authoritative retained kernel to `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>/`.
 - The generator writes the thin discovery wrapper to `../../../.agents/skills/<skill-name>/`.
 - Generated skills should treat `../../../.codex/tmp/` as the only repo-local home for temporary, helper, scratch, and ad hoc operator-input files that are not meant for source control.

--- a/.agents/skills/packet-workflow-skill-builder/SKILL.md
+++ b/.agents/skills/packet-workflow-skill-builder/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: packet-workflow-skill-builder
+description: Thin entrypoint for the foundry packet-workflow builder. Use when Codex should invoke the authoritative root builder, contracts, templates, and defaults in this repository.
+---
+
+# Packet Workflow Skill Builder
+
+Thin entry wiring for the foundry's packet-workflow builder.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative builder logic and tests in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/`
+- keep authoritative contracts, templates, and default semantics in `../../../core/`
+- do not reintroduce local copies of contracts, templates, scripts, or tests under this skill subtree
+
+Use this skill only for repo packet workflows that follow `collect -> optional lint -> build packets -> optional validate -> optional apply`.
+
+## Workflow
+
+1. Ground the target workflow before scaffolding.
+- Inspect the target repo artifacts and existing workflow entrypoints.
+- Decide whether the new skill is `audit-only`, `audit-and-apply`, or `plan-validate-apply`.
+- Read `../../../core/contracts/packet-workflow/pattern-catalog.md` only when you need help mapping the workflow to the packet pattern.
+
+2. Draft a builder spec before generating files.
+- Use `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/builder-contract.md` to lock the `builder-spec.json` fields.
+- Keep the workflow narrow: choose only the packets, scripts, and stop conditions the target workflow actually needs.
+- Add `repo_profile` only for repo-specific path bindings, review-doc lists, and lint toggles.
+- Keep repo profiles declarative and data-only: paths, globs, doc lists, booleans, defaults, and notes only.
+- Choose `orchestrator_profile=standard` by default and use `packet-heavy-orchestrator` only when the workflow needs the packet-heavy common path from `../../../core/contracts/packet-workflow/common-path-contract.md`.
+
+3. Generate the scaffold deterministically.
+- Run `python ../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/scripts/init_packet_skill.py --spec <builder-spec.json> --output-dir <foundry-root>`.
+- The generator consumes templates from `../../../core/templates/packet-workflow/` and defaults from `../../../core/defaults/packet-workflow/`.
+- The generator writes the authoritative retained kernel to `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>/`.
+- The generator writes the thin discovery wrapper to `../../../.agents/skills/<skill-name>/`.
+- Generated skills should treat `../../../.codex/tmp/` as the only repo-local home for temporary, helper, scratch, and ad hoc operator-input files that are not meant for source control.
+- Generated skills should place runtime artifacts under the fixed gitignored repo-local root `../../../.codex/tmp/packet-workflow/<skill-name>/<run-id>/`.
+- Generated skills should default evaluation logging to `~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json` and use the fixed gitignored `.codex/tmp/` fallback only when sandbox rules require repo-local writes.
+
+4. Validate the generated skill immediately.
+- Run `python <codex-home>/skills/.system/skill-creator/scripts/quick_validate.py ../../../.agents/skills/<skill-name>`.
+- Run `python -m py_compile ../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>/scripts/*.py` for every generated retained script.
+
+## Guardrails
+
+- Keep mutation, final synthesis, and broad code changes local in generated skills.
+- Keep final adjudication local even when mini workers propose candidate classifications.
+- Keep repo profiles data-only end to end; executable behavior stays in scripts and core contracts.
+- Treat `worker_selection_guidance` as explanatory metadata only; `packet_worker_map` is the routing authority when present.
+- Prefer foundry baseline behavior first, then optional foundry overlay, then project-local profile overrides outside this repo.
+- Do not place authoritative builder specs, profiles, references, scripts, tests, or migration worksheets back under `.agents/skills/`.
+
+## Output
+
+- Tell the user which archetype and packet set you chose.
+- Tell the user which generated scripts are placeholders versus ready-to-fill skeletons.
+- Tell the user which defaults came from foundry core versus the repo profile scaffold.

--- a/.agents/skills/packet-workflow-skill-builder/SKILL.md
+++ b/.agents/skills/packet-workflow-skill-builder/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: packet-workflow-skill-builder
+description: Thin entrypoint for the foundry packet-workflow builder. Use when Codex should invoke the authoritative root builder, contracts, templates, and defaults in this repository.
+---
+
+# Packet Workflow Skill Builder
+
+Thin entry wiring for the foundry's packet-workflow builder.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative builder logic and tests in `../../../builders/packet-workflow/`
+- keep authoritative contracts, templates, and default semantics in `../../../core/`
+- do not reintroduce local copies of contracts, templates, scripts, or tests under this skill subtree
+
+Use this skill only for repo packet workflows that follow `collect -> optional lint -> build packets -> optional validate -> optional apply`.
+
+## Workflow
+
+1. Ground the target workflow before scaffolding.
+- Inspect the target repo artifacts and existing workflow entrypoints.
+- Decide whether the new skill is `audit-only`, `audit-and-apply`, or `plan-validate-apply`.
+- Read `../../../core/contracts/packet-workflow/pattern-catalog.md` only when you need help mapping the workflow to the packet pattern.
+
+2. Draft a builder spec before generating files.
+- Use `../../../builders/packet-workflow/builder-contract.md` to lock the `builder-spec.json` fields.
+- Keep the workflow narrow: choose only the packets, scripts, and stop conditions the target workflow actually needs.
+- Add `repo_profile` only for repo-specific path bindings, review-doc lists, and lint toggles.
+- Keep repo profiles declarative and data-only: paths, globs, doc lists, booleans, defaults, and notes only.
+- Choose `orchestrator_profile=standard` by default and use `packet-heavy-orchestrator` only when the workflow needs the packet-heavy common path from `../../../core/contracts/packet-workflow/common-path-contract.md`.
+
+3. Generate the scaffold deterministically.
+- Run `python ../../../builders/packet-workflow/scripts/init_packet_skill.py --spec <builder-spec.json> --output-dir <foundry-root>`.
+- The generator consumes templates from `../../../core/templates/packet-workflow/` and defaults from `../../../core/defaults/packet-workflow/`.
+- The generator writes the authoritative retained kernel to `../../../builders/packet-workflow/retained-skills/<skill-name>/`.
+- The generator writes the thin discovery wrapper to `../../../.agents/skills/<skill-name>/`.
+- Generated skills should place runtime artifacts under the fixed gitignored repo-local root `../../../.codex/tmp/packet-workflow/<skill-name>/<run-id>/`.
+- Generated skills should default evaluation logging to `~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json` and use the fixed gitignored `.codex/tmp/` fallback only when sandbox rules require repo-local writes.
+
+4. Validate the generated skill immediately.
+- Run `python <codex-home>/skills/.system/skill-creator/scripts/quick_validate.py ../../../.agents/skills/<skill-name>`.
+- Run `python -m py_compile ../../../builders/packet-workflow/retained-skills/<skill-name>/scripts/*.py` for every generated retained script.
+
+## Guardrails
+
+- Keep mutation, final synthesis, and broad code changes local in generated skills.
+- Keep final adjudication local even when mini workers propose candidate classifications.
+- Keep repo profiles data-only end to end; executable behavior stays in scripts and core contracts.
+- Treat `worker_selection_guidance` as explanatory metadata only; `packet_worker_map` is the routing authority when present.
+- Prefer foundry baseline behavior first, then optional foundry overlay, then project-local profile overrides outside this repo.
+- Do not place authoritative builder specs, profiles, references, scripts, tests, or migration worksheets back under `.agents/skills/`.
+
+## Output
+
+- Tell the user which archetype and packet set you chose.
+- Tell the user which generated scripts are placeholders versus ready-to-fill skeletons.
+- Tell the user which defaults came from foundry core versus the repo profile scaffold.

--- a/.agents/skills/packet-workflow-skill-builder/SKILL.md
+++ b/.agents/skills/packet-workflow-skill-builder/SKILL.md
@@ -34,6 +34,7 @@ Use this skill only for repo packet workflows that follow `collect -> optional l
 - The generator consumes templates from `../../../core/templates/packet-workflow/` and defaults from `../../../core/defaults/packet-workflow/`.
 - The generator writes the authoritative retained kernel to `../../../builders/packet-workflow/retained-skills/<skill-name>/`.
 - The generator writes the thin discovery wrapper to `../../../.agents/skills/<skill-name>/`.
+- Generated skills should treat `../../../.codex/tmp/` as the only repo-local home for temporary, helper, scratch, and ad hoc operator-input files that are not meant for source control.
 - Generated skills should place runtime artifacts under the fixed gitignored repo-local root `../../../.codex/tmp/packet-workflow/<skill-name>/<run-id>/`.
 - Generated skills should default evaluation logging to `~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json` and use the fixed gitignored `.codex/tmp/` fallback only when sandbox rules require repo-local writes.
 

--- a/.agents/skills/packet-workflow-skill-builder/agents/openai.yaml
+++ b/.agents/skills/packet-workflow-skill-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Packet Workflow Skill Builder"
+  short_description: "Thin entrypoint to the root packet-workflow builder"
+  default_prompt: "Use the root packet-workflow builder to scaffold a new packet-driven repo workflow skill from the authoritative core contracts, templates, and defaults in this repository."

--- a/.agents/skills/public-docs-sync
+++ b/.agents/skills/public-docs-sync
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/public-docs-sync

--- a/.agents/skills/public-docs-sync
+++ b/.agents/skills/public-docs-sync
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/public-docs-sync

--- a/.agents/skills/public-docs-sync/SKILL.md
+++ b/.agents/skills/public-docs-sync/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: public-docs-sync
+description: Audit and synchronize public repository docs against tracked runtime metadata, selected GitHub evidence, and validator-normalized deterministic edits. Use when Codex must detect public-doc drift, propose scoped fixes, and update marker state without embedding repo-specific governance policy in the retained kernel.
+---
+
+# Public Docs Sync
+
+Thin entrypoint for the foundry retained `public-docs-sync` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/public-docs-sync/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/public-docs-sync/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/public-docs-sync/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/public-docs-sync/SKILL.md
+++ b/.agents/skills/public-docs-sync/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: public-docs-sync
+description: Audit and synchronize public repository docs against tracked runtime metadata, selected GitHub evidence, and validator-normalized deterministic edits. Use when Codex must detect public-doc drift, propose scoped fixes, and update marker state without embedding repo-specific governance policy in the retained kernel.
+---
+
+# Public Docs Sync
+
+Thin entrypoint for the foundry retained `public-docs-sync` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/public-docs-sync/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/public-docs-sync/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/public-docs-sync/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/public-docs-sync/agents/openai.yaml
+++ b/.agents/skills/public-docs-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Public Docs Sync"
+  short_description: "audit public docs with scoped packet analysis and..."
+  default_prompt: "audit public docs with scoped packet analysis and validator-normalized deterministic sync actions"

--- a/.agents/skills/reword-head-commit/SKILL.md
+++ b/.agents/skills/reword-head-commit/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: reword-head-commit
+description: Rewrite only the current HEAD commit message to the active repository's commit-message rules. Use when Codex needs a fast amend-based path for one clean HEAD commit with explicit repo guidance and no packet or replay audit requirements.
+---
+
+# Reword Head Commit
+
+Thin entrypoint for the foundry retained `reword-head-commit` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/reword-head-commit/`
+- do not reintroduce local copies of references, scripts, tests, or helper
+  code under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at
+`../../../builders/packet-workflow/retained-skills/reword-head-commit/SKILL.md`.
+
+Decision guide:
+- use `reword-head-commit` for a trivial `HEAD`-only rewrite on a clean branch
+  tip with explicit repo rules
+- use `reword-recent-commits` for broader or riskier history rewrites
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/reword-head-commit/`
+  as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/reword-head-commit/SKILL.md
+++ b/.agents/skills/reword-head-commit/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: reword-head-commit
+description: Rewrite only the current HEAD commit message to the active repository's commit-message rules. Use when Codex needs a fast amend-based path for one clean HEAD commit with explicit repo guidance and no packet or replay audit requirements.
+---
+
+# Reword Head Commit
+
+Thin entrypoint for the foundry retained `reword-head-commit` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/reword-head-commit/`
+- do not reintroduce local copies of references, scripts, tests, or helper
+  code under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at
+`../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/reword-head-commit/SKILL.md`.
+
+Decision guide:
+- use `reword-head-commit` for a trivial `HEAD`-only rewrite on a clean branch
+  tip with explicit repo rules
+- use `reword-recent-commits` for broader or riskier history rewrites
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/reword-head-commit/`
+  as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/reword-head-commit/agents/openai.yaml
+++ b/.agents/skills/reword-head-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reword Head Commit"
+  short_description: "Rewrite only the current HEAD commit message"
+  default_prompt: "Use $reword-head-commit to rewrite only the current HEAD commit message to the repo rules."

--- a/.agents/skills/reword-recent-commits
+++ b/.agents/skills/reword-recent-commits
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/reword-recent-commits

--- a/.agents/skills/reword-recent-commits
+++ b/.agents/skills/reword-recent-commits
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/reword-recent-commits

--- a/.agents/skills/reword-recent-commits/SKILL.md
+++ b/.agents/skills/reword-recent-commits/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: reword-recent-commits
+description: Rewrite or reword a recent range of Git commit messages to the active repository's commit-message rules. Use when Codex needs replay-style safety, packet/audit artifacts, or anything broader than a trivial HEAD-only amend path.
+---
+
+# Reword Recent Commits
+
+Thin entrypoint for the foundry retained `reword-recent-commits` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/reword-recent-commits/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md`.
+
+Decision guide:
+- use `reword-head-commit` for a trivial `HEAD`-only rewrite on a clean branch
+  tip with explicit repo rules
+- use `reword-recent-commits` for broader or riskier history rewrites
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/reword-recent-commits/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/reword-recent-commits/SKILL.md
+++ b/.agents/skills/reword-recent-commits/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: reword-recent-commits
+description: Rewrite or reword the latest n Git commit messages to the active repository's commit-message rules. Use when Codex needs to inspect repo-specific commit guidance, draft replacement commit messages for recent local commits, and optionally apply the rewrite safely without hand-driving an interactive rebase. Keep orchestration, final message synthesis, confirmation, and ref updates local while offloading narrow read-only packet analysis to gpt-5.4-mini workers when the rewrite spans multiple commits or areas.
+---
+
+# Reword Recent Commits
+
+Thin entrypoint for the foundry retained `reword-recent-commits` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/reword-recent-commits/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/reword-recent-commits/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/reword-recent-commits/SKILL.md
+++ b/.agents/skills/reword-recent-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reword-recent-commits
-description: Rewrite or reword the latest n Git commit messages to the active repository's commit-message rules. Use when Codex needs to inspect repo-specific commit guidance, draft replacement commit messages for recent local commits, and optionally apply the rewrite safely without hand-driving an interactive rebase. Keep orchestration, final message synthesis, confirmation, and ref updates local while offloading narrow read-only packet analysis to gpt-5.4-mini workers when the rewrite spans multiple commits or areas.
+description: Rewrite or reword a recent range of Git commit messages to the active repository's commit-message rules. Use when Codex needs replay-style safety, packet/audit artifacts, or anything broader than a trivial HEAD-only amend path.
 ---
 
 # Reword Recent Commits
@@ -13,6 +13,11 @@ This subtree is intentionally minimal:
 - do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
 
 Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md`.
+
+Decision guide:
+- use `reword-head-commit` for a trivial `HEAD`-only rewrite on a clean branch
+  tip with explicit repo rules
+- use `reword-recent-commits` for broader or riskier history rewrites
 
 When working on this skill:
 - treat `../../../builders/packet-workflow/retained-skills/reword-recent-commits/` as the source of truth

--- a/.agents/skills/reword-recent-commits/agents/openai.yaml
+++ b/.agents/skills/reword-recent-commits/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reword Recent Commits"
-  short_description: "Reword recent commits to repo conventions"
-  default_prompt: "Use $reword-recent-commits to rewrite the last 3 commit messages to the repo rules."
+  short_description: "Reword recent commit ranges with replay safety"
+  default_prompt: "Use $reword-recent-commits to rewrite a recent commit range when replay-style safety or packet evidence is needed."

--- a/.agents/skills/reword-recent-commits/agents/openai.yaml
+++ b/.agents/skills/reword-recent-commits/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reword Recent Commits"
+  short_description: "Reword recent commit ranges with replay safety"
+  default_prompt: "Use $reword-recent-commits to rewrite a recent commit range when replay-style safety or packet evidence is needed."

--- a/.agents/skills/reword-recent-commits/agents/openai.yaml
+++ b/.agents/skills/reword-recent-commits/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reword Recent Commits"
+  short_description: "Reword recent commits to repo conventions"
+  default_prompt: "Use $reword-recent-commits to rewrite the last 3 commit messages to the repo rules."

--- a/.agents/skills/weekly-update
+++ b/.agents/skills/weekly-update
@@ -1,0 +1,1 @@
+../../.codex/vendor/packetflow_foundry/.agents/skills/weekly-update

--- a/.agents/skills/weekly-update
+++ b/.agents/skills/weekly-update
@@ -1,1 +1,0 @@
-../../.codex/vendor/packetflow_foundry/.agents/skills/weekly-update

--- a/.agents/skills/weekly-update/SKILL.md
+++ b/.agents/skills/weekly-update/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: weekly-update
+description: Top-level orchestration skill for reusable weekly updates. Synthesize recent PRs, rollouts, incidents, reviews, and blockers using packet-driven evidence collection and narrow read-only delegation, keep worker outputs proposal-grade, keep final classification and wording local, and update only a last-success marker after a reviewed plan clears apply gates.
+---
+
+# Weekly Update
+
+Thin entrypoint for the foundry retained `weekly-update` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/weekly-update/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/weekly-update/SKILL.md`.
+
+When working on this skill:
+- treat `../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/weekly-update/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/weekly-update/SKILL.md
+++ b/.agents/skills/weekly-update/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: weekly-update
+description: Top-level orchestration skill for reusable weekly updates. Synthesize recent PRs, rollouts, incidents, reviews, and blockers using packet-driven evidence collection and narrow read-only delegation, keep worker outputs proposal-grade, keep final classification and wording local, and update only a last-success marker after a reviewed plan clears apply gates.
+---
+
+# Weekly Update
+
+Thin entrypoint for the foundry retained `weekly-update` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `../../../builders/packet-workflow/retained-skills/weekly-update/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `../../../builders/packet-workflow/retained-skills/weekly-update/SKILL.md`.
+
+When working on this skill:
+- treat `../../../builders/packet-workflow/retained-skills/weekly-update/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/.agents/skills/weekly-update/agents/openai.yaml
+++ b/.agents/skills/weekly-update/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Weekly Update"
+  short_description: "Top-level packet-driven weekly update orchestrator with profile-aware repo conventions"
+  default_prompt: >-
+    Use $weekly-update to collect context, build packets, optionally delegate
+    narrow read-only packet analysis, keep final adjudication and wording
+    local, state the exact reporting window, and apply only after local plan
+    validation.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,14 @@
+# .codex AGENTS
+
+<!-- packetflow_foundry consumer bootstrap:start -->
+## PacketFlow Foundry
+- Vendor: `.codex/vendor/packetflow_foundry`
+- Project-local overlays: `.codex/project/profiles/`, `.agents/skills/`, `.codex/agents/`
+- `.codex/agents/` is the project-scoped subagent discovery surface. Vendored foundry agent TOMLs are bridged there from `.codex/vendor/packetflow_foundry/.codex/agents/`.
+- `.agents/skills/` is a thin discovery-wrapper surface. Reusable retained kernels stay under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`.
+- Do not edit `.codex/vendor/packetflow_foundry` for local needs.
+- `.codex/project/profiles/default/profile.json` is a project-local scaffold.
+- Skill-specific packet-workflow overrides may live at `.codex/project/profiles/<skill-name>/profile.json`.
+- Legacy `.codex/project/agents/` is migration-only and should move to `.codex/agents/`.
+- Legacy `.codex/project/skills/` is migration-only and should move to `.agents/skills/`.
+<!-- packetflow_foundry consumer bootstrap:end -->

--- a/.codex/agents/docs-verifier.toml
+++ b/.codex/agents/docs-verifier.toml
@@ -1,0 +1,1 @@
+../vendor/packetflow_foundry/.codex/agents/docs-verifier.toml

--- a/.codex/agents/docs-verifier.toml
+++ b/.codex/agents/docs-verifier.toml
@@ -1,0 +1,19 @@
+name = "docs_verifier"
+description = "Read-only documentation checker and claim verifier for APIs, framework behavior, local maintainer docs, and version-sensitive assumptions."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Notary", "Citation", "Canon"]
+developer_instructions = """
+Verify behavior against primary sources first.
+Prefer official documentation, local maintainer docs, and exact code references over memory.
+Return verification findings using:
+- verified claims
+- inferred claims
+- unknowns or claim gaps
+- exact refs
+If asked to attach verification findings to a local candidate, keep the attachment narrow and include refs, confidence, and explicit verification_status for each attached claim.
+Use this agent as a narrow verifier, not a broad summarizer.
+If asked to support a local candidate, attach verification findings only and keep final classification local.
+Do not edit files.
+"""

--- a/.codex/agents/docs-verifier.toml
+++ b/.codex/agents/docs-verifier.toml
@@ -1,1 +1,19 @@
-../vendor/packetflow_foundry/.codex/agents/docs-verifier.toml
+name = "docs_verifier"
+description = "Read-only documentation checker and claim verifier for APIs, framework behavior, local maintainer docs, and version-sensitive assumptions."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Notary", "Citation", "Canon"]
+developer_instructions = """
+Verify behavior against primary sources first.
+Prefer official documentation, local maintainer docs, and exact code references over memory.
+Return verification findings using:
+- verified claims
+- inferred claims
+- unknowns or claim gaps
+- exact refs
+If asked to attach verification findings to a local candidate, keep the attachment narrow and include refs, confidence, and explicit verification_status for each attached claim.
+Use this agent as a narrow verifier, not a broad summarizer.
+If asked to support a local candidate, attach verification findings only and keep final classification local.
+Do not edit files.
+"""

--- a/.codex/agents/evidence-summarizer.toml
+++ b/.codex/agents/evidence-summarizer.toml
@@ -1,1 +1,14 @@
-../vendor/packetflow_foundry/.codex/agents/evidence-summarizer.toml
+name = "evidence_summarizer"
+description = "Read-only decision-ready evidence condenser for long diagnostics, investigation notes, perf reports, and supporting documents."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
+sandbox_mode = "read-only"
+nickname_candidates = ["Distill", "Digest", "Synopsis"]
+developer_instructions = """
+Condense long evidence into decision-ready findings.
+Extract stable facts, supporting references, contradictions, unresolved questions, ambiguity, confidence, and reread_control signals.
+When the caller asks for classification-oriented packet output, return proposal-grade candidate records using generic slots such as fact_summary, proposal_classification, classification_rationale, supporting_references, ambiguity, confidence, and reread_control, plus footer fields when hierarchical output is requested.
+Prefer short supporting refs or excerpt anchors over long raw excerpts.
+Lower confidence or set reread_control instead of widening scope on your own.
+Do not edit files.
+"""

--- a/.codex/agents/evidence-summarizer.toml
+++ b/.codex/agents/evidence-summarizer.toml
@@ -1,0 +1,14 @@
+name = "evidence_summarizer"
+description = "Read-only decision-ready evidence condenser for long diagnostics, investigation notes, perf reports, and supporting documents."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
+sandbox_mode = "read-only"
+nickname_candidates = ["Distill", "Digest", "Synopsis"]
+developer_instructions = """
+Condense long evidence into decision-ready findings.
+Extract stable facts, supporting references, contradictions, unresolved questions, ambiguity, confidence, and reread_control signals.
+When the caller asks for classification-oriented packet output, return proposal-grade candidate records using generic slots such as fact_summary, proposal_classification, classification_rationale, supporting_references, ambiguity, confidence, and reread_control, plus footer fields when hierarchical output is requested.
+Prefer short supporting refs or excerpt anchors over long raw excerpts.
+Lower confidence or set reread_control instead of widening scope on your own.
+Do not edit files.
+"""

--- a/.codex/agents/evidence-summarizer.toml
+++ b/.codex/agents/evidence-summarizer.toml
@@ -1,0 +1,1 @@
+../vendor/packetflow_foundry/.codex/agents/evidence-summarizer.toml

--- a/.codex/agents/large-diff-auditor.toml
+++ b/.codex/agents/large-diff-auditor.toml
@@ -1,1 +1,15 @@
-../vendor/packetflow_foundry/.codex/agents/large-diff-auditor.toml
+name = "large_diff_auditor"
+description = "Read-only reviewer for large diffs and long files that extracts high-risk hotspots as candidate-ready findings."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Sentinel", "Tripwire", "Scanline"]
+developer_instructions = """
+Review large diffs or long files for real risk.
+Prioritize correctness, regressions, edge cases, invariants, and missing tests.
+Surface only the highest-signal hotspots with exact file references.
+When the caller asks for classification-oriented packet output, return proposal-grade candidate records using generic slots such as fact_summary, proposal_classification, classification_rationale, supporting_references, ambiguity, confidence, and reread_control, plus footer fields when hierarchical output is requested.
+Keep final adjudication local by treating every classification as proposal-only.
+Do not spend time on style-only comments unless they hide a real bug.
+Do not edit files.
+"""

--- a/.codex/agents/large-diff-auditor.toml
+++ b/.codex/agents/large-diff-auditor.toml
@@ -1,0 +1,15 @@
+name = "large_diff_auditor"
+description = "Read-only reviewer for large diffs and long files that extracts high-risk hotspots as candidate-ready findings."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Sentinel", "Tripwire", "Scanline"]
+developer_instructions = """
+Review large diffs or long files for real risk.
+Prioritize correctness, regressions, edge cases, invariants, and missing tests.
+Surface only the highest-signal hotspots with exact file references.
+When the caller asks for classification-oriented packet output, return proposal-grade candidate records using generic slots such as fact_summary, proposal_classification, classification_rationale, supporting_references, ambiguity, confidence, and reread_control, plus footer fields when hierarchical output is requested.
+Keep final adjudication local by treating every classification as proposal-only.
+Do not spend time on style-only comments unless they hide a real bug.
+Do not edit files.
+"""

--- a/.codex/agents/large-diff-auditor.toml
+++ b/.codex/agents/large-diff-auditor.toml
@@ -1,0 +1,1 @@
+../vendor/packetflow_foundry/.codex/agents/large-diff-auditor.toml

--- a/.codex/agents/log-triager.toml
+++ b/.codex/agents/log-triager.toml
@@ -1,1 +1,15 @@
-../vendor/packetflow_foundry/.codex/agents/log-triager.toml
+name = "log_triager"
+description = "Read-only triage agent for test failures, runtime logs, stack traces, and CI output that returns candidate-ready failure analysis."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Traceback", "Faultline", "Stackframe"]
+developer_instructions = """
+Treat logs and test output as evidence, not noise.
+Group failures into candidate-ready runtime or CI triage findings and identify the earliest useful signal.
+Highlight the most likely root cause, competing hypotheses, and the next one or two checks that would reduce uncertainty.
+Prefer concrete error lines, timestamps, and stack frames over generic advice.
+When the caller asks for classification-oriented packet output, return proposal-grade candidate records using generic slots such as fact_summary, proposal_classification, classification_rationale, supporting_references, ambiguity, confidence, and reread_control, plus footer fields when hierarchical output is requested.
+Keep final adjudication local by treating every classification as proposal-only.
+Do not edit files.
+"""

--- a/.codex/agents/log-triager.toml
+++ b/.codex/agents/log-triager.toml
@@ -1,0 +1,15 @@
+name = "log_triager"
+description = "Read-only triage agent for test failures, runtime logs, stack traces, and CI output that returns candidate-ready failure analysis."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Traceback", "Faultline", "Stackframe"]
+developer_instructions = """
+Treat logs and test output as evidence, not noise.
+Group failures into candidate-ready runtime or CI triage findings and identify the earliest useful signal.
+Highlight the most likely root cause, competing hypotheses, and the next one or two checks that would reduce uncertainty.
+Prefer concrete error lines, timestamps, and stack frames over generic advice.
+When the caller asks for classification-oriented packet output, return proposal-grade candidate records using generic slots such as fact_summary, proposal_classification, classification_rationale, supporting_references, ambiguity, confidence, and reread_control, plus footer fields when hierarchical output is requested.
+Keep final adjudication local by treating every classification as proposal-only.
+Do not edit files.
+"""

--- a/.codex/agents/log-triager.toml
+++ b/.codex/agents/log-triager.toml
@@ -1,0 +1,1 @@
+../vendor/packetflow_foundry/.codex/agents/log-triager.toml

--- a/.codex/agents/packet-explorer.toml
+++ b/.codex/agents/packet-explorer.toml
@@ -1,0 +1,1 @@
+../vendor/packetflow_foundry/.codex/agents/packet-explorer.toml

--- a/.codex/agents/packet-explorer.toml
+++ b/.codex/agents/packet-explorer.toml
@@ -1,0 +1,20 @@
+name = "packet_explorer"
+description = "Read-only packet-scoped analyzer that inspects one focused packet plus only the explicitly referenced file slices needed to ground code or behavior findings."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Prism", "Probe", "Slice"]
+developer_instructions = """
+Stay in packet-scoped analysis mode.
+Read global_packet.json first, then exactly one focused packet or one batch packet.
+Open extra file slices only when the packet cannot carry enough evidence on its own.
+Return packet-friendly findings only:
+- primary outcome
+- touched surfaces
+- evidence files or exact refs
+- risks or unknowns
+- narrow next-step hints
+Do not draft final wording, final adjudication, or mutations.
+Do not widen the scope to the whole repo or full diff unless the caller explicitly requests an exception path.
+Do not edit files.
+"""

--- a/.codex/agents/packet-explorer.toml
+++ b/.codex/agents/packet-explorer.toml
@@ -1,1 +1,20 @@
-../vendor/packetflow_foundry/.codex/agents/packet-explorer.toml
+name = "packet_explorer"
+description = "Read-only packet-scoped analyzer that inspects one focused packet plus only the explicitly referenced file slices needed to ground code or behavior findings."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Prism", "Probe", "Slice"]
+developer_instructions = """
+Stay in packet-scoped analysis mode.
+Read global_packet.json first, then exactly one focused packet or one batch packet.
+Open extra file slices only when the packet cannot carry enough evidence on its own.
+Return packet-friendly findings only:
+- primary outcome
+- touched surfaces
+- evidence files or exact refs
+- risks or unknowns
+- narrow next-step hints
+Do not draft final wording, final adjudication, or mutations.
+Do not widen the scope to the whole repo or full diff unless the caller explicitly requests an exception path.
+Do not edit files.
+"""

--- a/.codex/agents/repo-mapper.toml
+++ b/.codex/agents/repo-mapper.toml
@@ -1,0 +1,21 @@
+name = "repo_mapper"
+description = "Read-only explorer that maps execution paths, touched surfaces, and packet-relevant findings before implementation or adjudication."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Atlas", "Surveyor", "Waypoint"]
+developer_instructions = """
+Stay in exploration mode.
+Trace the real execution path before suggesting changes.
+Return packet-friendly findings only:
+- execution path
+- touched surfaces
+- packet membership or evidence-map hints
+- assumptions
+- unknowns
+- exact refs
+Do not emit proposal classifications unless the caller explicitly asks for a narrow classification step.
+Prefer fast search and targeted reads over broad scans.
+Do not edit files.
+Do not invent architecture that is not present in the code.
+"""

--- a/.codex/agents/repo-mapper.toml
+++ b/.codex/agents/repo-mapper.toml
@@ -1,1 +1,21 @@
-../vendor/packetflow_foundry/.codex/agents/repo-mapper.toml
+name = "repo_mapper"
+description = "Read-only explorer that maps execution paths, touched surfaces, and packet-relevant findings before implementation or adjudication."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+nickname_candidates = ["Atlas", "Surveyor", "Waypoint"]
+developer_instructions = """
+Stay in exploration mode.
+Trace the real execution path before suggesting changes.
+Return packet-friendly findings only:
+- execution path
+- touched surfaces
+- packet membership or evidence-map hints
+- assumptions
+- unknowns
+- exact refs
+Do not emit proposal classifications unless the caller explicitly asks for a narrow classification step.
+Prefer fast search and targeted reads over broad scans.
+Do not edit files.
+Do not invent architecture that is not present in the code.
+"""

--- a/.codex/agents/repo-mapper.toml
+++ b/.codex/agents/repo-mapper.toml
@@ -1,0 +1,1 @@
+../vendor/packetflow_foundry/.codex/agents/repo-mapper.toml

--- a/.codex/project/bootstrap/bridge-state.json
+++ b/.codex/project/bootstrap/bridge-state.json
@@ -1,0 +1,158 @@
+{
+  "kind": "packetflow-foundry-bootstrap-bridge-state",
+  "version": 1,
+  "agents": {
+    "docs-verifier.toml": {
+      "type": "file-copy",
+      "source": ".codex/vendor/packetflow_foundry/.codex/agents/docs-verifier.toml",
+      "sha256": "4fea3678ffe407c5dccd63335272f54792ae6bf4039547bc67e5cdde2cdbc199"
+    },
+    "evidence-summarizer.toml": {
+      "type": "file-copy",
+      "source": ".codex/vendor/packetflow_foundry/.codex/agents/evidence-summarizer.toml",
+      "sha256": "f2be048c5d96f179a54e14d07dacd1fa52c022c246702e6e4a26fa49bc4d2126"
+    },
+    "large-diff-auditor.toml": {
+      "type": "file-copy",
+      "source": ".codex/vendor/packetflow_foundry/.codex/agents/large-diff-auditor.toml",
+      "sha256": "06cf5327dbf180e8c5e20114e83a825079a6455ced8b4045ad6d14b5b9046422"
+    },
+    "log-triager.toml": {
+      "type": "file-copy",
+      "source": ".codex/vendor/packetflow_foundry/.codex/agents/log-triager.toml",
+      "sha256": "2dba8ddfd75a81a792f1e323649e1c5b230be274dd159dbb256a1a4520e9e96a"
+    },
+    "packet-explorer.toml": {
+      "type": "file-copy",
+      "source": ".codex/vendor/packetflow_foundry/.codex/agents/packet-explorer.toml",
+      "sha256": "49a2049806a9b173f7161abeebf1b91f86cf6eef5bf8a2feb8e9f6b902538553"
+    },
+    "repo-mapper.toml": {
+      "type": "file-copy",
+      "source": ".codex/vendor/packetflow_foundry/.codex/agents/repo-mapper.toml",
+      "sha256": "d14bf73f7db3859f3a9ba30768d29ef1fd90da83dfbb162048c00bf2e761879e"
+    }
+  },
+  "skills": {
+    "draft-release-copy": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/draft-release-copy",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "84eb802f94d3af1c9f7c25ba02011ae6d3fa82e2ec297e66ff901bd3ff07462b"
+        },
+        "SKILL.md": {
+          "sha256": "c1dfbd453145faf5911fa0e22bfcbbea4b449f456226e045e622cb16dc0da842"
+        }
+      }
+    },
+    "gh-address-review-threads": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/gh-address-review-threads",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "2e31b5e59faba57b16fe5521e57bf775e1c7de4212f3e531c3cb5bd572a1d657"
+        },
+        "SKILL.md": {
+          "sha256": "07bb593835035c2bce8bfb7f32868aeec3ba867be6cb84334d65f52b15b9dc5b"
+        }
+      }
+    },
+    "gh-create-pr": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/gh-create-pr",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "4e7fb774a7076aa2a77fde52b17c5d851d6b687624094627899736fae6320066"
+        },
+        "SKILL.md": {
+          "sha256": "413aece9fbfd75a2dfaa8ac3b746293cb6a3128011f69e57f960a0cc1ece2e1a"
+        }
+      }
+    },
+    "gh-fix-pr-writeup": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/gh-fix-pr-writeup",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "38006ffef099ed0d8055736f3893edb72dc6f28d2020e5eeeeb6e84514886ba2"
+        },
+        "SKILL.md": {
+          "sha256": "d3fc7ea5a51180ae7bbd35c462d594ee86e6a468d043d5b236c256b3b31d2789"
+        }
+      }
+    },
+    "git-split-and-commit": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/git-split-and-commit",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "75b6a06930d6fd75200dfb85e1e665b912422cefd8c88e1e34088b2c8c8d8d3c"
+        },
+        "SKILL.md": {
+          "sha256": "ada38fa6df8fc8b19823571f55fff91b28469b04496d806eab5715c41b7c8ca4"
+        }
+      }
+    },
+    "packet-workflow-skill-builder": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/packet-workflow-skill-builder",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "82d844ebd7a3159ce3f81e6997f60ace0619f33a8001585a6f73e566d8f1c203"
+        },
+        "SKILL.md": {
+          "sha256": "a8c3e7689e837f70fd467f221447f4efa311ee55a6fd5c8f59a20633ae938921"
+        }
+      }
+    },
+    "public-docs-sync": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/public-docs-sync",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "9349d6ace9a054ddfb348365202d7cd83526b14766a3075d19715dbd26224ef1"
+        },
+        "SKILL.md": {
+          "sha256": "bc3265f625b666a3634964361656af1f7cd069cd50b21425e6a0d1c4302ff530"
+        }
+      }
+    },
+    "reword-head-commit": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/reword-head-commit",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "d64ae0b4ea77c13388f0b56d42b02fef6f530a17679a4bc168f2149cf8dd45e2"
+        },
+        "SKILL.md": {
+          "sha256": "454544c8fb8a97da1c4d906564a51579dc6f68519e256f225d570500946a47c6"
+        }
+      }
+    },
+    "reword-recent-commits": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/reword-recent-commits",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "f4041e5b9ec145ec5e3d32825c9f4ca0e471a58d6cb40dd0c3b848bd4b1391e4"
+        },
+        "SKILL.md": {
+          "sha256": "c63e6ed50a2b6d3c4c89cfc17740720385e534dcb929f2caecfd154c16b1c70d"
+        }
+      }
+    },
+    "weekly-update": {
+      "type": "directory-copy",
+      "source": ".codex/vendor/packetflow_foundry/.agents/skills/weekly-update",
+      "files": {
+        "agents/openai.yaml": {
+          "sha256": "654721a49b6ac528e80808b3d4eaac4795f21137378ae2fa233b6f48f0119a77"
+        },
+        "SKILL.md": {
+          "sha256": "a929ef19430a723fb9fedc8920b62f9b9db531e532af5951a6763897bbf97705"
+        }
+      }
+    }
+  }
+}

--- a/.codex/project/profiles/default/profile.json
+++ b/.codex/project/profiles/default/profile.json
@@ -1,0 +1,33 @@
+{
+  "name": "default",
+  "kind": "project-local-scaffold-profile",
+  "profile_path": ".codex/project/profiles/default/profile.json",
+  "summary": "Project-local scaffold profile for this consumer repository. This is not a reusable foundry overlay; replace the placeholder values here with repo-specific bindings, review docs, and local notes.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": null,
+    "publish_config_path": null
+  },
+  "packet_defaults": {
+    "review_docs": {},
+    "source_path_globs": {}
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "notes": [
+    "This file is a project-local scaffold profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, globs, review docs, booleans, and notes here.",
+    "Skill-specific packet-workflow bindings should live in `.codex/project/profiles/<skill-name>/profile.json` instead of this default scaffold.",
+    "Do not add executable hooks, prompt fragments, or packet routing authority here."
+  ]
+}

--- a/.codex/project/profiles/default/profile.json
+++ b/.codex/project/profiles/default/profile.json
@@ -1,0 +1,40 @@
+{
+  "kind": "project-local-profile",
+  "name": "default",
+  "profile_path": ".codex/project/profiles/default/profile.json",
+  "summary": "Project-local default scaffold for packetflow_foundry. Keep repo-wide notes here and put skill-specific bindings in skill-named profiles.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": null,
+    "publish_config_path": null
+  },
+  "packet_defaults": {
+    "review_docs": {},
+    "source_path_globs": {}
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "notes": [
+    "This file is a project-local scaffold profile for one repository.",
+    "It is not a reusable foundry overlay and should stay outside reusable skill defaults.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, booleans, and notes here.",
+    "Skill-specific packet-workflow bindings should live in `.codex/project/profiles/<skill-name>/profile.json` instead of this default scaffold."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/draft-release-copy/profile.json
+++ b/.codex/project/profiles/draft-release-copy/profile.json
@@ -1,0 +1,126 @@
+{
+  "kind": "project-local-profile",
+  "name": "draft-release-copy",
+  "profile_path": ".codex/project/profiles/draft-release-copy/profile.json",
+  "summary": "Project-local draft-release-copy profile for NoOfficeDemandFix release review and checklist generation.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "changes_packet": [
+        "README.md",
+        "MAINTAINING.md",
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        ".github/workflows/release.yml"
+      ],
+      "checklist_packet": [
+        ".github/ISSUE_TEMPLATE/release_checklist.yml",
+        ".github/workflows/release.yml",
+        "MAINTAINING.md",
+        ".github/pull_request_template.md"
+      ],
+      "evidence_packet": [
+        "README.md",
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        ".github/software-evidence-schema.md",
+        ".github/software-investigation-workflow.md"
+      ],
+      "publish_packet": [
+        "NoOfficeDemandFix/Properties/PublishConfiguration.xml",
+        "scripts/release.ps1",
+        ".github/workflows/release.yml"
+      ],
+      "readme_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/ISSUE_TEMPLATE/release_checklist.yml"
+      ]
+    },
+    "source_path_globs": {
+      "changes_packet": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/workflows/release.yml",
+        "*.md"
+      ],
+      "checklist_packet": [
+        ".github/ISSUE_TEMPLATE/*.yml",
+        ".github/workflows/release.yml",
+        "*.md"
+      ],
+      "evidence_packet": [
+        ".github/**",
+        "*.md",
+        "NoOfficeDemandFix/**",
+        "scripts/**"
+      ],
+      "publish_packet": [
+        "NoOfficeDemandFix/Properties/**",
+        "scripts/release.ps1",
+        ".github/workflows/release.yml"
+      ],
+      "readme_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/ISSUE_TEMPLATE/*.yml"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "extra": {
+    "release_copy": {
+      "allowed_publish_fields": [
+        "short_description",
+        "long_description",
+        "mod_version",
+        "change_log"
+      ],
+      "allowed_readme_sections": [
+        "Current Release",
+        "Current Status"
+      ],
+      "issue_defaults": {
+        "label_names": [
+          "release"
+        ],
+        "project_mode": "none",
+        "title_prefix": "[Release]"
+      },
+      "maintaining_path": "MAINTAINING.md",
+      "release_checklist_template_path": ".github/ISSUE_TEMPLATE/release_checklist.yml",
+      "release_workflow_path": ".github/workflows/release.yml"
+    }
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use the release workflow, checklist template, and publish configuration paths in this repository as the canonical release inputs.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/draft-release-copy/profile.json
+++ b/.codex/project/profiles/draft-release-copy/profile.json
@@ -1,0 +1,149 @@
+{
+  "kind": "project-local-profile",
+  "name": "draft-release-copy",
+  "profile_path": ".codex/project/profiles/draft-release-copy/profile.json",
+  "summary": "Project-local draft-release-copy profile for packetflow_foundry release review and checklist generation.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": ".codex/project/release/ReleaseSettings.cs",
+    "publish_config_path": ".codex/project/release/ReleaseConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "changes_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        "builders/packet-workflow/version.json"
+      ],
+      "checklist_packet": [
+        ".github/ISSUE_TEMPLATE/release_checklist.yml",
+        ".github/workflows/release.yml",
+        "MAINTAINING.md",
+        ".codex/project/profiles/draft-release-copy/profile.json"
+      ],
+      "evidence_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/workflows/release.yml"
+      ],
+      "publish_packet": [
+        ".codex/project/release/ReleaseConfiguration.xml",
+        "builders/packet-workflow/version.json",
+        ".github/workflows/release.yml"
+      ],
+      "readme_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        ".github/ISSUE_TEMPLATE/release_checklist.yml",
+        ".codex/project/profiles/draft-release-copy/profile.json"
+      ]
+    },
+    "source_path_globs": {
+      "changes_packet": [
+        ".agents/skills/**",
+        "builders/**",
+        "core/**",
+        "docs/**",
+        ".github/**"
+      ],
+      "checklist_packet": [
+        ".github/ISSUE_TEMPLATE/*.yml",
+        ".github/workflows/*.yml",
+        ".codex/project/**"
+      ],
+      "evidence_packet": [
+        ".github/**",
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        "builders/**"
+      ],
+      "publish_packet": [
+        ".codex/project/release/**",
+        "builders/packet-workflow/version.json"
+      ],
+      "readme_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/ISSUE_TEMPLATE/*.yml"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "extra": {
+    "release_copy": {
+      "allowed_publish_fields": [
+        "short_description",
+        "long_description",
+        "mod_version",
+        "change_log"
+      ],
+      "allowed_readme_sections": [
+        "Current Release",
+        "Current Status"
+      ],
+      "issue_defaults": {
+        "label_names": [
+          "release"
+        ],
+        "project_mode": "none",
+        "title_prefix": "[Release]"
+      },
+      "maintaining_path": "MAINTAINING.md",
+      "release_checklist_template_path": ".github/ISSUE_TEMPLATE/release_checklist.yml",
+      "release_workflow_path": ".github/workflows/release.yml",
+      "release_goal": "Keep release scope anchored on packet-first orchestration that uses 5.4-mini subagents to reduce token usage.",
+      "classification_labels": [
+        "direct savings",
+        "measurement-enabling",
+        "structural-only"
+      ],
+      "measurement_metrics": [
+        "estimated_packet_tokens",
+        "estimated_delegation_savings",
+        "raw_reread_count",
+        "common_path_sufficient"
+      ],
+      "direct_savings_examples": [
+        "packet compaction",
+        "raw reread reduction",
+        "delegation scope reduction",
+        "local scripted preprocessing"
+      ],
+      "rules": {
+        "require_release_item_classification": true,
+        "require_structural_only_justification": true,
+        "require_measurement_metrics": true,
+        "require_direct_savings_path": true,
+        "retained_skill_direct_savings_requires_efficiency_path_or_metric_target": true
+      }
+    }
+  },
+  "notes": [
+    "This file is a project-local skill profile for one repository.",
+    "It is not a reusable foundry overlay and should stay outside reusable skill defaults.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, booleans, and notes here.",
+    "Packetflow Foundry release review should block drift away from the packet-efficiency goal by classifying release items as direct savings, measurement-enabling, or structural-only."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/gh-address-review-threads/profile.json
+++ b/.codex/project/profiles/gh-address-review-threads/profile.json
@@ -1,0 +1,67 @@
+{
+  "kind": "project-local-profile",
+  "name": "gh-address-review-threads",
+  "profile_path": ".codex/project/profiles/gh-address-review-threads/profile.json",
+  "summary": "Project-local gh-address-review-threads profile for NoOfficeDemandFix PR review follow-up and thread guidance.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "batch-packet-01": [
+        ".github/instructions/pull-request.instructions.md",
+        ".github/pull_request_template.md",
+        ".github/copilot-instructions.md",
+        "CONTRIBUTING.md"
+      ],
+      "thread": [
+        ".github/instructions/pull-request.instructions.md",
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ]
+    },
+    "source_path_globs": {
+      "batch-packet-01": [
+        ".github/**",
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        "*.md"
+      ],
+      "thread": [
+        ".github/**",
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        "*.md"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use the repository PR instructions and template as the canonical sources for thread replies and reviewer-facing phrasing.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/gh-create-pr/profile.json
+++ b/.codex/project/profiles/gh-create-pr/profile.json
@@ -1,0 +1,86 @@
+{
+  "kind": "project-local-profile",
+  "name": "gh-create-pr",
+  "profile_path": ".codex/project/profiles/gh-create-pr/profile.json",
+  "summary": "Project-local gh-create-pr profile for NoOfficeDemandFix PR drafting and repo-specific PR guidance.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "process": [
+        ".github/instructions/pull-request.instructions.md",
+        ".github/pull_request_template.md",
+        ".github/copilot-instructions.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "rules": [
+        ".github/instructions/pull-request.instructions.md",
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "runtime": [
+        "README.md",
+        ".codex/AGENTS.md",
+        "MAINTAINING.md"
+      ],
+      "testing": [
+        ".github/instructions/pull-request.instructions.md",
+        "CONTRIBUTING.md",
+        "README.md"
+      ]
+    },
+    "source_path_globs": {
+      "process": [
+        ".github/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ],
+      "rules": [
+        ".github/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ],
+      "runtime": [
+        "NoOfficeDemandFix/**",
+        "scripts/**"
+      ],
+      "testing": [
+        ".github/scripts/**",
+        ".github/workflows/**",
+        "NoOfficeDemandFix/**"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "extra": {},
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use the repository PR instructions and template as the canonical sources for generated PR titles and descriptions.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/gh-fix-pr-writeup/profile.json
+++ b/.codex/project/profiles/gh-fix-pr-writeup/profile.json
@@ -1,0 +1,85 @@
+{
+  "kind": "project-local-profile",
+  "name": "gh-fix-pr-writeup",
+  "profile_path": ".codex/project/profiles/gh-fix-pr-writeup/profile.json",
+  "summary": "Project-local gh-fix-pr-writeup profile for NoOfficeDemandFix PR title and body repair workflows.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "process": [
+        ".github/instructions/pull-request.instructions.md",
+        ".github/pull_request_template.md",
+        ".github/copilot-instructions.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "rules": [
+        ".github/instructions/pull-request.instructions.md",
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "runtime": [
+        "README.md",
+        ".codex/AGENTS.md",
+        "MAINTAINING.md"
+      ],
+      "testing": [
+        ".github/instructions/pull-request.instructions.md",
+        "CONTRIBUTING.md",
+        "README.md"
+      ]
+    },
+    "source_path_globs": {
+      "process": [
+        ".github/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ],
+      "rules": [
+        ".github/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ],
+      "runtime": [
+        "NoOfficeDemandFix/**",
+        "scripts/**"
+      ],
+      "testing": [
+        ".github/scripts/**",
+        ".github/workflows/**",
+        "NoOfficeDemandFix/**"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use the repository PR instructions and template as the canonical sources when repairing PR titles or descriptions.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/git-split-and-commit/profile.json
+++ b/.codex/project/profiles/git-split-and-commit/profile.json
@@ -1,0 +1,88 @@
+{
+  "kind": "project-local-profile",
+  "name": "git-split-and-commit",
+  "profile_path": ".codex/project/profiles/git-split-and-commit/profile.json",
+  "summary": "Project-local git-split-and-commit profile for NoOfficeDemandFix commit planning and repo-specific review guidance.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": null,
+    "publish_config_path": null
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "rules": [
+        ".github/instructions/commit-message.instructions.md",
+        ".github/copilot-instructions.md",
+        "CONTRIBUTING.md",
+        "README.md"
+      ],
+      "worktree": [
+        "README.md",
+        ".codex/AGENTS.md"
+      ],
+      "candidate-batch": [
+        ".github/instructions/commit-message.instructions.md",
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "split-file": [
+        ".github/instructions/commit-message.instructions.md",
+        ".codex/AGENTS.md",
+        "README.md",
+        "CONTRIBUTING.md"
+      ]
+    },
+    "source_path_globs": {
+      "rules": [
+        ".github/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ],
+      "worktree": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/**",
+        "*.md"
+      ],
+      "candidate-batch": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/**",
+        "*.md"
+      ],
+      "split-file": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/**",
+        "*.md"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use `.github/instructions/commit-message.instructions.md` as the canonical source for generated commit messages in this repository.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/public-docs-sync/profile.json
+++ b/.codex/project/profiles/public-docs-sync/profile.json
@@ -1,0 +1,128 @@
+{
+  "kind": "project-local-profile",
+  "name": "public-docs-sync",
+  "profile_path": ".codex/project/profiles/public-docs-sync/profile.json",
+  "summary": "Project-local public-docs-sync profile for NoOfficeDemandFix public documentation drift auditing.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "claims_packet": [
+        "README.md",
+        ".github/software-evidence-schema.md",
+        ".github/software-investigation-workflow.md"
+      ],
+      "forms_batch_packet": [
+        ".github/ISSUE_TEMPLATE/bug_report.yml",
+        ".github/ISSUE_TEMPLATE/feature_request.yml",
+        ".github/ISSUE_TEMPLATE/investigation.yml",
+        ".github/ISSUE_TEMPLATE/release_checklist.yml",
+        ".github/ISSUE_TEMPLATE/performance_telemetry_report.yml",
+        ".github/ISSUE_TEMPLATE/raw_log_report.yml",
+        ".github/ISSUE_TEMPLATE/software_evidence.yml",
+        ".github/ISSUE_TEMPLATE/software_investigation.yml"
+      ],
+      "reporting_packet": [
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        ".github/software-evidence-schema.md",
+        ".github/software-investigation-workflow.md"
+      ],
+      "workflow_packet": [
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/pull_request_template.md",
+        ".github/workflows/release.yml"
+      ]
+    },
+    "source_path_globs": {
+      "claims_packet": [
+        "README.md",
+        "NoOfficeDemandFix/Properties/PublishConfiguration.xml",
+        "NoOfficeDemandFix/Setting.cs"
+      ],
+      "forms_batch_packet": [
+        ".github/ISSUE_TEMPLATE/*.yml"
+      ],
+      "reporting_packet": [
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        ".github/software-*.md"
+      ],
+      "workflow_packet": [
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/pull_request_template.md",
+        ".github/workflows/*.yml"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": true,
+    "missing_review_docs_are_errors": false
+  },
+  "extra": {
+    "public_docs_sync": {
+      "audited_public_doc_inventory": [
+        "README.md",
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md",
+        ".github/pull_request_template.md",
+        ".github/software-evidence-schema.md",
+        ".github/software-investigation-workflow.md",
+        ".github/workflows/release.yml"
+      ],
+      "issue_template_groups": {
+        "reporting": [
+          "performance_telemetry_report.yml",
+          "raw_log_report.yml",
+          "software_evidence.yml",
+          "software_investigation.yml"
+        ],
+        "workflow": [
+          "bug_report.yml",
+          "feature_request.yml",
+          "investigation.yml",
+          "release_checklist.yml"
+        ]
+      },
+      "public_workflow_doc_paths": [
+        ".github/pull_request_template.md",
+        ".github/software-evidence-schema.md",
+        ".github/software-investigation-workflow.md",
+        ".github/workflows/release.yml"
+      ],
+      "state": {
+        "marker_path": ".codex/state/public-docs-sync-last-success.json",
+        "namespace": "public-docs-sync"
+      }
+    }
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use the public docs inventory and issue-template grouping in this repository as the canonical public-doc auditing surface.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/reword-recent-commits/profile.json
+++ b/.codex/project/profiles/reword-recent-commits/profile.json
@@ -1,0 +1,66 @@
+{
+  "kind": "project-local-profile",
+  "name": "reword-recent-commits",
+  "profile_path": ".codex/project/profiles/reword-recent-commits/profile.json",
+  "summary": "Project-local reword-recent-commits profile for NoOfficeDemandFix commit-message guidance and repo-specific path hints.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "commit": [
+        ".github/instructions/commit-message.instructions.md",
+        ".github/copilot-instructions.md",
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "rules": [
+        ".github/instructions/commit-message.instructions.md",
+        ".github/copilot-instructions.md",
+        "CONTRIBUTING.md",
+        "README.md"
+      ]
+    },
+    "source_path_globs": {
+      "commit": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/**",
+        "*.md"
+      ],
+      "rules": [
+        ".github/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use `.github/instructions/commit-message.instructions.md` as the canonical source for commit-message generation and rewrites in this repository.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/profiles/weekly-update/profile.json
+++ b/.codex/project/profiles/weekly-update/profile.json
@@ -1,0 +1,107 @@
+{
+  "kind": "project-local-profile",
+  "name": "weekly-update",
+  "profile_path": ".codex/project/profiles/weekly-update/profile.json",
+  "summary": "Project-local weekly-update profile for NoOfficeDemandFix weekly change summaries, incidents, and risk tracking.",
+  "repo_match": {
+    "root_markers": [
+      ".git",
+      "README.md"
+    ],
+    "remote_patterns": []
+  },
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "settings_source_path": "NoOfficeDemandFix/Setting.cs",
+    "publish_config_path": "NoOfficeDemandFix/Properties/PublishConfiguration.xml"
+  },
+  "packet_defaults": {
+    "review_docs": {
+      "changes_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "incidents_packet": [
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        ".github/software-investigation-workflow.md"
+      ],
+      "mapping_packet": [
+        "README.md",
+        "CONTRIBUTING.md",
+        ".codex/AGENTS.md"
+      ],
+      "risks_packet": [
+        "README.md",
+        "MAINTAINING.md",
+        ".github/workflows/release.yml"
+      ]
+    },
+    "source_path_globs": {
+      "changes_packet": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/**",
+        "*.md"
+      ],
+      "incidents_packet": [
+        "LOG_REPORTING.md",
+        "PERF_REPORTING.md",
+        ".github/**",
+        "scripts/**"
+      ],
+      "mapping_packet": [
+        "NoOfficeDemandFix/**",
+        ".codex/AGENTS.md",
+        "*.md"
+      ],
+      "risks_packet": [
+        "NoOfficeDemandFix/**",
+        "scripts/**",
+        ".github/**",
+        "*.md"
+      ]
+    }
+  },
+  "lint_rules": {
+    "require_readme_settings_table": false,
+    "missing_review_docs_are_errors": false
+  },
+  "extra": {
+    "weekly_update": {
+      "priority_markers": {
+        "regex": "\\[(?:P[0-3]|medium|high|low)\\]"
+      },
+      "release_issue": {
+        "title_regex": "^\\[Release\\]\\s*(?P<tag>v[0-9A-Za-z._-]+)$"
+      },
+      "review_markers": {
+        "acknowledged": [
+          "phase=ack"
+        ],
+        "resolved": [
+          "phase=complete"
+        ]
+      },
+      "state": {
+        "namespace": "weekly-update"
+      }
+    }
+  },
+  "notes": [
+    "This file is a project-local skill profile for one consumer repository.",
+    "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+    "Keep this profile data-only: add repo-specific bindings, review docs, globs, booleans, and notes here.",
+    "Use the repository reporting docs, release workflow, and project conventions as the weekly-update evidence surface.",
+    "Do not add executable hooks, prompt fragments, packet routing authority, or validator/apply behavior here."
+  ],
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/.codex/project/release/ReleaseConfiguration.xml
+++ b/.codex/project/release/ReleaseConfiguration.xml
@@ -1,0 +1,16 @@
+<Configuration>
+  <ModId Value="packetflow_foundry" />
+  <DisplayName Value="PacketFlow Foundry" />
+  <ShortDescription Value="Vendorable packet-first workflow core for token-efficient Codex orchestration." />
+  <LongDescription>
+    PacketFlow Foundry ships reusable packet-workflow contracts, templates, builders, and retained skills.
+    This repo-local release adapter exists so the draft-release-copy workflow can bind PacketFlow Foundry
+    release metadata without changing reusable core skill semantics.
+  </LongDescription>
+  <ModVersion Value="0.1.0" />
+  <ChangeLog>
+    - Restore wrapper-only repo-root .agents/skills and keep authoritative retained kernels under builders/packet-workflow/retained-skills.
+    - Add consumer bootstrap and packet-workflow versioning metadata.
+    - Capture repo-local release gating around packet-efficiency and token-savings drift.
+  </ChangeLog>
+</Configuration>

--- a/.codex/project/release/ReleaseSettings.cs
+++ b/.codex/project/release/ReleaseSettings.cs
@@ -1,0 +1,8 @@
+namespace PacketFlowFoundry.ReleaseProfile;
+
+// PacketFlow Foundry does not expose runtime settings in the same shape as
+// the mod-oriented default release-copy scaffold. This repo-local adapter
+// keeps the required binding in place without adding reusable core behavior.
+public sealed class ReleaseSettings
+{
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Default owner
+* @FennexFox
+
+# Repository metadata and workflow docs
+/.github/ @FennexFox
+/AGENTS.md @FennexFox
+/CONTRIBUTING.md @FennexFox
+/README.md @FennexFox
+/docs/ @FennexFox
+
+# Foundry surfaces
+/.agents/ @FennexFox
+/.codex/agents/ @FennexFox
+/builders/ @FennexFox
+/core/ @FennexFox
+/profiles/ @FennexFox

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: fennexfox
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a reproducible bug or incorrect behavior in packetflow_foundry.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for confirmed or at least reproducible problems.
+        For open-ended design ideas or capability proposals, use the Feature request form.
+  - type: input
+    id: foundry-version
+    attributes:
+      label: Foundry version or commit
+      placeholder: e.g. main@abc1234, vendored snapshot, or local branch
+    validations:
+      required: true
+  - type: input
+    id: consumer-context
+    attributes:
+      label: Consumer context
+      description: Where was this observed?
+      placeholder: e.g. .codex/vendor/packetflow_foundry in <repo>
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is happening, and why is it wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Vendor or open packetflow_foundry
+        2. Run the relevant builder or workflow
+        3. Observe the incorrect output or behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs / generated output / screenshots
+      description: Paste logs or attach artifacts if available.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - agents
+        - builders
+        - contracts
+        - defaults
+        - templates
+        - profiles
+        - skills
+        - docs
+        - vendoring
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Propose a new reusable capability or a meaningful improvement.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for intentional behavior changes or new reusable capabilities.
+        For confirmed breakage, use the Bug report form instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or limitation
+      description: What consumer pain, maintenance issue, or workflow gap motivates this?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the behavior you want, not just the implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or examples
+      description: Link issues, generated output, prior investigations, or consumer examples if available.
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and non-goals
+      description: Note compatibility concerns, vendoring impact, or what the change should explicitly avoid.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - agents
+        - builders
+        - contracts
+        - defaults
+        - templates
+        - profiles
+        - skills
+        - docs
+        - vendoring
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/release_checklist.yml
+++ b/.github/ISSUE_TEMPLATE/release_checklist.yml
@@ -1,0 +1,93 @@
+name: Release checklist
+description: Prepare and verify a packetflow_foundry release.
+title: "[Release] "
+labels: ["release"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Target version
+      description: Confirm the release target matches `builders/packet-workflow/version.json`, `.codex/project/release/ReleaseConfiguration.xml`, and the planned `v*` tag.
+      placeholder: e.g. v0.2.0
+    validations:
+      required: true
+  - type: textarea
+    id: baseline
+    attributes:
+      label: Release range / baseline
+      description: Document the comparison base for this release. For the first tagged release, call out the branch or revision range used until a prior `v*` tag exists.
+      placeholder: |
+        - prior release tag: v0.1.0 | none
+        - comparison range: v0.1.0..HEAD | master..develop
+        - first-release note: ...
+    validations:
+      required: true
+  - type: textarea
+    id: changes
+    attributes:
+      label: Included changes
+      description: Summarize the main reusable changes shipping in this release.
+    validations:
+      required: true
+  - type: textarea
+    id: release_gating
+    attributes:
+      label: Release gating
+      description: Classify each shipped item against the packet-efficiency goal before approving the release.
+      placeholder: |
+        - <item>: direct savings | measurement-enabling | structural-only
+          - direct savings path: packet compaction / raw reread reduction / delegation scope reduction / local scripted preprocessing
+          - target metric(s): estimated_packet_tokens / estimated_delegation_savings / raw_reread_count / common_path_sufficient
+          - structural-only release justification: ...
+        - Retained skill additions count as direct savings only when they add a concrete packet-efficiency path or a measurable reduction target.
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Consumer impact / compatibility notes
+      description: Call out required consumer actions, regenerated output, or migration notes.
+      placeholder: |
+        - consumer action required: yes / no
+        - generated output or template refresh needed: ...
+        - vendoring or migration note: ...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Validation evidence
+      description: List the tests, generation checks, and manual review evidence that gate this release.
+      placeholder: |
+        - builder tests:
+          - ...
+        - generated output or fixture validation:
+          - ...
+        - docs / template review:
+          - ...
+        - manual verification:
+          - ...
+        - version source alignment:
+          - `builders/packet-workflow/version.json` == `.codex/project/release/ReleaseConfiguration.xml` == planned tag
+        - release workflow / artifact expectation:
+          - source archives (`.tar.gz`, `.zip`) and `SHA256SUMS.txt`
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: First-release baseline or prior `v*` comparison range documented
+        - label: Each release item is labeled as direct savings, measurement-enabling, or structural-only
+        - label: Structural-only items are deferred or include a brief release justification
+        - label: Measurement-enabling items name the target metric(s) they improve or make more trustworthy
+        - label: Direct-savings items name the concrete savings path
+        - label: Retained skills are only labeled direct savings when they add a concrete efficiency path or measurable reduction target
+        - label: README and CONTRIBUTING reviewed against shipped behavior
+        - label: .github instructions, templates, and release workflow reviewed against the current publication path
+        - label: Changes to core/contracts, core/templates, or core/defaults are paired with builder/test updates
+        - label: Consumer or vendoring impact documented
+        - label: Validation evidence captured
+        - label: Target version matches builders/packet-workflow/version.json, ReleaseConfiguration ModVersion, and planned `v*` tag
+        - label: Release notes reviewed

--- a/.github/instructions/commit-message.instructions.md
+++ b/.github/instructions/commit-message.instructions.md
@@ -1,0 +1,105 @@
+# Commit Message Instructions
+
+This file is the canonical source for generated commit messages in this
+repository. Read it before drafting commit text.
+
+When asked to generate a commit message, output only the final commit
+message.
+
+## Format
+- For ordinary commits and squash-merge commit text, use Conventional
+  Commits:
+  - `<type>(<scope>): <subject>`
+  - Body and footer are optional.
+  - If a body is present, separate subject, body, and footer with blank
+    lines.
+
+## PR Merge Commits
+- For PR merge commits into long-running branches, use the PR title
+  exactly as the merge commit subject.
+- Leave the body empty unless the merge itself adds release or
+  integration context not already captured in the PR description.
+- Do not use `Merge pull request #123 from ...` as the subject.
+
+## Types
+Use one of:
+- `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+  `ci`, `chore`, `revert`
+
+## Type Selection (strict)
+- Choose `feat` only for a clearly new reusable capability, new reusable
+  profile, new builder workflow, or new managed-agent behavior.
+- Choose `fix` for behavior correction, compatibility alignment, broken
+  generation, incorrect vendoring guidance, or keeping existing foundry
+  workflows usable.
+- Choose `refactor` only when behavior is unchanged and the change is
+  primarily structural.
+- Choose `test` only when the meaningful change is limited to tests or
+  test infrastructure.
+- If shared behavior changed and tests/docs/config changed alongside it,
+  do not choose `test` or `docs`; title the logic or contract change and
+  mention the supporting work in the body instead.
+- If a change touches `core/contracts`, `core/templates`, or
+  `core/defaults` together with `builders/` or tests, title the primary
+  shared behavior change rather than the follow-up sync work.
+- If uncertain between `feat` and `fix`, choose `fix`.
+
+## Scopes
+- `scope` is required.
+- Prefer the concrete changed surface. If unsure, choose one of:
+  - `agents`, `builders`, `contracts`, `defaults`, `templates`,
+    `profiles`, `skills`, `docs`, `tests`, `infra`, `config`
+- Prefer `contracts`, `defaults`, or `templates` over generic `core`
+  when one core surface is primary.
+- Keep scope lowercase and short (1-2 words).
+
+## Subject Rules
+- Imperative mood: "add", "fix", "remove", "align", "clarify",
+  "prevent", "rename"
+- 50 characters or fewer
+- No trailing period
+- Describe the primary behavior or workflow intent, not the file list.
+- Do not let tests, deleted files, or doc cleanup override the subject
+  when they only support a behavior change.
+- Avoid generic subjects like "update files", "clean up repo", or "add
+  tests for behavior" when a more specific shared intent is visible in
+  the diff.
+- Prefer the narrowest real module or behavior scope.
+
+## Body Rules (only when needed)
+Add a body when:
+- more than one file changed, or
+- a new file/system/component was added, or
+- behavior changed in a way reviewers should verify, or
+- consumer adoption or migration notes matter
+
+Body should:
+- explain what changed and why
+- wrap lines at about 72 chars
+- use 2-4 bullets
+- each bullet starts with `- ` and an imperative verb
+
+## Breaking Changes
+- If breaking, add `!` after type or scope, e.g. `feat(templates)!: ...`
+- Add footer:
+  - `BREAKING CHANGE: <what breaks and what to do>`
+
+## References
+- If an issue or PR number is known from context, add:
+  - `Refs: #123`
+
+## Examples
+- `fix(builders): preserve validator defaults in generated output`
+- `feat(templates): add common packet review scaffolding`
+- `docs(contracts): clarify profile boundary contract`
+- `test(builders): cover overlay composition edge cases`
+
+Example with body:
+
+```text
+fix(templates): align common-path packet defaults
+
+- update shared packet template defaults for common-path planning
+- keep builder-generated output in sync with the template change
+- add regression coverage for the packet-workflow builder path
+```

--- a/.github/instructions/pull-request.instructions.md
+++ b/.github/instructions/pull-request.instructions.md
@@ -1,0 +1,94 @@
+# Pull Request Instructions
+
+This file is the canonical source for generated PR titles and
+descriptions in this repository. Read it before drafting PR text.
+
+When asked to generate a PR title or description, follow this structure.
+Prefer filling the repository template at
+`.github/pull_request_template.md`.
+
+## PR Title
+- Use Conventional Commit style:
+  - `<type>(<scope>): <summary>`
+- Choose `type` and `scope` using the same rules as commit messages.
+- Summary 72 characters or fewer, imperative mood, no trailing period.
+- The PR title is also the default subject for PR merge commits into
+  long-running branches, so it must stand on its own in
+  `git log --oneline`.
+- Determine `type` from the full PR outcome, not the active file, latest
+  commit, or noisiest part of the diff.
+- Title the primary behavior or workflow change, not the biggest file or
+  supporting test/doc churn.
+- If shared behavior changed and tests/docs/config changed alongside it,
+  title the behavior change.
+- Use `docs` only when the meaningful change is limited to
+  documentation.
+- Use `test` only when the meaningful change is limited to tests or test
+  infrastructure.
+- If the PR adds a new reusable workflow, managed-agent capability,
+  overlay, or builder path, prefer `feat` unless the change is clearly a
+  correction to existing behavior.
+- Prefer `contracts`, `defaults`, or `templates` over generic `core`
+  when one core surface is primary.
+
+## Title Selection Heuristics
+- Start from the highest-impact non-doc behavior change in the PR, then
+  treat docs/tests/config as supporting detail.
+- For multi-commit PRs, ignore intermediate cleanup or follow-up commit
+  messages and summarize the final merged state instead.
+- Because PR merge commits usually reuse the PR title without a body,
+  keep the title specific enough that the merge commit still reads well
+  on its own.
+- Avoid generic or misleading titles like `fix(docs): ...` when the PR
+  also introduces or changes shared semantics, builder behavior, or
+  shipped templates/defaults.
+
+## PR Description Template
+Use these sections in template order. Keep bullets concise, concrete,
+and non-redundant.
+
+The PR description is the canonical detailed summary for PR merges. Do
+not rely on merge commit bodies for routine reviewer context.
+
+## What changed
+- 2-6 bullets covering the main functional or behavioral changes
+- Start with the primary consumer-facing or reviewer-relevant change
+
+## Why
+- State the problem being solved or the reason for the change
+- Link issues if known (e.g. `Refs: #123`)
+
+## How
+- Capture key implementation choices, constraints, and tradeoffs
+- Mention important authority-order, routing, validation, or template
+  assumptions when relevant
+
+## Testing
+- State what was tested: targeted tests, generated output validation,
+  manual review, or none
+- Include reviewer verification commands or steps when applicable
+
+## Compatibility / Adoption
+- Call out consumer or vendoring impact only when it exists
+- Mention required regeneration, profile changes, migration notes, or
+  rollout constraints when relevant
+
+## Risk / Rollback
+- Call out meaningful risk areas only
+- Include rollback or mitigation when shipped behavior could regress
+
+## Reviewer Checklist
+- Keep the template checklist when filling the full repository template.
+- Mark items only when the diff or provided context supports them.
+
+## PR Classification (optional)
+If asked to classify the PR, use one label:
+- `Feature`, `Bugfix`, `Refactor`, `Docs`, `Chore/Maintenance`,
+  `Build/CI`, `Test`
+
+Provide a one to two sentence justification.
+
+## Examples
+- `feat(templates): add reusable packet review starter set`
+- `fix(builders): keep generated defaults aligned with core`
+- `docs(contracts): clarify foundry profile boundary`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,73 @@
+<!--
+Before filling this template, read:
+- .github/instructions/pull-request.instructions.md
+
+PR title format:
+<type>(<scope>): <summary>
+
+Examples:
+- fix(builders): keep generated defaults aligned with core
+- docs(contracts): clarify profile boundary contract
+
+Automation guardrails:
+- Treat the instruction file above as the canonical source for generated
+  PR text.
+- Replace every placeholder bullet with concrete details from the final
+  diff, or remove the bullet if it does not apply.
+- Do not fill this template from memory or the latest commit summary
+  when the instruction file above applies.
+-->
+
+## What changed
+- 
+- 
+
+## Why
+- 
+- Refs: #
+
+## How
+- 
+- Note any important authority-order, routing, validation, or template
+  constraints.
+
+## Testing
+- Validation / tests:
+  - 
+- Manual review:
+  - 
+- If not tested, state why.
+
+## Compatibility / Adoption
+- Consumer / vendor impact:
+  - [ ] None
+  - [ ] Requires regenerating builder output
+  - [ ] Requires updating project-local profiles or agents
+  - [ ] Requires a migration note for vendored consumers
+- Details:
+  - 
+
+## Risk / Rollback
+- Risk areas:
+  - 
+- Rollback / mitigation:
+  - 
+
+## Reviewer Checklist
+- [ ] Linked issue, design note, or release item when applicable
+- [ ] Docs or templates updated if shared behavior changed
+- [ ] Builder/tests updated with core contract/template/default changes
+- [ ] Consumer impact called out when applicable
+- [ ] Validation steps are specific enough to reproduce
+- [ ] Risk and rollback are concrete when behavior could regress
+
+## PR Classification (optional)
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Refactor
+- [ ] Docs
+- [ ] Chore/Maintenance
+- [ ] Build/CI
+- [ ] Test
+
+Justification:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag matches builder version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected_tag="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("builders/packet-workflow/version.json").read_text(encoding="utf-8"))
+          print(f"v{payload['builder_semver']}")
+          PY
+          )"
+
+          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "::error::Ref ${GITHUB_REF_NAME} does not match builders/packet-workflow/version.json (${expected_tag})."
+            exit 1
+          fi
+
+      - name: Build source archives
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          archive_root="packetflow_foundry-${tag}"
+          mkdir -p dist
+
+          git archive \
+            --format=tar.gz \
+            --prefix="${archive_root}/" \
+            --output="dist/${archive_root}.tar.gz" \
+            "${tag}"
+
+          git archive \
+            --format=zip \
+            --prefix="${archive_root}/" \
+            --output="dist/${archive_root}.zip" \
+            "${tag}"
+
+          (
+            cd dist
+            sha256sum "${archive_root}.tar.gz" "${archive_root}.zip" > SHA256SUMS.txt
+          )
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          title="packetflow_foundry ${tag}"
+          assets=(dist/*)
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release upload "${tag}" "${assets[@]}" --clobber
+          else
+            gh release create \
+              "${tag}" \
+              "${assets[@]}" \
+              --title "${title}" \
+              --generate-notes \
+              --verify-tag
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.codex/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Ignore the scripts folder, which contains local development scripts that should not be shared
 /scripts/
 .vscode/
+.codex/tmp/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# PacketFlow Foundry AGENTS
+
+This `AGENTS.md` governs the `packetflow_foundry` subtree itself.
+It does not try to map or govern an entire consumer project.
+
+## Identity
+
+`packetflow_foundry` is a vendorable shared core for:
+- packet-first workflow orchestration
+- token-efficient packet and subagent patterns
+- reusable contracts, templates, builders, and managed agents
+
+It is not a project-specific monolith.
+Repo-specific profiles belong in `.codex/project/profiles/`, repo-specific skills in `.agents/skills/`, and project-scoped subagents in `.codex/agents/`.
+
+## Directory Ownership
+
+- `.codex/agents/`
+  - Foundry default managed worker registry and the direct-repo project-scoped subagent discovery surface.
+  - This is the reusable default set shipped by the foundry, not a claim that every consumer project must use only these agents.
+  - When vendored, bridge the foundry defaults into the consumer repo-root `.codex/agents/`.
+  - Legacy `.codex/project/agents/` entries are migration-only and should move to `.codex/agents/`.
+- `core/`
+  - Authoritative home for cross-project behavior semantics, contracts, templates, and shared defaults.
+- `profiles/`
+  - Reusable foundry overlay profiles only.
+  - `baseline` is the default overlay.
+  - `packet-heavy-orchestrator` is an opt-in upper overlay.
+- `builders/`
+  - Builder logic, builder-specific contracts, generators, and tests that consume `core/`.
+- `builders/packet-workflow/retained-skills/`
+  - Authoritative retained skill kernels.
+  - Owns reusable builder specs, profiles, references, scripts, tests, and migration worksheets for foundry packet workflows.
+- `.agents/skills/`
+  - Thin skill entrypoints only.
+  - Do not place authoritative contracts, templates, scripts, or tests here.
+
+## Core Versus Profile
+
+Keep in `core/`:
+- validator/apply semantics
+- stop taxonomy meaning
+- common-path contract semantics
+- worker-family and routing semantics
+- packet schema and template semantics
+- shared default authority order and review-mode defaults
+
+Allowed in reusable or project-local profiles:
+- repo-specific or overlay-specific values
+- paths and globs
+- review-doc lists
+- lint and review defaults
+- worker selection defaults and binding metadata
+- notes
+
+Never move into profiles:
+- executable hooks
+- prompt fragments that define behavior
+- packet routing authority
+- validator/apply behavior
+- stop taxonomy meaning
+- token-budget or common-path semantics
+
+See `core/contracts/packet-workflow/profile-boundary-contract.md` for the authoritative boundary.
+
+## Managed Agents
+
+Foundry core owns reusable agent behavior semantics.
+Consumer projects may adjust binding, selection, and routing locally, but should not fork shared semantics for repo-specific convenience.
+
+Use this model when vendored:
+- foundry default managed set: `.codex/vendor/packetflow_foundry/.codex/agents/`
+- foundry thin skill wrapper surface: `.codex/vendor/packetflow_foundry/.agents/skills/`
+- foundry authoritative retained skill source: `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- consumer-local skill discovery surface: `.agents/skills/`
+- consumer-local subagent discovery surface: `.codex/agents/`
+- legacy project-agent shim: `.codex/project/agents/`
+
+## Vendoring Rules
+
+When this repo is used as `.codex/vendor/packetflow_foundry`:
+- do not make repo-specific edits inside the vendor subtree
+- put repo-specific profiles in `.codex/project/profiles/`
+- put repo-specific skills in `.agents/skills/`
+- put repo-specific agents in `.codex/agents/`
+- treat legacy `.codex/project/agents/` as migration-only, not canonical
+- treat legacy `.codex/project/skills/` as migration-only, not canonical
+
+Direct vendor edits are reserved for reusable fixes or reusable capability additions that should be kept upstream in the foundry.
+
+## Change Discipline
+
+- If you change `core/contracts`, `core/templates`, or `core/defaults`, update `builders/` and builder tests in the same change.
+- If you add a new foundry profile, it must be reusable across multiple repos. Otherwise keep it in `.codex/project/profiles/`.
+- Do not reintroduce duplicate authoritative copies of contracts, templates, scripts, or tests under `.agents/skills/`.
+- Treat `codex.example.toml` as a repo convention example only, not a Codex platform standard.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ Repo-specific profiles belong in `.codex/project/profiles/`, repo-specific skill
   - This is the reusable default set shipped by the foundry, not a claim that every consumer project must use only these agents.
   - When vendored, bridge the foundry defaults into the consumer repo-root `.codex/agents/`.
   - Legacy `.codex/project/agents/` entries are migration-only and should move to `.codex/agents/`.
+- `.codex/tmp/`
+  - Gitignored repo-local scratch tree for temporary, helper, runtime-artifact, and ad hoc operator-input files that are not meant to be tracked.
+  - If a workflow needs a repo-local temp file, keep it under `.codex/tmp/` rather than the repo root or another tracked directory.
+  - Packet-workflow artifacts belong under `.codex/tmp/packet-workflow/`; repo-local evaluation-log fallbacks belong under `.codex/tmp/evaluation_logs/`.
 - `core/`
   - Authoritative home for cross-project behavior semantics, contracts, templates, and shared defaults.
 - `profiles/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+`packetflow_foundry` is a shared foundry, not a consumer-project home.
+Keep repo-specific profiles, skills, agents, and one-off workflow policy
+out of this repository unless they are meant to be reusable upstream.
+
+## What belongs here
+
+Changes are a good fit for this repo when they improve reusable foundry
+behavior such as:
+- shared packet-workflow contracts, templates, and defaults
+- reusable builder logic and regression coverage
+- reusable overlay profiles
+- default managed agents that should ship with the foundry
+- general documentation for vendoring or operating the foundry
+
+Changes are usually not a fit when they only support one consumer repo.
+Put repo-specific profiles in `.codex/project/profiles/`, repo-specific
+skills in `.agents/skills/`, and project-scoped subagents in
+`.codex/agents/` in the consumer repository instead.
+
+## Commit messages
+
+The canonical rules live in
+`.github/instructions/commit-message.instructions.md`.
+
+Use Conventional Commits:
+- `<type>(<scope>): <subject>`
+
+Repository-specific guidance:
+- `scope` is required
+- prefer concrete surfaces such as `contracts`, `templates`,
+  `defaults`, `builders`, `profiles`, or `agents`
+- if a shared behavior change also updates docs/tests/config, title the
+  shared behavior change rather than the support work
+
+## Pull requests
+
+The canonical rules live in
+`.github/instructions/pull-request.instructions.md`.
+
+Prefer filling `.github/pull_request_template.md`.
+
+PRs should describe:
+- what changed
+- why the change exists
+- how the change works
+- what validation ran
+- whether vendored consumers need to do anything
+- what risks or rollback paths matter
+
+## Issues
+
+Prefer the repository issue templates:
+- Bug report -> `bug`
+- Feature request -> `enhancement`
+- Release checklist -> `release`
+
+Maintainers may add one `area:` label for the primary reusable foundry
+surface and may use `question`, `duplicate`, `invalid`, or `wontfix`
+for triage or disposition.
+
+See `MAINTAINING.md` for the canonical label taxonomy and maintenance
+rules.
+
+## Change discipline
+
+Keep shared semantics authoritative in `core/`.
+Profiles can carry reusable values and defaults, but not executable
+behavior or prompt fragments that redefine foundry semantics.
+
+When a change touches `core/contracts`, `core/templates`, or
+`core/defaults`, update `builders/` and the relevant tests in the same
+change.
+
+Do not add duplicate authoritative copies of contracts, templates,
+scripts, or tests under `.agents/skills/`.
+
+## Validation
+
+Run the narrowest relevant validation for the surfaces you changed and
+record it in the PR description.
+
+Examples:
+- builder tests when `builders/` changes
+- generation or fixture validation when templates/defaults change
+- manual doc review when contributor-facing instructions change
+
+If you did not run validation, say so explicitly and explain why.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,90 @@
+# Maintaining
+
+`packetflow_foundry` maintainer workflow rules should stay small,
+reusable, and explicit.
+Avoid inventing ad hoc labels or repo-local shortcuts that are not
+reflected in tracked docs and templates.
+
+## Issue labels
+
+Use labels to answer three separate questions:
+- what kind of issue is this?
+- which reusable foundry surface owns it?
+- what triage or disposition state matters right now?
+
+Prefer a small fixed taxonomy over one-off labels.
+
+## Intake labels
+
+These are the default labels applied by the issue templates.
+
+- `bug`
+  - confirmed or reproducible incorrect behavior in
+    `packetflow_foundry`
+  - default for `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `enhancement`
+  - a new reusable capability or a meaningful improvement
+  - default for `.github/ISSUE_TEMPLATE/feature_request.yml`
+- `release`
+  - release preparation, validation, and version-tracking work
+  - default for `.github/ISSUE_TEMPLATE/release_checklist.yml`
+
+Keep one intake label on an issue unless the issue is reclassified.
+
+## Area labels
+
+Apply one `area:` label when the primary owned surface is clear.
+These labels should stay aligned with the `Area` dropdown in the bug and
+feature issue templates.
+
+- `area:agents`
+  - default managed agents and agent-routing surfaces
+- `area:builders`
+  - builder logic, generators, and builder-side tests
+- `area:contracts`
+  - shared contracts and authoritative foundry semantics
+- `area:defaults`
+  - shared defaults and shipped baseline behavior
+- `area:docs`
+  - contributor-facing docs, templates, and instructions
+- `area:profiles`
+  - reusable overlay profiles and profile defaults
+- `area:skills`
+  - reusable skill entrypoints and skill-side workflow glue
+- `area:templates`
+  - shared templates and generated scaffolding
+- `area:vendoring`
+  - consumer vendoring, adoption, and upgrade path concerns
+
+If an issue spans multiple surfaces, label the primary owner and capture
+secondary surfaces in the issue body or comments instead of stacking
+multiple `area:` labels.
+
+## Triage and disposition labels
+
+Use these only when they change how the issue should be handled:
+
+- `question`
+  - clarification or usage question about the foundry
+- `duplicate`
+  - already tracked elsewhere
+- `invalid`
+  - report does not describe a valid repo issue
+- `wontfix`
+  - acknowledged but not planned for work
+
+These labels complement the intake label; they do not replace it unless
+the issue is being closed as pure triage.
+
+## Labeling rules
+
+- Prefer issue templates over blank issues so the intake label and area
+  context are captured up front.
+- Add an `area:` label during triage when the owner is clear.
+- Keep `release` issues focused on release gating, validation, and
+  version tracking rather than using ad hoc milestone-style labels.
+- Do not recreate removed generic labels such as `documentation`,
+  `good first issue`, or `help wanted` unless repo policy changes and
+  the docs and templates are updated in the same change.
+- If the template taxonomy changes, update the live GitHub labels and
+  the corresponding docs in the same change.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,21 @@ python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init
 ```
 
 Bootstrap now writes managed copies into repo-root `.codex/agents/` and `.agents/skills/`.
+Those bootstrap-copied entries are managed artifacts only when they came from the
+vendor subtree; do not patch those copied artifacts in place. Update the vendor source
+or replace the entry with a project-local one, then rerun bootstrap.
 After updating `.codex/vendor/packetflow_foundry`, rerun the same bootstrap command to
 refresh those managed copies while leaving locally modified copies untouched.
+
+Recommended update flow:
+
+```text
+git subtree pull --prefix=.codex/vendor/packetflow_foundry packetflow_foundry <upstream-branch> --squash
+python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+<run the relevant consumer smoke test(s)>
+git diff
+git commit
+```
 
 Bootstrap behavior:
 - repo-root `.gitignore` is created or appended so `.codex/tmp/` stays ignored
@@ -140,6 +153,7 @@ Bootstrap behavior:
 - vendored foundry thin skill wrappers are copied into root `.agents/skills/` unless a root entry already exists
 - copied skill wrappers keep resolving authoritative retained kernels from `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
 - rerunning bootstrap refreshes managed copies that still match the last managed state
+- `bridge-state.json` stores both raw and LF-normalized hashes so CRLF/LF-only drift does not trigger a refresh or local-modification warning
 - `--bridge-mode copy-on-fail` is retained only as a deprecated compatibility alias for `copy`
 - legacy `.codex/project/agents/` entries are bridged only as a migration shim and should be moved to `.codex/agents/`
 - legacy `.codex/project/skills/` entries are bridged only as a migration shim and should be moved to root `.agents/skills/`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,145 @@
+# PacketFlow Foundry
+
+`packetflow_foundry` is a vendorable shared core for packet-first, token-efficient workflow orchestration.
+It ships reusable contracts, templates, builders, overlay profiles, a default managed agent set, and reusable repo-scoped skills.
+
+It is not a project-specific monolith.
+Consumer projects should keep repo-specific profiles in `.codex/project/profiles/`, repo-specific skills in `.agents/skills/`, and project-scoped subagents in `.codex/agents/`.
+
+Thin-entrypoint intent predates the current retained-skill layout. The earlier drift came from generator and test contracts that still emitted bundled skills under `.agents/skills/`. The current contract is enforced by layout generation and tests instead of prose alone.
+
+## Compose Precedence
+
+`foundry baseline -> optional foundry overlay -> project-local profile -> root .agents/skills wrapper/override surface`
+
+## Layout
+
+```text
+packetflow_foundry/
+  .agents/
+    skills/
+  .codex/
+    agents/
+    project/
+      profiles/
+  AGENTS.md
+  README.md
+  codex.example.toml
+  core/
+    contracts/packet-workflow/
+    templates/packet-workflow/
+    defaults/packet-workflow/
+  profiles/
+    baseline/
+    packet-heavy-orchestrator/
+  builders/
+    consumer-bootstrap/
+    packet-workflow/
+      retained-skills/
+  docs/
+    vendoring.md
+```
+
+## Directory Roles
+
+- `.codex/agents/`
+  - Foundry default managed worker registry and the direct-repo project-scoped subagent discovery surface.
+  - Vendored consumers should expose the foundry defaults and their own local agent TOMLs through repo-root `.codex/agents/`.
+  - Legacy `.codex/project/agents/` entries are migration-only and should move to `.codex/agents/`.
+- `core/contracts/packet-workflow/`
+  - Authoritative shared semantics.
+  - This is where validator/apply rules, common-path rules, profile boundaries, worker-family semantics, and evaluation-log rules live.
+- `core/templates/packet-workflow/`
+  - Authoritative scaffold templates consumed by the builder.
+- `core/defaults/packet-workflow/`
+  - Authoritative shared default values consumed by the builder.
+- `profiles/`
+  - Reusable overlay profiles only.
+  - `baseline` is the default.
+  - `packet-heavy-orchestrator` is opt-in and additive.
+- `builders/packet-workflow/`
+  - Builder logic, builder contract, helper scripts, and tests.
+  - This builder consumes `core/`; it does not own shared semantics.
+- `builders/packet-workflow/retained-skills/`
+  - Authoritative retained skill kernels for reusable foundry workflows.
+  - Owns reusable `builder-spec.json`, profiles, references, scripts, tests, and migration worksheets.
+- `builders/consumer-bootstrap/`
+  - Consumer-repo bootstrap helper for initializing the minimum project-local Codex overlay after vendoring.
+  - This builder is append-only for `AGENTS.md` handling and otherwise keeps an all-or-nothing conflict policy for tracked scaffolds.
+- `.agents/skills/`
+  - Thin skill entrypoints only.
+  - Authoritative contracts, templates, scripts, and tests must not live here.
+
+## Managed Agents
+
+The root `.codex/agents/` directory is the foundry's default managed agent set.
+It is not a declaration that every consumer project must use only this exact global set unchanged.
+
+The intended model is:
+- foundry default managed agents under `.codex/vendor/packetflow_foundry/.codex/agents/`
+- foundry thin skill wrappers under `.codex/vendor/packetflow_foundry/.agents/skills/`
+- foundry authoritative retained skills under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- consumer-local repo skill discovery under `.agents/skills/`
+- consumer-local project-scoped subagent discovery under `.codex/agents/`
+- legacy project-agent migration shim under `.codex/project/agents/`
+
+Foundry owns reusable agent behavior semantics.
+Projects should only adjust binding, selection, or routing locally.
+
+## Using As A Vendor
+
+Vendor the repo at `.codex/vendor/packetflow_foundry` and compose it with project-local overlays.
+
+Typical consumer layout:
+
+```text
+project-root/
+  .agents/
+    skills/
+  .codex/
+    AGENTS.md
+    agents/
+    vendor/
+      packetflow_foundry/
+    project/
+      profiles/
+```
+
+Rules:
+- use foundry `profiles/baseline/profile.json` by default
+- opt into `profiles/packet-heavy-orchestrator/profile.json` only when the workflow is packet-heavy
+- put repo-specific profile data in `.codex/project/profiles/`
+  - keep repo-wide defaults in `.codex/project/profiles/default/profile.json`
+  - keep skill-specific overrides in `.codex/project/profiles/<skill-name>/profile.json`
+- put repo-specific skills in repo-root `.agents/skills/`
+- put repo-specific agents in `.codex/agents/`
+- treat legacy `.codex/project/agents/` as migration-only
+- treat legacy `.codex/project/skills/` as migration-only
+- do not make repo-specific edits in the vendor subtree
+
+Bootstrap the local overlay after vendoring:
+
+```text
+git subtree add --prefix=.codex/vendor/packetflow_foundry packetflow_foundry master --squash
+python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+```
+
+Bootstrap behavior:
+- root `AGENTS.md` and `.codex/AGENTS.md` are append-only targets
+- repo-root `.codex/agents/` is the canonical project-scoped subagent discovery surface
+- `.codex/project/profiles/default/profile.json` is a project-local scaffold, not a reusable foundry overlay
+- skill-specific project-local overrides belong in `.codex/project/profiles/<skill-name>/profile.json`
+- repo-root `.agents/skills/` is the canonical discovery surface in the consumer repo
+- vendored foundry default agent TOMLs are bridged into repo-root `.codex/agents/` unless a root entry already exists
+- vendored foundry thin skill wrappers are bridged into root `.agents/skills/` with directory symlinks unless a root entry already exists
+- bridged wrappers resolve their authoritative retained kernels under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- legacy `.codex/project/agents/` entries are bridged only as a migration shim and should be moved to `.codex/agents/`
+- legacy `.codex/project/skills/` entries are bridged only as a migration shim and should be moved to root `.agents/skills/`
+- if any non-`AGENTS.md` tracked bootstrap output already exists, the helper aborts without writing files
+
+See [docs/vendoring.md](./docs/vendoring.md) for the full model.
+
+## Example Config
+
+`codex.example.toml` is a repo convention example only.
+It is not a Codex platform standard and should not be treated as one.

--- a/README.md
+++ b/README.md
@@ -124,18 +124,27 @@ git subtree add --prefix=.codex/vendor/packetflow_foundry packetflow_foundry mas
 python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py
 ```
 
+Bootstrap now writes managed copies into repo-root `.codex/agents/` and `.agents/skills/`.
+After updating `.codex/vendor/packetflow_foundry`, rerun the same bootstrap command to
+refresh those managed copies while leaving locally modified copies untouched.
+
 Bootstrap behavior:
+- repo-root `.gitignore` is created or appended so `.codex/tmp/` stays ignored
+- repo-local temporary, helper, scratch, and ad hoc operator-input files belong under `.codex/tmp/`, not at repo root or in tracked source directories
 - root `AGENTS.md` and `.codex/AGENTS.md` are append-only targets
 - repo-root `.codex/agents/` is the canonical project-scoped subagent discovery surface
 - `.codex/project/profiles/default/profile.json` is a project-local scaffold, not a reusable foundry overlay
 - skill-specific project-local overrides belong in `.codex/project/profiles/<skill-name>/profile.json`
 - repo-root `.agents/skills/` is the canonical discovery surface in the consumer repo
-- vendored foundry default agent TOMLs are bridged into repo-root `.codex/agents/` unless a root entry already exists
-- vendored foundry thin skill wrappers are bridged into root `.agents/skills/` with directory symlinks unless a root entry already exists
-- bridged wrappers resolve their authoritative retained kernels under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- vendored foundry default agent TOMLs are copied into repo-root `.codex/agents/` unless a root entry already exists
+- vendored foundry thin skill wrappers are copied into root `.agents/skills/` unless a root entry already exists
+- copied skill wrappers keep resolving authoritative retained kernels from `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- rerunning bootstrap refreshes managed copies that still match the last managed state
+- `--bridge-mode copy-on-fail` is retained only as a deprecated compatibility alias for `copy`
 - legacy `.codex/project/agents/` entries are bridged only as a migration shim and should be moved to `.codex/agents/`
 - legacy `.codex/project/skills/` entries are bridged only as a migration shim and should be moved to root `.agents/skills/`
-- if any non-`AGENTS.md` tracked bootstrap output already exists, the helper aborts without writing files
+- a compatible existing `.codex/project/profiles/default/profile.json` is left unchanged on rerun
+- conflicting non-`AGENTS.md` bootstrap outputs still cause the helper to abort before creating or overwriting those managed artifacts, although append-only targets like `AGENTS.md` and `.gitignore` may already have been updated
 
 See [docs/vendoring.md](./docs/vendoring.md) for the full model.
 

--- a/builders/consumer-bootstrap/README.md
+++ b/builders/consumer-bootstrap/README.md
@@ -9,21 +9,31 @@ Primary entrypoint:
 Usage:
 - `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py`
 - `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py --repo-root <project-root>`
+- `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py --bridge-mode copy`
+- `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py --bridge-mode copy-on-fail`
+
+Bridge mode note:
+- bootstrap now writes managed copies for agent and skill bridges by default
+- rerun bootstrap after updating `.codex/vendor/packetflow_foundry` to refresh managed copies that were not modified locally
+- `--bridge-mode copy-on-fail` remains accepted as a deprecated compatibility alias for `copy`
 
 Behavior:
+- creates or appends repo-root `.gitignore` with `.codex/tmp/`
+- reserves `.codex/tmp/` as the repo-local scratch tree for temporary, helper, runtime-artifact, and ad hoc operator-input files that are not meant to be tracked
 - creates `.codex/project/profiles/default/profile.json`
 - reserves `.codex/project/profiles/<skill-name>/profile.json` for skill-specific project-local overrides
 - ensures repo-root `.codex/agents/` exists as the consumer subagent discovery surface
-- creates file-symlink bridges from repo-root `.codex/agents/<agent>.toml` to `.codex/vendor/packetflow_foundry/.codex/agents/<agent>.toml`
+- copies vendored foundry agent TOMLs from `.codex/vendor/packetflow_foundry/.codex/agents/<agent>.toml` into repo-root `.codex/agents/<agent>.toml`
 - skips agent bridge creation when a root `.codex/agents/<agent>.toml` entry already exists
-- bridges legacy `.codex/project/agents/<agent>.toml` only as a migration shim and emits a deprecation notice
+- copies legacy `.codex/project/agents/<agent>.toml` only as a migration shim and emits a deprecation notice
 - ensures repo-root `.agents/skills/` exists as the consumer discovery surface
-- creates directory-symlink bridges from repo-root `.agents/skills/<skill-name>` to `.codex/vendor/packetflow_foundry/.agents/skills/<skill-name>`
-- bridges thin wrappers only; authoritative retained kernels stay under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>`
+- copies vendored foundry thin wrappers into repo-root `.agents/skills/<skill-name>` and rewrites wrapper `SKILL.md` references so retained kernels still resolve under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>`
 - skips bridge creation when a root `.agents/skills/<skill-name>` entry already exists
-- bridges legacy `.codex/project/skills/<skill-name>` only as a migration shim and emits a deprecation notice
+- copies legacy `.codex/project/skills/<skill-name>` only as a migration shim and emits a deprecation notice
 - creates or appends `.codex/AGENTS.md`
 - appends a short PacketFlow Foundry note to root `AGENTS.md` only when that file already exists
 - keeps `AGENTS.md` handling append-only
-- aborts the entire run when any tracked non-`AGENTS.md` scaffold output already exists
-- aborts on symlink creation failure instead of copying skills
+- keeps a compatible existing `.codex/project/profiles/default/profile.json` unchanged on rerun
+- aborts when conflicting non-`AGENTS.md` scaffold output already exists
+- refreshes managed copies on later runs while they remain unchanged locally
+- migrates legacy bootstrap symlink bridges to managed copies on rerun when they still point at the expected foundry source

--- a/builders/consumer-bootstrap/README.md
+++ b/builders/consumer-bootstrap/README.md
@@ -15,7 +15,15 @@ Usage:
 Bridge mode note:
 - bootstrap now writes managed copies for agent and skill bridges by default
 - rerun bootstrap after updating `.codex/vendor/packetflow_foundry` to refresh managed copies that were not modified locally
+- bootstrap tracks both raw and LF-normalized hashes in `bridge-state.json` so CRLF/LF-only drift does not force a refresh or local-modification skip
 - `--bridge-mode copy-on-fail` remains accepted as a deprecated compatibility alias for `copy`
+
+Recommended vendor update flow:
+- `git subtree pull --prefix=.codex/vendor/packetflow_foundry packetflow_foundry <upstream-branch> --squash`
+- rerun `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py`
+- run the relevant consumer smoke test(s)
+- inspect the resulting diff
+- commit the subtree update and bootstrap refresh together
 
 Behavior:
 - creates or appends repo-root `.gitignore` with `.codex/tmp/`
@@ -24,10 +32,12 @@ Behavior:
 - reserves `.codex/project/profiles/<skill-name>/profile.json` for skill-specific project-local overrides
 - ensures repo-root `.codex/agents/` exists as the consumer subagent discovery surface
 - copies vendored foundry agent TOMLs from `.codex/vendor/packetflow_foundry/.codex/agents/<agent>.toml` into repo-root `.codex/agents/<agent>.toml`
+- bootstrap-copied entries under `.codex/agents/` are managed bootstrap artifacts; update the vendor source or replace them with a project-local entry, then rerun bootstrap instead of patching the copied artifact in place
 - skips agent bridge creation when a root `.codex/agents/<agent>.toml` entry already exists
 - copies legacy `.codex/project/agents/<agent>.toml` only as a migration shim and emits a deprecation notice
 - ensures repo-root `.agents/skills/` exists as the consumer discovery surface
 - copies vendored foundry thin wrappers into repo-root `.agents/skills/<skill-name>` and rewrites wrapper `SKILL.md` references so retained kernels still resolve under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>`
+- bootstrap-copied entries under `.agents/skills/` are managed bootstrap artifacts; update the vendor source or replace them with a project-local entry, then rerun bootstrap instead of patching the copied artifact in place
 - skips bridge creation when a root `.agents/skills/<skill-name>` entry already exists
 - copies legacy `.codex/project/skills/<skill-name>` only as a migration shim and emits a deprecation notice
 - creates or appends `.codex/AGENTS.md`

--- a/builders/consumer-bootstrap/README.md
+++ b/builders/consumer-bootstrap/README.md
@@ -1,0 +1,29 @@
+# Consumer Bootstrap Builder
+
+This builder initializes the minimum consumer-repo Codex layout after
+vendoring PacketFlow Foundry under `.codex/vendor/packetflow_foundry`.
+
+Primary entrypoint:
+- `scripts/init_consumer_codex.py`
+
+Usage:
+- `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py`
+- `python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py --repo-root <project-root>`
+
+Behavior:
+- creates `.codex/project/profiles/default/profile.json`
+- reserves `.codex/project/profiles/<skill-name>/profile.json` for skill-specific project-local overrides
+- ensures repo-root `.codex/agents/` exists as the consumer subagent discovery surface
+- creates file-symlink bridges from repo-root `.codex/agents/<agent>.toml` to `.codex/vendor/packetflow_foundry/.codex/agents/<agent>.toml`
+- skips agent bridge creation when a root `.codex/agents/<agent>.toml` entry already exists
+- bridges legacy `.codex/project/agents/<agent>.toml` only as a migration shim and emits a deprecation notice
+- ensures repo-root `.agents/skills/` exists as the consumer discovery surface
+- creates directory-symlink bridges from repo-root `.agents/skills/<skill-name>` to `.codex/vendor/packetflow_foundry/.agents/skills/<skill-name>`
+- bridges thin wrappers only; authoritative retained kernels stay under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/<skill-name>`
+- skips bridge creation when a root `.agents/skills/<skill-name>` entry already exists
+- bridges legacy `.codex/project/skills/<skill-name>` only as a migration shim and emits a deprecation notice
+- creates or appends `.codex/AGENTS.md`
+- appends a short PacketFlow Foundry note to root `AGENTS.md` only when that file already exists
+- keeps `AGENTS.md` handling append-only
+- aborts the entire run when any tracked non-`AGENTS.md` scaffold output already exists
+- aborts on symlink creation failure instead of copying skills

--- a/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+++ b/builders/consumer-bootstrap/scripts/init_consumer_codex.py
@@ -11,7 +11,7 @@ import shutil
 import stat
 import sys
 from pathlib import Path
-from typing import TypeAlias, TypedDict
+from typing import NotRequired, TypeAlias, TypedDict
 
 
 FOUNDRY_KEYWORDS = (
@@ -54,6 +54,31 @@ BridgeEvent: TypeAlias = tuple[str, str]
 class BridgeReport(TypedDict):
     events: list[BridgeEvent]
     notices: list[str]
+
+
+class HashState(TypedDict):
+    sha256: str
+    raw_sha256: str
+    lf_sha256: str
+
+
+class ValidatedHashState(TypedDict):
+    raw_sha256: str
+    lf_sha256: NotRequired[str]
+
+
+class FileCopyStateEntry(TypedDict):
+    type: str
+    source: str
+    sha256: str
+    raw_sha256: str
+    lf_sha256: str
+
+
+class DirectoryCopyStateEntry(TypedDict):
+    type: str
+    source: str
+    files: dict[str, HashState]
 
 
 def parse_args() -> argparse.Namespace:
@@ -142,6 +167,23 @@ def sha256_digest(content: bytes) -> str:
 
 def sha256_path(path: Path) -> str:
     return sha256_digest(path.read_bytes())
+
+
+def normalize_lf_bytes(content: bytes) -> bytes:
+    return content.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def hash_state_from_bytes(content: bytes) -> HashState:
+    raw_sha256 = sha256_digest(content)
+    return {
+        "sha256": raw_sha256,
+        "raw_sha256": raw_sha256,
+        "lf_sha256": sha256_digest(normalize_lf_bytes(content)),
+    }
+
+
+def hash_state_from_path(path: Path) -> HashState:
+    return hash_state_from_bytes(path.read_bytes())
 
 
 def relative_repo_path(path: Path, repo_root: Path) -> str:
@@ -243,6 +285,13 @@ def render_agents_block() -> str:
                 "Bootstrap writes managed copies of vendored wrappers there "
                 "while reusable retained kernels stay under "
                 "`.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`."
+            ),
+            (
+                "- Entries that consumer bootstrap copied from the vendor subtree "
+                "into `.codex/agents/` or `.agents/skills/` are managed bootstrap "
+                "artifacts. Update the vendor source or replace them with a "
+                "project-local entry, then rerun bootstrap instead of patching the "
+                "copied artifact in place."
             ),
             (
                 "- Rerun consumer bootstrap after updating the vendor subtree "
@@ -704,11 +753,15 @@ def bridge_state_group(
     return group
 
 
-def build_file_copy_state_entry(repo_root: Path, source_path: Path) -> dict[str, str]:
+def build_file_copy_state_entry(repo_root: Path, source_path: Path) -> FileCopyStateEntry:
+    source_bytes = source_path.read_bytes()
+    hash_state = hash_state_from_bytes(source_bytes)
     return {
         "type": "file-copy",
         "source": relative_repo_path(source_path, repo_root),
-        "sha256": sha256_path(source_path),
+        "sha256": hash_state["sha256"],
+        "raw_sha256": hash_state["raw_sha256"],
+        "lf_sha256": hash_state["lf_sha256"],
     }
 
 
@@ -716,12 +769,12 @@ def build_directory_copy_state_entry(
     repo_root: Path,
     source_root: Path,
     copied_files: dict[str, bytes],
-) -> dict[str, object]:
+) -> DirectoryCopyStateEntry:
     return {
         "type": "directory-copy",
         "source": relative_repo_path(source_root, repo_root),
         "files": {
-            relative_path: {"sha256": sha256_digest(content)}
+            relative_path: hash_state_from_bytes(content)
             for relative_path, content in copied_files.items()
         },
     }
@@ -731,35 +784,75 @@ def validate_file_copy_state_entry(
     entry: object,
     *,
     bridge_name: str,
-) -> str:
+) -> ValidatedHashState:
     if not isinstance(entry, dict) or entry.get("type") != "file-copy":
         raise RuntimeError(f"Malformed managed file copy state for {bridge_name}.")
-    expected_hash = entry.get("sha256")
-    if not isinstance(expected_hash, str):
+    raw_sha256 = entry.get("raw_sha256")
+    if raw_sha256 is None:
+        raw_sha256 = entry.get("sha256")
+    if not isinstance(raw_sha256, str):
         raise RuntimeError(f"Malformed managed file copy state for {bridge_name}.")
-    return expected_hash
+    validated: ValidatedHashState = {"raw_sha256": raw_sha256}
+    lf_sha256 = entry.get("lf_sha256")
+    if lf_sha256 is not None:
+        if not isinstance(lf_sha256, str):
+            raise RuntimeError(f"Malformed managed file copy state for {bridge_name}.")
+        validated["lf_sha256"] = lf_sha256
+    return validated
 
 
 def validate_directory_copy_state_entry(
     entry: object,
     *,
     bridge_name: str,
-) -> dict[str, str]:
+) -> dict[str, ValidatedHashState]:
     if not isinstance(entry, dict) or entry.get("type") != "directory-copy":
         raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
     raw_files = entry.get("files")
     if not isinstance(raw_files, dict):
         raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
 
-    validated: dict[str, str] = {}
+    validated: dict[str, ValidatedHashState] = {}
     for relative_path, metadata in raw_files.items():
         if not isinstance(relative_path, str) or not isinstance(metadata, dict):
             raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
-        expected_hash = metadata.get("sha256")
-        if not isinstance(expected_hash, str):
+        raw_sha256 = metadata.get("raw_sha256")
+        if raw_sha256 is None:
+            raw_sha256 = metadata.get("sha256")
+        if not isinstance(raw_sha256, str):
             raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
-        validated[relative_path] = expected_hash
+        validated_hashes: ValidatedHashState = {"raw_sha256": raw_sha256}
+        lf_sha256 = metadata.get("lf_sha256")
+        if lf_sha256 is not None:
+            if not isinstance(lf_sha256, str):
+                raise RuntimeError(
+                    f"Malformed managed directory copy state for {bridge_name}."
+                )
+            validated_hashes["lf_sha256"] = lf_sha256
+        validated[relative_path] = validated_hashes
     return validated
+
+
+def hash_matches_expected(
+    current_hashes: HashState,
+    expected_hashes: ValidatedHashState,
+) -> bool:
+    expected_lf_sha256 = expected_hashes.get("lf_sha256")
+    if expected_lf_sha256 is not None:
+        return current_hashes["lf_sha256"] == expected_lf_sha256
+    return current_hashes["raw_sha256"] == expected_hashes["raw_sha256"]
+
+
+def legacy_hash_matches_peer(
+    current_hashes: HashState,
+    expected_hashes: ValidatedHashState,
+    peer_hashes: HashState | None,
+) -> bool:
+    return (
+        "lf_sha256" not in expected_hashes
+        and peer_hashes is not None
+        and current_hashes["lf_sha256"] == peer_hashes["lf_sha256"]
+    )
 
 
 def sync_directory_copy(
@@ -789,10 +882,14 @@ def sync_managed_file_copy(
     state_group: dict[str, object],
 ) -> tuple[str, str, str | None]:
     state_entry = build_file_copy_state_entry(repo_root, source_path)
-    source_hash = str(state_entry["sha256"])
+    source_hashes: HashState = {
+        "sha256": str(state_entry["sha256"]),
+        "raw_sha256": str(state_entry["raw_sha256"]),
+        "lf_sha256": str(state_entry["lf_sha256"]),
+    }
     entry = state_group.get(bridge_name)
     if entry is not None:
-        expected_hash = validate_file_copy_state_entry(entry, bridge_name=bridge_name)
+        expected_hashes = validate_file_copy_state_entry(entry, bridge_name=bridge_name)
         existed_before = target_path.exists()
         if target_path.exists():
             if target_path.is_symlink() or not target_path.is_file():
@@ -807,8 +904,12 @@ def sync_managed_file_copy(
                         f"{target_path.as_posix()}. Remove it to resume bootstrap refreshes."
                     ),
                 )
-            current_hash = sha256_path(target_path)
-            if current_hash != expected_hash:
+            current_hashes = hash_state_from_path(target_path)
+            if not hash_matches_expected(current_hashes, expected_hashes) and not legacy_hash_matches_peer(
+                current_hashes,
+                expected_hashes,
+                source_hashes,
+            ):
                 return (
                     "skipped",
                     (
@@ -820,7 +921,13 @@ def sync_managed_file_copy(
                         f"overwritten: {target_path.as_posix()}."
                     ),
                 )
-            if source_hash == expected_hash:
+            if hash_matches_expected(source_hashes, expected_hashes) or legacy_hash_matches_peer(
+                source_hashes,
+                expected_hashes,
+                current_hashes,
+            ):
+                if "lf_sha256" not in expected_hashes:
+                    state_group[bridge_name] = state_entry
                 return "unchanged", target_path.as_posix(), None
 
         write_bytes(target_path, source_path.read_bytes())
@@ -854,6 +961,14 @@ def sync_managed_directory_copy(
         source_root,
         copied_files,
     )
+    source_hashes: dict[str, HashState] = {
+        relative_path: {
+            "sha256": str(metadata["sha256"]),
+            "raw_sha256": str(metadata["raw_sha256"]),
+            "lf_sha256": str(metadata["lf_sha256"]),
+        }
+        for relative_path, metadata in state_entry["files"].items()
+    }
     entry = state_group.get(bridge_name)
     if entry is not None:
         expected_hashes = validate_directory_copy_state_entry(entry, bridge_name=bridge_name)
@@ -872,6 +987,7 @@ def sync_managed_directory_copy(
                 )
 
             target_files = iter_relative_files(target_root)
+            target_hashes: dict[str, HashState] = {}
             for relative_path, target_file in target_files.items():
                 if target_file.is_symlink() or not target_file.is_file():
                     return (
@@ -898,7 +1014,16 @@ def sync_managed_directory_copy(
                             f"overwritten: {target_root.as_posix()}."
                         ),
                     )
-                if sha256_path(target_file) != expected_hash:
+                current_hashes = hash_state_from_path(target_file)
+                target_hashes[relative_path] = current_hashes
+                if not hash_matches_expected(
+                    current_hashes,
+                    expected_hash,
+                ) and not legacy_hash_matches_peer(
+                    current_hashes,
+                    expected_hash,
+                    source_hashes.get(relative_path),
+                ):
                     return (
                         "skipped",
                         (
@@ -911,11 +1036,25 @@ def sync_managed_directory_copy(
                         ),
                     )
 
-            copied_hashes = {
-                relative_path: sha256_digest(content)
-                for relative_path, content in copied_files.items()
-            }
-            if copied_hashes == expected_hashes and set(target_files) == set(expected_hashes):
+            source_matches_expected = set(source_hashes) == set(expected_hashes)
+            if source_matches_expected:
+                for relative_path, source_file_hashes in source_hashes.items():
+                    expected_hash = expected_hashes[relative_path]
+                    if hash_matches_expected(
+                        source_file_hashes,
+                        expected_hash,
+                    ) or legacy_hash_matches_peer(
+                        source_file_hashes,
+                        expected_hash,
+                        target_hashes.get(relative_path),
+                    ):
+                        continue
+                    source_matches_expected = False
+                    break
+
+            if source_matches_expected and set(target_files) == set(expected_hashes):
+                if any("lf_sha256" not in hashes for hashes in expected_hashes.values()):
+                    state_group[bridge_name] = state_entry
                 return "unchanged", target_root.as_posix(), None
 
             sync_directory_copy(
@@ -942,7 +1081,7 @@ def prune_stale_managed_file_copy(
     if entry is None:
         return "unchanged", target_path.as_posix(), None
 
-    expected_hash = validate_file_copy_state_entry(entry, bridge_name=bridge_name)
+    expected_hashes = validate_file_copy_state_entry(entry, bridge_name=bridge_name)
     if not target_path.exists():
         state_group.pop(bridge_name, None)
         return "unchanged", target_path.as_posix(), None
@@ -960,8 +1099,8 @@ def prune_stale_managed_file_copy(
             ),
         )
 
-    current_hash = sha256_path(target_path)
-    if current_hash != expected_hash:
+    current_hashes = hash_state_from_path(target_path)
+    if not hash_matches_expected(current_hashes, expected_hashes):
         return (
             "skipped",
             (
@@ -1036,7 +1175,8 @@ def prune_stale_managed_directory_copy(
                     f"and was not removed: {target_root.as_posix()}."
                 ),
             )
-        if sha256_path(target_file) != expected_hashes[relative_path]:
+        current_hashes = hash_state_from_path(target_file)
+        if not hash_matches_expected(current_hashes, expected_hashes[relative_path]):
             return (
                 "skipped",
                 (

--- a/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+++ b/builders/consumer-bootstrap/scripts/init_consumer_codex.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import shutil
+import stat
 import sys
 from pathlib import Path
+from typing import TypeAlias, TypedDict
 
 
 FOUNDRY_KEYWORDS = (
@@ -19,15 +23,37 @@ BOOTSTRAP_MARKER_START = "<!-- packetflow_foundry consumer bootstrap:start -->"
 BOOTSTRAP_MARKER_END = "<!-- packetflow_foundry consumer bootstrap:end -->"
 CODEX_AGENTS_RELATIVE = Path(".codex/AGENTS.md")
 ROOT_AGENTS_RELATIVE = Path("AGENTS.md")
+GITIGNORE_RELATIVE = Path(".gitignore")
 PROJECT_PROFILE_RELATIVE = Path(".codex/project/profiles/default/profile.json")
 PROJECT_AGENT_DISCOVERY_RELATIVE = Path(".codex/agents")
 LEGACY_PROJECT_AGENTS_RELATIVE = Path(".codex/project/agents")
 ROOT_SKILLS_RELATIVE = Path(".agents/skills")
 LEGACY_PROJECT_SKILLS_RELATIVE = Path(".codex/project/skills")
+BRIDGE_STATE_RELATIVE = Path(".codex/project/bootstrap/bridge-state.json")
 PROJECT_LOCAL_PROFILE_KIND = "project-local-scaffold-profile"
+BRIDGE_STATE_KIND = "packetflow-foundry-bootstrap-bridge-state"
+BRIDGE_STATE_VERSION = 1
+BRIDGE_MODE_COPY = "copy"
+BRIDGE_MODE_COPY_ON_FAIL = "copy-on-fail"
+CODEX_TMP_GITIGNORE_ENTRY = ".codex/tmp/"
+CODEX_TMP_GITIGNORE_ALIASES = frozenset(
+    {
+        ".codex/tmp",
+        ".codex/tmp/",
+        "/.codex/tmp",
+        "/.codex/tmp/",
+    }
+)
 CONFLICT_TARGETS = (
     PROJECT_PROFILE_RELATIVE,
 )
+
+BridgeEvent: TypeAlias = tuple[str, str]
+
+
+class BridgeReport(TypedDict):
+    events: list[BridgeEvent]
+    notices: list[str]
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,7 +63,24 @@ def parse_args() -> argparse.Namespace:
         default=str(Path.cwd()),
         help="Consumer repository root. Defaults to the current directory.",
     )
+    parser.add_argument(
+        "--bridge-mode",
+        choices=(BRIDGE_MODE_COPY, BRIDGE_MODE_COPY_ON_FAIL),
+        default=BRIDGE_MODE_COPY,
+        help=(
+            "Bridge strategy for vendored agents and skills. "
+            "`copy` writes managed copies and refreshes them on rerun while "
+            "they remain unchanged locally. `copy-on-fail` is kept as a "
+            "deprecated compatibility alias for `copy`."
+        ),
+    )
     return parser.parse_args()
+
+
+def normalize_bridge_mode(value: str) -> str:
+    if value == BRIDGE_MODE_COPY_ON_FAIL:
+        return BRIDGE_MODE_COPY
+    return value
 
 
 def resolve_repo_root(value: str) -> Path:
@@ -88,6 +131,97 @@ def write_text(path: Path, content: str) -> None:
     path.write_text(content.rstrip() + "\n", encoding="utf-8", newline="\n")
 
 
+def write_bytes(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def sha256_digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def sha256_path(path: Path) -> str:
+    return sha256_digest(path.read_bytes())
+
+
+def relative_repo_path(path: Path, repo_root: Path) -> str:
+    try:
+        resolved_path = path.resolve()
+    except OSError as exc:
+        raise RuntimeError(
+            "Failed to resolve bootstrap bridge source path: "
+            f"{path.as_posix()}."
+        ) from exc
+    try:
+        return resolved_path.relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise RuntimeError(
+            "Bootstrap bridge source path must resolve inside the repository root: "
+            f"{path.as_posix()}."
+        ) from exc
+
+
+def default_bridge_state() -> dict[str, object]:
+    return {
+        "kind": BRIDGE_STATE_KIND,
+        "version": BRIDGE_STATE_VERSION,
+        "agents": {},
+        "skills": {},
+    }
+
+
+def load_bridge_state(repo_root: Path) -> dict[str, object]:
+    state_path = repo_root / BRIDGE_STATE_RELATIVE
+    if not state_path.exists():
+        return default_bridge_state()
+
+    try:
+        state = json.loads(read_text(state_path))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "Malformed bootstrap bridge state at "
+            f"{state_path.as_posix()}."
+        ) from exc
+
+    if not isinstance(state, dict):
+        raise RuntimeError(
+            "Malformed bootstrap bridge state at "
+            f"{state_path.as_posix()}."
+        )
+    if state.get("kind") != BRIDGE_STATE_KIND or state.get("version") != BRIDGE_STATE_VERSION:
+        raise RuntimeError(
+            "Unsupported bootstrap bridge state at "
+            f"{state_path.as_posix()}."
+        )
+    for key in ("agents", "skills"):
+        if not isinstance(state.get(key), dict):
+            raise RuntimeError(
+                "Malformed bootstrap bridge state at "
+                f"{state_path.as_posix()}."
+            )
+    return state
+
+
+def save_bridge_state(repo_root: Path, state: dict[str, object]) -> None:
+    write_text(
+        repo_root / BRIDGE_STATE_RELATIVE,
+        json.dumps(state, indent=2, ensure_ascii=True),
+    )
+
+
+def delete_bridge_state(repo_root: Path) -> None:
+    state_path = repo_root / BRIDGE_STATE_RELATIVE
+    if state_path.exists():
+        state_path.unlink()
+
+
+def persist_bridge_state(repo_root: Path, state: dict[str, object]) -> None:
+    if bridge_state_has_entries(state):
+        save_bridge_state(repo_root, state)
+    else:
+        delete_bridge_state(repo_root)
+
+
 def render_agents_block() -> str:
     return "\n".join(
         [
@@ -100,13 +234,20 @@ def render_agents_block() -> str:
             ),
             (
                 "- `.codex/agents/` is the project-scoped subagent discovery "
-                "surface. Vendored foundry agent TOMLs are bridged there from "
+                "surface. Bootstrap writes managed copies of vendored foundry "
+                "agent TOMLs there from "
                 "`.codex/vendor/packetflow_foundry/.codex/agents/`."
             ),
             (
                 "- `.agents/skills/` is a thin discovery-wrapper surface. "
-                "Reusable retained kernels stay under "
+                "Bootstrap writes managed copies of vendored wrappers there "
+                "while reusable retained kernels stay under "
                 "`.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`."
+            ),
+            (
+                "- Rerun consumer bootstrap after updating the vendor subtree "
+                "to refresh managed agent and skill copies that were not "
+                "modified locally."
             ),
             "- Do not edit `.codex/vendor/packetflow_foundry` for local needs.",
             (
@@ -151,6 +292,35 @@ def append_block(existing: str, block: str) -> str:
 def ensure_agents_target(path: Path) -> None:
     if path.exists() and not path.is_file():
         raise RuntimeError(f"AGENTS target is not a file: {path.as_posix()}")
+
+
+def ensure_gitignore_target(path: Path) -> None:
+    if path.exists() and not path.is_file():
+        raise RuntimeError(f".gitignore target is not a file: {path.as_posix()}")
+
+
+def contains_codex_tmp_gitignore(text: str) -> bool:
+    return any(line.strip() in CODEX_TMP_GITIGNORE_ALIASES for line in text.splitlines())
+
+
+def append_gitignore_entry(existing: str, entry: str) -> str:
+    stripped = existing.rstrip()
+    if not stripped:
+        return entry
+    return stripped + "\n" + entry
+
+
+def update_gitignore(repo_root: Path) -> str:
+    path = repo_root / GITIGNORE_RELATIVE
+    ensure_gitignore_target(path)
+    if not path.exists():
+        write_text(path, CODEX_TMP_GITIGNORE_ENTRY)
+        return f"created with {CODEX_TMP_GITIGNORE_ENTRY}"
+    existing = read_text(path)
+    if contains_codex_tmp_gitignore(existing):
+        return "unchanged"
+    write_text(path, append_gitignore_entry(existing, CODEX_TMP_GITIGNORE_ENTRY))
+    return f"appended {CODEX_TMP_GITIGNORE_ENTRY}"
 
 
 def update_root_agents(repo_root: Path) -> str:
@@ -240,11 +410,28 @@ def render_project_local_profile(repo_root: Path) -> str:
     )
 
 
+def is_existing_project_local_profile(path: Path) -> bool:
+    try:
+        document = json.loads(read_text(path))
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(document, dict):
+        return False
+    return (
+        document.get("kind") == PROJECT_LOCAL_PROFILE_KIND
+        and document.get("profile_path") == PROJECT_PROFILE_RELATIVE.as_posix()
+    )
+
+
 def preflight_non_agents(repo_root: Path) -> None:
     conflicts: list[str] = []
     for relative_path in CONFLICT_TARGETS:
         target = repo_root / relative_path
         if target.exists():
+            if relative_path == PROJECT_PROFILE_RELATIVE and is_existing_project_local_profile(
+                target
+            ):
+                continue
             conflicts.append(relative_path.as_posix())
     if conflicts:
         joined = ", ".join(conflicts)
@@ -280,9 +467,81 @@ def iter_skill_directories(root: Path) -> dict[str, Path]:
         return {}
     skills: dict[str, Path] = {}
     for child in sorted(root.iterdir(), key=lambda entry: entry.name):
+        if child.is_dir():
+            validate_managed_source_directory(
+                child,
+                source_root=root,
+                bridge_kind="skill",
+                root_label="skill root",
+            )
         if child.is_dir() and (child / "SKILL.md").is_file():
             skills[child.name] = child
     return skills
+
+
+def path_has_reparse_point(path: Path) -> bool:
+    try:
+        file_attributes = getattr(path.lstat(), "st_file_attributes", 0)
+    except OSError:
+        return False
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    return bool(reparse_flag and file_attributes & reparse_flag)
+
+
+def validate_managed_source_directory(
+    path: Path,
+    *,
+    source_root: Path,
+    bridge_kind: str,
+    root_label: str,
+) -> None:
+    if path.is_symlink() or path_has_reparse_point(path):
+        raise RuntimeError(
+            f"Managed {bridge_kind} bridge source contains unsupported linked directory: "
+            f"{path.as_posix()}."
+        )
+    try:
+        resolved_path = path.resolve()
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to resolve managed {bridge_kind} bridge source: "
+            f"{path.as_posix()}."
+        ) from exc
+    try:
+        resolved_path.relative_to(source_root.resolve())
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Managed {bridge_kind} bridge source resolves outside the {root_label}: "
+            f"{path.as_posix()}."
+        ) from exc
+
+
+def validate_managed_source_file(
+    path: Path,
+    *,
+    source_root: Path,
+    bridge_kind: str,
+    root_label: str,
+) -> None:
+    if path.is_symlink():
+        raise RuntimeError(
+            f"Managed {bridge_kind} bridge source contains unsupported symlinked file: "
+            f"{path.as_posix()}."
+        )
+    try:
+        resolved_path = path.resolve()
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to resolve managed {bridge_kind} bridge source: "
+            f"{path.as_posix()}."
+        ) from exc
+    try:
+        resolved_path.relative_to(source_root.resolve())
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Managed {bridge_kind} bridge source resolves outside the {root_label}: "
+            f"{path.as_posix()}."
+        ) from exc
 
 
 def iter_agent_files(root: Path) -> dict[str, Path]:
@@ -291,62 +550,656 @@ def iter_agent_files(root: Path) -> dict[str, Path]:
     agents: dict[str, Path] = {}
     for child in sorted(root.iterdir(), key=lambda entry: entry.name):
         if child.is_file() and child.suffix == ".toml":
+            validate_managed_source_file(
+                child,
+                source_root=root,
+                bridge_kind="agent",
+                root_label="agent root",
+            )
             agents[child.name] = child
     return agents
 
 
-def relative_link_target(source: Path, *, target_parent: Path) -> Path:
-    return Path(os.path.relpath(source, start=target_parent))
+def iter_relative_files(root: Path) -> dict[str, Path]:
+    if not root.is_dir():
+        return {}
+    files: dict[str, Path] = {}
+    for child in sorted(root.rglob("*")):
+        if child.is_file():
+            files[child.relative_to(root).as_posix()] = child
+    return files
 
 
-def create_symlink(link_path: Path, source_path: Path, *, is_directory: bool) -> str:
-    link_path.parent.mkdir(parents=True, exist_ok=True)
-    relative_target = relative_link_target(source_path, target_parent=link_path.parent)
+def remove_empty_parent_dirs(path: Path, *, stop: Path) -> None:
+    current = path.parent
+    while current != stop and current.exists():
+        if any(current.iterdir()):
+            return
+        current.rmdir()
+        current = current.parent
+
+
+def path_is_within(path: Path, root: Path) -> bool:
     try:
-        link_path.symlink_to(relative_target, target_is_directory=is_directory)
-    except OSError as exc:
-        kind = "directory" if is_directory else "file"
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def same_resolved_path(path: Path, other: Path) -> bool:
+    try:
+        return path.resolve() == other.resolve()
+    except OSError:
+        return False
+
+
+def maybe_remove_expected_bridge_symlink(target_path: Path, source_path: Path) -> bool:
+    if not target_path.is_symlink():
+        return False
+    if not same_resolved_path(target_path, source_path):
+        return False
+    target_path.unlink()
+    return True
+
+
+def skill_bridge_anchor(repo_root: Path, source_root: Path) -> Path | None:
+    vendor_skills_root = repo_root / ".codex" / "vendor" / "packetflow_foundry" / ".agents" / "skills"
+    legacy_skills_root = repo_root / LEGACY_PROJECT_SKILLS_RELATIVE
+    if path_is_within(source_root, vendor_skills_root):
+        return repo_root / ".codex" / "vendor" / "packetflow_foundry"
+    if path_is_within(source_root, legacy_skills_root):
+        return repo_root
+    return None
+
+
+def rewrite_skill_wrapper_for_target(
+    repo_root: Path,
+    source_root: Path,
+    target_root: Path,
+    content: bytes,
+) -> bytes:
+    anchor = skill_bridge_anchor(repo_root, source_root)
+    if anchor is None:
+        return content
+
+    source_prefix = Path(os.path.relpath(anchor / "builders", start=source_root)).as_posix()
+    target_prefix = Path(os.path.relpath(anchor / "builders", start=target_root)).as_posix()
+    source_token = f"{source_prefix}/"
+    target_token = f"{target_prefix}/"
+
+    text = content.decode("utf-8")
+    if source_token not in text:
+        return content
+    return text.replace(source_token, target_token).encode("utf-8")
+
+
+def build_skill_bridge_files(
+    repo_root: Path,
+    source_root: Path,
+    target_root: Path,
+) -> dict[str, bytes]:
+    copied_files: dict[str, bytes] = {}
+    for relative_path, source_file in iter_relative_files(source_root).items():
+        validate_managed_source_file(
+            source_file,
+            source_root=source_root,
+            bridge_kind="skill",
+            root_label="skill root",
+        )
+        content = source_file.read_bytes()
+        if relative_path == "SKILL.md":
+            content = rewrite_skill_wrapper_for_target(
+                repo_root,
+                source_root,
+                target_root,
+                content,
+            )
+        copied_files[relative_path] = content
+    return copied_files
+
+
+def append_bridge_event(
+    events: list[BridgeEvent],
+    *,
+    bridge_kind: str,
+    status: str,
+    detail: str,
+    legacy: bool = False,
+    migrated: bool = False,
+) -> None:
+    if status == "unchanged":
+        return
+
+    words: list[str] = []
+    if status == "refreshed":
+        words.append("refreshed")
+    if migrated:
+        words.append("migrated")
+    if legacy:
+        words.append("legacy")
+    if status == "removed":
+        words.append("removed")
+    elif status in {"copied", "refreshed"}:
+        words.append("copied")
+    elif status == "skipped":
+        words.append("skipped")
+    else:
+        raise RuntimeError(f"Unsupported bridge status: {status}")
+
+    words.extend((bridge_kind, "bridge"))
+    events.append((" ".join(words), detail))
+
+
+def bridge_state_group(
+    state: dict[str, object],
+    key: str,
+) -> dict[str, object]:
+    group = state.get(key)
+    if not isinstance(group, dict):
         raise RuntimeError(
-            f"Failed to create {kind} symlink "
-            f"{link_path.as_posix()} -> {source_path.as_posix()}. "
-            "Enable Windows Developer Mode or run the bootstrap with permissions "
-            "that allow symbolic links."
-        ) from exc
-    return f"{link_path.as_posix()} -> {source_path.as_posix()}"
+            "Malformed bootstrap bridge state at "
+            f"{BRIDGE_STATE_RELATIVE.as_posix()}."
+        )
+    return group
 
 
-def create_skill_bridges(repo_root: Path, vendor_skills_root: Path) -> dict[str, list[str]]:
+def build_file_copy_state_entry(repo_root: Path, source_path: Path) -> dict[str, str]:
+    return {
+        "type": "file-copy",
+        "source": relative_repo_path(source_path, repo_root),
+        "sha256": sha256_path(source_path),
+    }
+
+
+def build_directory_copy_state_entry(
+    repo_root: Path,
+    source_root: Path,
+    copied_files: dict[str, bytes],
+) -> dict[str, object]:
+    return {
+        "type": "directory-copy",
+        "source": relative_repo_path(source_root, repo_root),
+        "files": {
+            relative_path: {"sha256": sha256_digest(content)}
+            for relative_path, content in copied_files.items()
+        },
+    }
+
+
+def validate_file_copy_state_entry(
+    entry: object,
+    *,
+    bridge_name: str,
+) -> str:
+    if not isinstance(entry, dict) or entry.get("type") != "file-copy":
+        raise RuntimeError(f"Malformed managed file copy state for {bridge_name}.")
+    expected_hash = entry.get("sha256")
+    if not isinstance(expected_hash, str):
+        raise RuntimeError(f"Malformed managed file copy state for {bridge_name}.")
+    return expected_hash
+
+
+def validate_directory_copy_state_entry(
+    entry: object,
+    *,
+    bridge_name: str,
+) -> dict[str, str]:
+    if not isinstance(entry, dict) or entry.get("type") != "directory-copy":
+        raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
+    raw_files = entry.get("files")
+    if not isinstance(raw_files, dict):
+        raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
+
+    validated: dict[str, str] = {}
+    for relative_path, metadata in raw_files.items():
+        if not isinstance(relative_path, str) or not isinstance(metadata, dict):
+            raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
+        expected_hash = metadata.get("sha256")
+        if not isinstance(expected_hash, str):
+            raise RuntimeError(f"Malformed managed directory copy state for {bridge_name}.")
+        validated[relative_path] = expected_hash
+    return validated
+
+
+def sync_directory_copy(
+    target_root: Path,
+    copied_files: dict[str, bytes],
+    *,
+    previous_files: set[str] | None = None,
+) -> None:
+    target_root.mkdir(parents=True, exist_ok=True)
+    if previous_files is not None:
+        for relative_path in sorted(previous_files - set(copied_files)):
+            stale_file = target_root / Path(relative_path)
+            if stale_file.exists():
+                stale_file.unlink()
+                remove_empty_parent_dirs(stale_file, stop=target_root)
+
+    for relative_path, content in copied_files.items():
+        write_bytes(target_root / Path(relative_path), content)
+
+
+def sync_managed_file_copy(
+    repo_root: Path,
+    source_path: Path,
+    target_path: Path,
+    *,
+    bridge_name: str,
+    state_group: dict[str, object],
+) -> tuple[str, str, str | None]:
+    state_entry = build_file_copy_state_entry(repo_root, source_path)
+    source_hash = str(state_entry["sha256"])
+    entry = state_group.get(bridge_name)
+    if entry is not None:
+        expected_hash = validate_file_copy_state_entry(entry, bridge_name=bridge_name)
+        existed_before = target_path.exists()
+        if target_path.exists():
+            if target_path.is_symlink() or not target_path.is_file():
+                return (
+                    "skipped",
+                    (
+                        f"{target_path.as_posix()} "
+                        "(managed copy target is no longer a regular file)"
+                    ),
+                    (
+                        "Managed copied agent bridge no longer points to a regular file: "
+                        f"{target_path.as_posix()}. Remove it to resume bootstrap refreshes."
+                    ),
+                )
+            current_hash = sha256_path(target_path)
+            if current_hash != expected_hash:
+                return (
+                    "skipped",
+                    (
+                        f"{target_path.as_posix()} "
+                        "(managed copy was modified locally; leaving in place)"
+                    ),
+                    (
+                        "Managed copied agent bridge was modified locally and was not "
+                        f"overwritten: {target_path.as_posix()}."
+                    ),
+                )
+            if source_hash == expected_hash:
+                return "unchanged", target_path.as_posix(), None
+
+        write_bytes(target_path, source_path.read_bytes())
+        state_group[bridge_name] = state_entry
+        status = "refreshed" if existed_before else "copied"
+        return status, f"{target_path.as_posix()} <- {source_path.as_posix()}", None
+
+    write_bytes(target_path, source_path.read_bytes())
+    state_group[bridge_name] = state_entry
+    return "copied", f"{target_path.as_posix()} <- {source_path.as_posix()}", None
+
+
+def sync_managed_directory_copy(
+    repo_root: Path,
+    source_root: Path,
+    target_root: Path,
+    *,
+    bridge_name: str,
+    state_group: dict[str, object],
+) -> tuple[str, str, str | None]:
+    validate_managed_source_directory(
+        source_root,
+        source_root=source_root,
+        bridge_kind="skill",
+        root_label="skill root",
+    )
+    relative_repo_path(source_root, repo_root)
+    copied_files = build_skill_bridge_files(repo_root, source_root, target_root)
+    state_entry = build_directory_copy_state_entry(
+        repo_root,
+        source_root,
+        copied_files,
+    )
+    entry = state_group.get(bridge_name)
+    if entry is not None:
+        expected_hashes = validate_directory_copy_state_entry(entry, bridge_name=bridge_name)
+        if target_root.exists():
+            if target_root.is_symlink() or not target_root.is_dir():
+                return (
+                    "skipped",
+                    (
+                        f"{target_root.as_posix()} "
+                        "(managed copy target is no longer a regular directory)"
+                    ),
+                    (
+                        "Managed copied skill bridge no longer points to a regular directory: "
+                        f"{target_root.as_posix()}. Remove it to resume bootstrap refreshes."
+                    ),
+                )
+
+            target_files = iter_relative_files(target_root)
+            for relative_path, target_file in target_files.items():
+                if target_file.is_symlink() or not target_file.is_file():
+                    return (
+                        "skipped",
+                        (
+                            f"{target_root.as_posix()} "
+                            "(managed copy contents were modified locally; leaving in place)"
+                        ),
+                        (
+                            "Managed copied skill bridge was modified locally and was not "
+                            f"overwritten: {target_root.as_posix()}."
+                        ),
+                    )
+                expected_hash = expected_hashes.get(relative_path)
+                if expected_hash is None:
+                    return (
+                        "skipped",
+                        (
+                            f"{target_root.as_posix()} "
+                            "(managed copy contents were modified locally; leaving in place)"
+                        ),
+                        (
+                            "Managed copied skill bridge was modified locally and was not "
+                            f"overwritten: {target_root.as_posix()}."
+                        ),
+                    )
+                if sha256_path(target_file) != expected_hash:
+                    return (
+                        "skipped",
+                        (
+                            f"{target_root.as_posix()} "
+                            "(managed copy contents were modified locally; leaving in place)"
+                        ),
+                        (
+                            "Managed copied skill bridge was modified locally and was not "
+                            f"overwritten: {target_root.as_posix()}."
+                        ),
+                    )
+
+            copied_hashes = {
+                relative_path: sha256_digest(content)
+                for relative_path, content in copied_files.items()
+            }
+            if copied_hashes == expected_hashes and set(target_files) == set(expected_hashes):
+                return "unchanged", target_root.as_posix(), None
+
+            sync_directory_copy(
+                target_root,
+                copied_files,
+                previous_files=set(target_files),
+            )
+            state_group[bridge_name] = state_entry
+            return "refreshed", f"{target_root.as_posix()} <- {source_root.as_posix()}", None
+
+    sync_directory_copy(target_root, copied_files)
+    state_group[bridge_name] = state_entry
+    return "copied", f"{target_root.as_posix()} <- {source_root.as_posix()}", None
+
+
+def prune_stale_managed_file_copy(
+    target_path: Path,
+    *,
+    managed_root: Path,
+    bridge_name: str,
+    state_group: dict[str, object],
+) -> tuple[str, str, str | None]:
+    entry = state_group.get(bridge_name)
+    if entry is None:
+        return "unchanged", target_path.as_posix(), None
+
+    expected_hash = validate_file_copy_state_entry(entry, bridge_name=bridge_name)
+    if not target_path.exists():
+        state_group.pop(bridge_name, None)
+        return "unchanged", target_path.as_posix(), None
+    if target_path.is_symlink() or not target_path.is_file():
+        return (
+            "skipped",
+            (
+                f"{target_path.as_posix()} "
+                "(managed copy target is no longer a regular file after upstream deletion)"
+            ),
+            (
+                "Managed copied agent bridge no longer points to a regular file after "
+                f"upstream deletion: {target_path.as_posix()}. Remove it to clear the "
+                "stale bootstrap entry."
+            ),
+        )
+
+    current_hash = sha256_path(target_path)
+    if current_hash != expected_hash:
+        return (
+            "skipped",
+            (
+                f"{target_path.as_posix()} "
+                "(managed copy was modified locally after upstream deletion; leaving in place)"
+            ),
+            (
+                "Managed copied agent bridge was modified locally after upstream deletion "
+                f"and was not removed: {target_path.as_posix()}."
+            ),
+        )
+
+    target_path.unlink()
+    remove_empty_parent_dirs(target_path, stop=managed_root)
+    state_group.pop(bridge_name, None)
+    return "removed", f"{target_path.as_posix()} (upstream source was deleted)", None
+
+
+def prune_stale_managed_directory_copy(
+    target_root: Path,
+    *,
+    managed_root: Path,
+    bridge_name: str,
+    state_group: dict[str, object],
+) -> tuple[str, str, str | None]:
+    entry = state_group.get(bridge_name)
+    if entry is None:
+        return "unchanged", target_root.as_posix(), None
+
+    expected_hashes = validate_directory_copy_state_entry(entry, bridge_name=bridge_name)
+    if not target_root.exists():
+        state_group.pop(bridge_name, None)
+        return "unchanged", target_root.as_posix(), None
+    if target_root.is_symlink() or not target_root.is_dir():
+        return (
+            "skipped",
+            (
+                f"{target_root.as_posix()} "
+                "(managed copy target is no longer a regular directory after upstream deletion)"
+            ),
+            (
+                "Managed copied skill bridge no longer points to a regular directory after "
+                f"upstream deletion: {target_root.as_posix()}. Remove it to clear the stale "
+                "bootstrap entry."
+            ),
+        )
+
+    target_files = iter_relative_files(target_root)
+    if set(target_files) != set(expected_hashes):
+        return (
+            "skipped",
+            (
+                f"{target_root.as_posix()} "
+                "(managed copy contents were modified locally after upstream deletion; leaving in place)"
+            ),
+            (
+                "Managed copied skill bridge was modified locally after upstream deletion "
+                f"and was not removed: {target_root.as_posix()}."
+            ),
+        )
+
+    for relative_path, target_file in target_files.items():
+        if target_file.is_symlink() or not target_file.is_file():
+            return (
+                "skipped",
+                (
+                    f"{target_root.as_posix()} "
+                    "(managed copy contents were modified locally after upstream deletion; leaving in place)"
+                ),
+                (
+                    "Managed copied skill bridge was modified locally after upstream deletion "
+                    f"and was not removed: {target_root.as_posix()}."
+                ),
+            )
+        if sha256_path(target_file) != expected_hashes[relative_path]:
+            return (
+                "skipped",
+                (
+                    f"{target_root.as_posix()} "
+                    "(managed copy contents were modified locally after upstream deletion; leaving in place)"
+                ),
+                (
+                    "Managed copied skill bridge was modified locally after upstream deletion "
+                    f"and was not removed: {target_root.as_posix()}."
+                ),
+            )
+
+    shutil.rmtree(target_root)
+    remove_empty_parent_dirs(target_root, stop=managed_root)
+    state_group.pop(bridge_name, None)
+    return "removed", f"{target_root.as_posix()} (upstream source was deleted)", None
+
+
+def bridge_state_has_entries(state: dict[str, object]) -> bool:
+    return bool(bridge_state_group(state, "agents")) or bool(bridge_state_group(state, "skills"))
+
+
+def create_skill_bridges(
+    repo_root: Path,
+    vendor_skills_root: Path,
+    *,
+    bridge_state: dict[str, object],
+) -> BridgeReport:
     root_skills = ensure_root_skill_dir(repo_root)
     vendor_skills = iter_skill_directories(vendor_skills_root)
     legacy_skills = iter_skill_directories(repo_root / LEGACY_PROJECT_SKILLS_RELATIVE)
+    skill_state = bridge_state_group(bridge_state, "skills")
 
-    created: list[str] = []
-    migrated: list[str] = []
-    skipped: list[str] = []
+    events: list[BridgeEvent] = []
     notices: list[str] = []
 
     for skill_name in sorted(set(vendor_skills) | set(legacy_skills)):
         target_path = root_skills / skill_name
-        if target_path.exists():
-            skipped.append(
-                f"{target_path.as_posix()} (existing root entry takes precedence)"
+        legacy_source = legacy_skills.get(skill_name)
+        source_path = legacy_source or vendor_skills[skill_name]
+        managed_copy_exists = skill_name in skill_state
+        if maybe_remove_expected_bridge_symlink(target_path, source_path):
+            status, detail, notice = sync_managed_directory_copy(
+                repo_root,
+                source_path,
+                target_path,
+                bridge_name=skill_name,
+                state_group=skill_state,
+            )
+            persist_bridge_state(repo_root, bridge_state)
+            append_bridge_event(
+                events,
+                bridge_kind="skill",
+                status=status,
+                detail=detail,
+                legacy=legacy_source is not None,
+                migrated=True,
+            )
+            if notice is not None:
+                notices.append(notice)
+            if legacy_source is not None:
+                notices.append(
+                    "Legacy `.codex/project/skills/` entry bridged for migration: "
+                    f"{skill_name}. Move canonical ownership to `.agents/skills/{skill_name}`."
+                )
+            continue
+
+        if target_path.is_symlink():
+            events.append(
+                (
+                    "skipped skill bridge",
+                    f"{target_path.as_posix()} (existing root symlink takes precedence)",
+                )
             )
             continue
 
-        legacy_source = legacy_skills.get(skill_name)
-        if legacy_source is not None:
-            migrated.append(
-                create_symlink(target_path, legacy_source, is_directory=True)
+        if target_path.exists():
+            if managed_copy_exists:
+                status, detail, notice = sync_managed_directory_copy(
+                    repo_root,
+                    source_path,
+                    target_path,
+                    bridge_name=skill_name,
+                    state_group=skill_state,
+                )
+                persist_bridge_state(repo_root, bridge_state)
+                append_bridge_event(
+                    events,
+                    bridge_kind="skill",
+                    status=status,
+                    detail=detail,
+                )
+                if notice is not None:
+                    notices.append(notice)
+                continue
+
+            events.append(
+                (
+                    "skipped skill bridge",
+                    f"{target_path.as_posix()} (existing root entry takes precedence)",
+                )
             )
+            continue
+
+        if legacy_source is not None:
+            status, detail, notice = sync_managed_directory_copy(
+                repo_root,
+                legacy_source,
+                target_path,
+                bridge_name=skill_name,
+                state_group=skill_state,
+            )
+            persist_bridge_state(repo_root, bridge_state)
+            append_bridge_event(
+                events,
+                bridge_kind="skill",
+                status=status,
+                detail=detail,
+                legacy=True,
+            )
+            if notice is not None:
+                notices.append(notice)
+
             notices.append(
                 "Legacy `.codex/project/skills/` entry bridged for migration: "
                 f"{skill_name}. Move canonical ownership to `.agents/skills/{skill_name}`."
             )
             continue
 
-        created.append(
-            create_symlink(target_path, vendor_skills[skill_name], is_directory=True)
+        status, detail, notice = sync_managed_directory_copy(
+            repo_root,
+            source_path,
+            target_path,
+            bridge_name=skill_name,
+            state_group=skill_state,
         )
+        persist_bridge_state(repo_root, bridge_state)
+        append_bridge_event(
+            events,
+            bridge_kind="skill",
+            status=status,
+            detail=detail,
+        )
+        if notice is not None:
+            notices.append(notice)
+
+    stale_skill_names = sorted(set(skill_state) - set(vendor_skills) - set(legacy_skills))
+    for skill_name in stale_skill_names:
+        status, detail, notice = prune_stale_managed_directory_copy(
+            root_skills / skill_name,
+            managed_root=root_skills,
+            bridge_name=skill_name,
+            state_group=skill_state,
+        )
+        persist_bridge_state(repo_root, bridge_state)
+        append_bridge_event(
+            events,
+            bridge_kind="skill",
+            status=status,
+            detail=detail,
+        )
+        if notice is not None:
+            notices.append(notice)
 
     if legacy_skills:
         notices.append(
@@ -354,36 +1207,113 @@ def create_skill_bridges(repo_root: Path, vendor_skills_root: Path) -> dict[str,
         )
 
     return {
-        "created": created,
-        "migrated": migrated,
-        "skipped": skipped,
+        "events": events,
         "notices": notices,
     }
 
 
-def create_agent_bridges(repo_root: Path, vendor_agents_root: Path) -> dict[str, list[str]]:
+def create_agent_bridges(
+    repo_root: Path,
+    vendor_agents_root: Path,
+    *,
+    bridge_state: dict[str, object],
+) -> BridgeReport:
     project_agents = ensure_project_agent_dir(repo_root)
     vendor_agents = iter_agent_files(vendor_agents_root)
     legacy_agents = iter_agent_files(repo_root / LEGACY_PROJECT_AGENTS_RELATIVE)
+    agent_state = bridge_state_group(bridge_state, "agents")
 
-    created: list[str] = []
-    migrated: list[str] = []
-    skipped: list[str] = []
+    events: list[BridgeEvent] = []
     notices: list[str] = []
 
     for agent_filename in sorted(set(vendor_agents) | set(legacy_agents)):
         target_path = project_agents / agent_filename
-        if target_path.exists():
-            skipped.append(
-                f"{target_path.as_posix()} (existing root entry takes precedence)"
+        legacy_source = legacy_agents.get(agent_filename)
+        source_path = legacy_source or vendor_agents[agent_filename]
+        managed_copy_exists = agent_filename in agent_state
+        if maybe_remove_expected_bridge_symlink(target_path, source_path):
+            status, detail, notice = sync_managed_file_copy(
+                repo_root,
+                source_path,
+                target_path,
+                bridge_name=agent_filename,
+                state_group=agent_state,
+            )
+            persist_bridge_state(repo_root, bridge_state)
+            append_bridge_event(
+                events,
+                bridge_kind="agent",
+                status=status,
+                detail=detail,
+                legacy=legacy_source is not None,
+                migrated=True,
+            )
+            if notice is not None:
+                notices.append(notice)
+            if legacy_source is not None:
+                notices.append(
+                    "Legacy `.codex/project/agents/` entry bridged for migration: "
+                    f"{Path(agent_filename).stem}. Move canonical ownership to "
+                    f"`.codex/agents/{agent_filename}`."
+                )
+            continue
+
+        if target_path.is_symlink():
+            events.append(
+                (
+                    "skipped agent bridge",
+                    f"{target_path.as_posix()} (existing root symlink takes precedence)",
+                )
             )
             continue
 
-        legacy_source = legacy_agents.get(agent_filename)
-        if legacy_source is not None:
-            migrated.append(
-                create_symlink(target_path, legacy_source, is_directory=False)
+        if target_path.exists():
+            if managed_copy_exists:
+                status, detail, notice = sync_managed_file_copy(
+                    repo_root,
+                    source_path,
+                    target_path,
+                    bridge_name=agent_filename,
+                    state_group=agent_state,
+                )
+                persist_bridge_state(repo_root, bridge_state)
+                append_bridge_event(
+                    events,
+                    bridge_kind="agent",
+                    status=status,
+                    detail=detail,
+                )
+                if notice is not None:
+                    notices.append(notice)
+                continue
+
+            events.append(
+                (
+                    "skipped agent bridge",
+                    f"{target_path.as_posix()} (existing root entry takes precedence)",
+                )
             )
+            continue
+
+        if legacy_source is not None:
+            status, detail, notice = sync_managed_file_copy(
+                repo_root,
+                legacy_source,
+                target_path,
+                bridge_name=agent_filename,
+                state_group=agent_state,
+            )
+            persist_bridge_state(repo_root, bridge_state)
+            append_bridge_event(
+                events,
+                bridge_kind="agent",
+                status=status,
+                detail=detail,
+                legacy=True,
+            )
+            if notice is not None:
+                notices.append(notice)
+
             notices.append(
                 "Legacy `.codex/project/agents/` entry bridged for migration: "
                 f"{Path(agent_filename).stem}. Move canonical ownership to "
@@ -391,9 +1321,40 @@ def create_agent_bridges(repo_root: Path, vendor_agents_root: Path) -> dict[str,
             )
             continue
 
-        created.append(
-            create_symlink(target_path, vendor_agents[agent_filename], is_directory=False)
+        status, detail, notice = sync_managed_file_copy(
+            repo_root,
+            source_path,
+            target_path,
+            bridge_name=agent_filename,
+            state_group=agent_state,
         )
+        persist_bridge_state(repo_root, bridge_state)
+        append_bridge_event(
+            events,
+            bridge_kind="agent",
+            status=status,
+            detail=detail,
+        )
+        if notice is not None:
+            notices.append(notice)
+
+    stale_agent_names = sorted(set(agent_state) - set(vendor_agents) - set(legacy_agents))
+    for agent_filename in stale_agent_names:
+        status, detail, notice = prune_stale_managed_file_copy(
+            project_agents / agent_filename,
+            managed_root=project_agents,
+            bridge_name=agent_filename,
+            state_group=agent_state,
+        )
+        persist_bridge_state(repo_root, bridge_state)
+        append_bridge_event(
+            events,
+            bridge_kind="agent",
+            status=status,
+            detail=detail,
+        )
+        if notice is not None:
+            notices.append(notice)
 
     if legacy_agents:
         notices.append(
@@ -401,9 +1362,7 @@ def create_agent_bridges(repo_root: Path, vendor_agents_root: Path) -> dict[str,
         )
 
     return {
-        "created": created,
-        "migrated": migrated,
-        "skipped": skipped,
+        "events": events,
         "notices": notices,
     }
 
@@ -412,6 +1371,15 @@ def create_non_agents(repo_root: Path) -> list[str]:
     created: list[str] = []
 
     profile_path = repo_root / PROJECT_PROFILE_RELATIVE
+    if profile_path.exists():
+        if not is_existing_project_local_profile(profile_path):
+            raise RuntimeError(
+                "Refusing to overwrite existing bootstrap outputs: "
+                f"{PROJECT_PROFILE_RELATIVE.as_posix()}. "
+                "AGENTS.md append targets are the only exception."
+            )
+        return created
+
     write_text(profile_path, render_project_local_profile(repo_root))
     created.append(PROJECT_PROFILE_RELATIVE.as_posix())
 
@@ -423,38 +1391,45 @@ def main() -> int:
 
     try:
         repo_root = resolve_repo_root(args.repo_root)
+        bridge_mode = normalize_bridge_mode(args.bridge_mode)
+        bridge_state = load_bridge_state(repo_root)
         vendor_dir = require_vendor_subtree(repo_root)
         vendor_agents_root = require_vendor_agents_root(vendor_dir)
         vendor_skills_root = require_vendor_skills_root(vendor_dir)
         preflight_non_agents(repo_root)
         root_agents_status = update_root_agents(repo_root)
         codex_agents_status = update_codex_agents(repo_root)
+        gitignore_status = update_gitignore(repo_root)
         created = create_non_agents(repo_root)
-        agent_bridge_report = create_agent_bridges(repo_root, vendor_agents_root)
-        bridge_report = create_skill_bridges(repo_root, vendor_skills_root)
+        agent_bridge_report = create_agent_bridges(
+            repo_root,
+            vendor_agents_root,
+            bridge_state=bridge_state,
+        )
+        persist_bridge_state(repo_root, bridge_state)
+        bridge_report = create_skill_bridges(
+            repo_root,
+            vendor_skills_root,
+            bridge_state=bridge_state,
+        )
+        persist_bridge_state(repo_root, bridge_state)
     except RuntimeError as exc:
         print(f"[ERROR] {exc}", file=sys.stderr)
         return 1
 
     print(f"[OK] Initialized PacketFlow consumer scaffold at {repo_root.as_posix()}")
+    print(f" - bridge mode: {bridge_mode}")
     print(f" - root AGENTS.md: {root_agents_status}")
     print(f" - .codex/AGENTS.md: {codex_agents_status}")
+    print(f" - {GITIGNORE_RELATIVE.as_posix()}: {gitignore_status}")
     for relative_path in created:
         print(f" - {relative_path}: created")
     print(f" - {PROJECT_AGENT_DISCOVERY_RELATIVE.as_posix()}: ready")
-    for bridge in agent_bridge_report["created"]:
-        print(f" - agent bridge: {bridge}")
-    for bridge in agent_bridge_report["migrated"]:
-        print(f" - legacy agent bridge: {bridge}")
-    for bridge in agent_bridge_report["skipped"]:
-        print(f" - skipped agent bridge: {bridge}")
+    for label, detail in agent_bridge_report["events"]:
+        print(f" - {label}: {detail}")
     print(f" - {ROOT_SKILLS_RELATIVE.as_posix()}: ready")
-    for bridge in bridge_report["created"]:
-        print(f" - skill bridge: {bridge}")
-    for bridge in bridge_report["migrated"]:
-        print(f" - legacy skill bridge: {bridge}")
-    for bridge in bridge_report["skipped"]:
-        print(f" - skipped skill bridge: {bridge}")
+    for label, detail in bridge_report["events"]:
+        print(f" - {label}: {detail}")
     for notice in agent_bridge_report["notices"]:
         print(f"[NOTICE] {notice}", file=sys.stderr)
     for notice in bridge_report["notices"]:

--- a/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+++ b/builders/consumer-bootstrap/scripts/init_consumer_codex.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Initialize the minimum `.codex` layout for a PacketFlow Foundry consumer repo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+FOUNDRY_KEYWORDS = (
+    "packetflow_foundry",
+    "packetflow foundry",
+    ".codex/vendor/packetflow_foundry",
+)
+BOOTSTRAP_MARKER_START = "<!-- packetflow_foundry consumer bootstrap:start -->"
+BOOTSTRAP_MARKER_END = "<!-- packetflow_foundry consumer bootstrap:end -->"
+CODEX_AGENTS_RELATIVE = Path(".codex/AGENTS.md")
+ROOT_AGENTS_RELATIVE = Path("AGENTS.md")
+PROJECT_PROFILE_RELATIVE = Path(".codex/project/profiles/default/profile.json")
+PROJECT_AGENT_DISCOVERY_RELATIVE = Path(".codex/agents")
+LEGACY_PROJECT_AGENTS_RELATIVE = Path(".codex/project/agents")
+ROOT_SKILLS_RELATIVE = Path(".agents/skills")
+LEGACY_PROJECT_SKILLS_RELATIVE = Path(".codex/project/skills")
+PROJECT_LOCAL_PROFILE_KIND = "project-local-scaffold-profile"
+CONFLICT_TARGETS = (
+    PROJECT_PROFILE_RELATIVE,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path.cwd()),
+        help="Consumer repository root. Defaults to the current directory.",
+    )
+    return parser.parse_args()
+
+
+def resolve_repo_root(value: str) -> Path:
+    repo_root = Path(value).resolve()
+    if not repo_root.exists():
+        raise RuntimeError(f"Missing repo root: {repo_root}")
+    if not repo_root.is_dir():
+        raise RuntimeError(f"Repo root is not a directory: {repo_root}")
+    return repo_root
+
+
+def require_vendor_subtree(repo_root: Path) -> Path:
+    vendor_dir = repo_root / ".codex" / "vendor" / "packetflow_foundry"
+    if not vendor_dir.is_dir():
+        raise RuntimeError(
+            "Missing PacketFlow Foundry vendor subtree at "
+            f"{vendor_dir.as_posix()}"
+        )
+    return vendor_dir
+
+
+def require_vendor_skills_root(vendor_dir: Path) -> Path:
+    vendor_skills = vendor_dir / ".agents" / "skills"
+    if not vendor_skills.is_dir():
+        raise RuntimeError(
+            "Missing PacketFlow Foundry vendor skills subtree at "
+            f"{vendor_skills.as_posix()}"
+        )
+    return vendor_skills
+
+
+def require_vendor_agents_root(vendor_dir: Path) -> Path:
+    vendor_agents = vendor_dir / ".codex" / "agents"
+    if not vendor_agents.is_dir():
+        raise RuntimeError(
+            "Missing PacketFlow Foundry vendor agents subtree at "
+            f"{vendor_agents.as_posix()}"
+        )
+    return vendor_agents
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8", newline="\n")
+
+
+def render_agents_block() -> str:
+    return "\n".join(
+        [
+            BOOTSTRAP_MARKER_START,
+            "## PacketFlow Foundry",
+            "- Vendor: `.codex/vendor/packetflow_foundry`",
+            (
+                "- Project-local overlays: `.codex/project/profiles/`, "
+                "`.agents/skills/`, `.codex/agents/`"
+            ),
+            (
+                "- `.codex/agents/` is the project-scoped subagent discovery "
+                "surface. Vendored foundry agent TOMLs are bridged there from "
+                "`.codex/vendor/packetflow_foundry/.codex/agents/`."
+            ),
+            (
+                "- `.agents/skills/` is a thin discovery-wrapper surface. "
+                "Reusable retained kernels stay under "
+                "`.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`."
+            ),
+            "- Do not edit `.codex/vendor/packetflow_foundry` for local needs.",
+            (
+                "- `.codex/project/profiles/default/profile.json` is a "
+                "project-local scaffold."
+            ),
+            (
+                "- Skill-specific packet-workflow overrides may live at "
+                "`.codex/project/profiles/<skill-name>/profile.json`."
+            ),
+            "- Legacy `.codex/project/agents/` is migration-only and should move to `.codex/agents/`.",
+            "- Legacy `.codex/project/skills/` is migration-only and should move to `.agents/skills/`.",
+            BOOTSTRAP_MARKER_END,
+        ]
+    )
+
+
+def render_codex_agents_file() -> str:
+    return "\n".join(
+        [
+            "# .codex AGENTS",
+            "",
+            render_agents_block(),
+        ]
+    )
+
+
+def contains_foundry_guidance(text: str) -> bool:
+    lowered = text.lower()
+    if BOOTSTRAP_MARKER_START in text:
+        return True
+    return any(keyword in lowered for keyword in FOUNDRY_KEYWORDS)
+
+
+def append_block(existing: str, block: str) -> str:
+    stripped = existing.rstrip()
+    if not stripped:
+        return block
+    return stripped + "\n\n" + block
+
+
+def ensure_agents_target(path: Path) -> None:
+    if path.exists() and not path.is_file():
+        raise RuntimeError(f"AGENTS target is not a file: {path.as_posix()}")
+
+
+def update_root_agents(repo_root: Path) -> str:
+    path = repo_root / ROOT_AGENTS_RELATIVE
+    ensure_agents_target(path)
+    if not path.exists():
+        return "not present"
+    existing = read_text(path)
+    if contains_foundry_guidance(existing):
+        return "unchanged"
+    write_text(path, append_block(existing, render_agents_block()))
+    return "appended foundry block"
+
+
+def update_codex_agents(repo_root: Path) -> str:
+    path = repo_root / CODEX_AGENTS_RELATIVE
+    ensure_agents_target(path)
+    if not path.exists():
+        write_text(path, render_codex_agents_file())
+        return "created"
+    existing = read_text(path)
+    if contains_foundry_guidance(existing):
+        return "unchanged"
+    write_text(path, append_block(existing, render_agents_block()))
+    return "appended foundry block"
+
+
+def project_root_markers(repo_root: Path) -> list[str]:
+    markers = [".git"]
+    if (repo_root / "README.md").is_file():
+        markers.append("README.md")
+    return markers
+
+
+def build_project_local_profile(repo_root: Path) -> dict[str, object]:
+    return {
+        "name": "default",
+        "kind": PROJECT_LOCAL_PROFILE_KIND,
+        "profile_path": PROJECT_PROFILE_RELATIVE.as_posix(),
+        "summary": (
+            "Project-local scaffold profile for this consumer repository. "
+            "This is not a reusable foundry overlay; replace the placeholder "
+            "values here with repo-specific bindings, review docs, and local notes."
+        ),
+        "repo_match": {
+            "root_markers": project_root_markers(repo_root),
+            "remote_patterns": [],
+        },
+        "bindings": {
+            "primary_readme_path": "README.md",
+            "settings_source_path": None,
+            "publish_config_path": None,
+        },
+        "packet_defaults": {
+            "review_docs": {},
+            "source_path_globs": {},
+        },
+        "lint_rules": {
+            "require_readme_settings_table": False,
+            "missing_review_docs_are_errors": False,
+        },
+        "notes": [
+            "This file is a project-local scaffold profile for one consumer repository.",
+            "It is not a reusable foundry overlay and should stay outside the vendor subtree.",
+            (
+                "Keep this profile data-only: add repo-specific bindings, globs, "
+                "review docs, booleans, and notes here."
+            ),
+            (
+                "Skill-specific packet-workflow bindings should live in "
+                "`.codex/project/profiles/<skill-name>/profile.json` instead "
+                "of this default scaffold."
+            ),
+            (
+                "Do not add executable hooks, prompt fragments, or packet routing "
+                "authority here."
+            ),
+        ],
+    }
+
+
+def render_project_local_profile(repo_root: Path) -> str:
+    return json.dumps(
+        build_project_local_profile(repo_root),
+        indent=2,
+        ensure_ascii=True,
+    )
+
+
+def preflight_non_agents(repo_root: Path) -> None:
+    conflicts: list[str] = []
+    for relative_path in CONFLICT_TARGETS:
+        target = repo_root / relative_path
+        if target.exists():
+            conflicts.append(relative_path.as_posix())
+    if conflicts:
+        joined = ", ".join(conflicts)
+        raise RuntimeError(
+            "Refusing to overwrite existing bootstrap outputs: "
+            f"{joined}. AGENTS.md append targets are the only exception."
+        )
+
+
+def ensure_root_skill_dir(repo_root: Path) -> Path:
+    root_skills = repo_root / ROOT_SKILLS_RELATIVE
+    if root_skills.exists() and not root_skills.is_dir():
+        raise RuntimeError(
+            f"Root skills target is not a directory: {root_skills.as_posix()}"
+        )
+    root_skills.mkdir(parents=True, exist_ok=True)
+    return root_skills
+
+
+def ensure_project_agent_dir(repo_root: Path) -> Path:
+    project_agents = repo_root / PROJECT_AGENT_DISCOVERY_RELATIVE
+    if project_agents.exists() and not project_agents.is_dir():
+        raise RuntimeError(
+            "Project-scoped agent discovery target is not a directory: "
+            f"{project_agents.as_posix()}"
+        )
+    project_agents.mkdir(parents=True, exist_ok=True)
+    return project_agents
+
+
+def iter_skill_directories(root: Path) -> dict[str, Path]:
+    if not root.is_dir():
+        return {}
+    skills: dict[str, Path] = {}
+    for child in sorted(root.iterdir(), key=lambda entry: entry.name):
+        if child.is_dir() and (child / "SKILL.md").is_file():
+            skills[child.name] = child
+    return skills
+
+
+def iter_agent_files(root: Path) -> dict[str, Path]:
+    if not root.is_dir():
+        return {}
+    agents: dict[str, Path] = {}
+    for child in sorted(root.iterdir(), key=lambda entry: entry.name):
+        if child.is_file() and child.suffix == ".toml":
+            agents[child.name] = child
+    return agents
+
+
+def relative_link_target(source: Path, *, target_parent: Path) -> Path:
+    return Path(os.path.relpath(source, start=target_parent))
+
+
+def create_symlink(link_path: Path, source_path: Path, *, is_directory: bool) -> str:
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    relative_target = relative_link_target(source_path, target_parent=link_path.parent)
+    try:
+        link_path.symlink_to(relative_target, target_is_directory=is_directory)
+    except OSError as exc:
+        kind = "directory" if is_directory else "file"
+        raise RuntimeError(
+            f"Failed to create {kind} symlink "
+            f"{link_path.as_posix()} -> {source_path.as_posix()}. "
+            "Enable Windows Developer Mode or run the bootstrap with permissions "
+            "that allow symbolic links."
+        ) from exc
+    return f"{link_path.as_posix()} -> {source_path.as_posix()}"
+
+
+def create_skill_bridges(repo_root: Path, vendor_skills_root: Path) -> dict[str, list[str]]:
+    root_skills = ensure_root_skill_dir(repo_root)
+    vendor_skills = iter_skill_directories(vendor_skills_root)
+    legacy_skills = iter_skill_directories(repo_root / LEGACY_PROJECT_SKILLS_RELATIVE)
+
+    created: list[str] = []
+    migrated: list[str] = []
+    skipped: list[str] = []
+    notices: list[str] = []
+
+    for skill_name in sorted(set(vendor_skills) | set(legacy_skills)):
+        target_path = root_skills / skill_name
+        if target_path.exists():
+            skipped.append(
+                f"{target_path.as_posix()} (existing root entry takes precedence)"
+            )
+            continue
+
+        legacy_source = legacy_skills.get(skill_name)
+        if legacy_source is not None:
+            migrated.append(
+                create_symlink(target_path, legacy_source, is_directory=True)
+            )
+            notices.append(
+                "Legacy `.codex/project/skills/` entry bridged for migration: "
+                f"{skill_name}. Move canonical ownership to `.agents/skills/{skill_name}`."
+            )
+            continue
+
+        created.append(
+            create_symlink(target_path, vendor_skills[skill_name], is_directory=True)
+        )
+
+    if legacy_skills:
+        notices.append(
+            "Legacy `.codex/project/skills/` is deprecated and remains migration-only."
+        )
+
+    return {
+        "created": created,
+        "migrated": migrated,
+        "skipped": skipped,
+        "notices": notices,
+    }
+
+
+def create_agent_bridges(repo_root: Path, vendor_agents_root: Path) -> dict[str, list[str]]:
+    project_agents = ensure_project_agent_dir(repo_root)
+    vendor_agents = iter_agent_files(vendor_agents_root)
+    legacy_agents = iter_agent_files(repo_root / LEGACY_PROJECT_AGENTS_RELATIVE)
+
+    created: list[str] = []
+    migrated: list[str] = []
+    skipped: list[str] = []
+    notices: list[str] = []
+
+    for agent_filename in sorted(set(vendor_agents) | set(legacy_agents)):
+        target_path = project_agents / agent_filename
+        if target_path.exists():
+            skipped.append(
+                f"{target_path.as_posix()} (existing root entry takes precedence)"
+            )
+            continue
+
+        legacy_source = legacy_agents.get(agent_filename)
+        if legacy_source is not None:
+            migrated.append(
+                create_symlink(target_path, legacy_source, is_directory=False)
+            )
+            notices.append(
+                "Legacy `.codex/project/agents/` entry bridged for migration: "
+                f"{Path(agent_filename).stem}. Move canonical ownership to "
+                f"`.codex/agents/{agent_filename}`."
+            )
+            continue
+
+        created.append(
+            create_symlink(target_path, vendor_agents[agent_filename], is_directory=False)
+        )
+
+    if legacy_agents:
+        notices.append(
+            "Legacy `.codex/project/agents/` is deprecated and remains migration-only."
+        )
+
+    return {
+        "created": created,
+        "migrated": migrated,
+        "skipped": skipped,
+        "notices": notices,
+    }
+
+
+def create_non_agents(repo_root: Path) -> list[str]:
+    created: list[str] = []
+
+    profile_path = repo_root / PROJECT_PROFILE_RELATIVE
+    write_text(profile_path, render_project_local_profile(repo_root))
+    created.append(PROJECT_PROFILE_RELATIVE.as_posix())
+
+    return created
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        repo_root = resolve_repo_root(args.repo_root)
+        vendor_dir = require_vendor_subtree(repo_root)
+        vendor_agents_root = require_vendor_agents_root(vendor_dir)
+        vendor_skills_root = require_vendor_skills_root(vendor_dir)
+        preflight_non_agents(repo_root)
+        root_agents_status = update_root_agents(repo_root)
+        codex_agents_status = update_codex_agents(repo_root)
+        created = create_non_agents(repo_root)
+        agent_bridge_report = create_agent_bridges(repo_root, vendor_agents_root)
+        bridge_report = create_skill_bridges(repo_root, vendor_skills_root)
+    except RuntimeError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+    print(f"[OK] Initialized PacketFlow consumer scaffold at {repo_root.as_posix()}")
+    print(f" - root AGENTS.md: {root_agents_status}")
+    print(f" - .codex/AGENTS.md: {codex_agents_status}")
+    for relative_path in created:
+        print(f" - {relative_path}: created")
+    print(f" - {PROJECT_AGENT_DISCOVERY_RELATIVE.as_posix()}: ready")
+    for bridge in agent_bridge_report["created"]:
+        print(f" - agent bridge: {bridge}")
+    for bridge in agent_bridge_report["migrated"]:
+        print(f" - legacy agent bridge: {bridge}")
+    for bridge in agent_bridge_report["skipped"]:
+        print(f" - skipped agent bridge: {bridge}")
+    print(f" - {ROOT_SKILLS_RELATIVE.as_posix()}: ready")
+    for bridge in bridge_report["created"]:
+        print(f" - skill bridge: {bridge}")
+    for bridge in bridge_report["migrated"]:
+        print(f" - legacy skill bridge: {bridge}")
+    for bridge in bridge_report["skipped"]:
+        print(f" - skipped skill bridge: {bridge}")
+    for notice in agent_bridge_report["notices"]:
+        print(f"[NOTICE] {notice}", file=sys.stderr)
+    for notice in bridge_report["notices"]:
+        print(f"[NOTICE] {notice}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/consumer-bootstrap/tests/test_consumer_bootstrap.py
+++ b/builders/consumer-bootstrap/tests/test_consumer_bootstrap.py
@@ -167,6 +167,16 @@ def relative_files(root: Path) -> list[str]:
     )
 
 
+def rewrite_line_endings(path: Path, newline: bytes) -> None:
+    content = path.read_bytes()
+    normalized = content.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    path.write_bytes(normalized.replace(b"\n", newline))
+
+
+def alternate_newline(content: bytes) -> bytes:
+    return b"\n" if b"\r\n" in content else b"\r\n"
+
+
 class ConsumerBootstrapTests(unittest.TestCase):
     def test_script_compiles(self) -> None:
         py_compile.compile(
@@ -597,8 +607,19 @@ class ConsumerBootstrapTests(unittest.TestCase):
                 (repo / bootstrap.BRIDGE_STATE_RELATIVE).read_text(encoding="utf-8")
             )
             self.assertEqual(bridge_state["kind"], bootstrap.BRIDGE_STATE_KIND)
+            self.assertEqual(bridge_state["version"], bootstrap.BRIDGE_STATE_VERSION)
             self.assertIn("vendor-agent.toml", bridge_state["agents"])
             self.assertIn("vendor-skill", bridge_state["skills"])
+            self.assertIn("raw_sha256", bridge_state["agents"]["vendor-agent.toml"])
+            self.assertIn("lf_sha256", bridge_state["agents"]["vendor-agent.toml"])
+            self.assertIn(
+                "raw_sha256",
+                bridge_state["skills"]["vendor-skill"]["files"]["SKILL.md"],
+            )
+            self.assertIn(
+                "lf_sha256",
+                bridge_state["skills"]["vendor-skill"]["files"]["SKILL.md"],
+            )
 
     def test_copy_refreshes_managed_copies_when_vendor_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -654,6 +675,39 @@ class ConsumerBootstrapTests(unittest.TestCase):
                 copied_skill.read_text(encoding="utf-8"),
                 'display_name: "Updated"\n',
             )
+
+    def test_copy_ignores_line_ending_only_target_changes_on_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            copied_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            copied_skill = (
+                repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "agents" / "openai.yaml"
+            )
+
+            rewrite_line_endings(copied_agent, alternate_newline(copied_agent.read_bytes()))
+            rewrite_line_endings(copied_skill, alternate_newline(copied_skill.read_bytes()))
+            expected_agent_bytes = copied_agent.read_bytes()
+            expected_skill_bytes = copied_skill.read_bytes()
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("refreshed copied agent bridge:", stdout)
+            self.assertNotIn("refreshed copied skill bridge:", stdout)
+            self.assertNotIn("skipped agent bridge:", stdout)
+            self.assertNotIn("skipped skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertEqual(copied_agent.read_bytes(), expected_agent_bytes)
+            self.assertEqual(copied_skill.read_bytes(), expected_skill_bytes)
 
     def test_sync_managed_file_copy_recreates_missing_target_once(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -1359,21 +1413,21 @@ class ConsumerBootstrapTests(unittest.TestCase):
             shutil.rmtree(vendor_skill)
 
             real_is_symlink = Path.is_symlink
-            real_sha256_path = bootstrap.sha256_path
+            real_hash_state_from_path = bootstrap.hash_state_from_path
 
             def fake_is_symlink(path: Path) -> bool:
                 if path == copied_skill:
                     return True
                 return real_is_symlink(path)
 
-            def fake_sha256_path(path: Path) -> str:
+            def fake_hash_state_from_path(path: Path) -> dict[str, str]:
                 if path == copied_skill:
                     raise OSError("symlink targets should not be hashed during prune")
-                return real_sha256_path(path)
+                return real_hash_state_from_path(path)
 
             with (
                 mock.patch.object(Path, "is_symlink", fake_is_symlink),
-                mock.patch.object(bootstrap, "sha256_path", fake_sha256_path),
+                mock.patch.object(bootstrap, "hash_state_from_path", fake_hash_state_from_path),
             ):
                 code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
 
@@ -1386,6 +1440,81 @@ class ConsumerBootstrapTests(unittest.TestCase):
                 (repo / bootstrap.BRIDGE_STATE_RELATIVE).read_text(encoding="utf-8")
             )
             self.assertIn("vendor-skill", bridge_state["skills"])
+
+    def test_copy_migrates_legacy_hash_state_for_line_ending_only_source_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            state_path = repo / bootstrap.BRIDGE_STATE_RELATIVE
+            bridge_state = json.loads(state_path.read_text(encoding="utf-8"))
+            agent_state = bridge_state["agents"]["vendor-agent.toml"]
+            agent_state.pop("raw_sha256", None)
+            agent_state.pop("lf_sha256", None)
+            for metadata in bridge_state["skills"]["vendor-skill"]["files"].values():
+                metadata.pop("raw_sha256", None)
+                metadata.pop("lf_sha256", None)
+            state_path.write_text(json.dumps(bridge_state, indent=2), encoding="utf-8")
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+                / "agents"
+                / "openai.yaml"
+            )
+            copied_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            copied_skill = (
+                repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "agents" / "openai.yaml"
+            )
+            expected_agent_bytes = copied_agent.read_bytes()
+            expected_skill_bytes = copied_skill.read_bytes()
+
+            rewrite_line_endings(vendor_agent, alternate_newline(vendor_agent.read_bytes()))
+            rewrite_line_endings(vendor_skill, alternate_newline(vendor_skill.read_bytes()))
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("refreshed copied agent bridge:", stdout)
+            self.assertNotIn("refreshed copied skill bridge:", stdout)
+            self.assertNotIn("skipped agent bridge:", stdout)
+            self.assertNotIn("skipped skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertEqual(copied_agent.read_bytes(), expected_agent_bytes)
+            self.assertEqual(copied_skill.read_bytes(), expected_skill_bytes)
+
+            migrated_state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertIn("raw_sha256", migrated_state["agents"]["vendor-agent.toml"])
+            self.assertIn("lf_sha256", migrated_state["agents"]["vendor-agent.toml"])
+            self.assertIn(
+                "raw_sha256",
+                migrated_state["skills"]["vendor-skill"]["files"]["agents/openai.yaml"],
+            )
+            self.assertIn(
+                "lf_sha256",
+                migrated_state["skills"]["vendor-skill"]["files"]["agents/openai.yaml"],
+            )
 
     def test_missing_vendor_subtree_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/builders/consumer-bootstrap/tests/test_consumer_bootstrap.py
+++ b/builders/consumer-bootstrap/tests/test_consumer_bootstrap.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import io
+import json
+import py_compile
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+PACKET_WORKFLOW_SCRIPT_DIR = Path(__file__).resolve().parents[2] / "packet-workflow" / "scripts"
+REWORD_SCRIPT_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "builders"
+    / "packet-workflow"
+    / "retained-skills"
+    / "reword-recent-commits"
+    / "scripts"
+)
+GIT_SPLIT_SCRIPT_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "builders"
+    / "packet-workflow"
+    / "retained-skills"
+    / "git-split-and-commit"
+    / "scripts"
+)
+for candidate in (SCRIPT_DIR, PACKET_WORKFLOW_SCRIPT_DIR, REWORD_SCRIPT_DIR, GIT_SPLIT_SCRIPT_DIR):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+import collect_recent_commits as reword_collect
+import collect_worktree_context as worktree_collect
+import init_consumer_codex as bootstrap
+
+
+def create_skill_dir(root: Path, name: str) -> Path:
+    skill_dir = root / name
+    (skill_dir / "agents").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: test skill\n---\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "agents" / "openai.yaml").write_text(
+        'display_name: "Test"\n',
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def create_agent_file(root: Path, name: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    agent_path = root / f"{name}.toml"
+    agent_path.write_text(
+        "\n".join(
+            [
+                f'name = "{name.replace("-", "_")}"',
+                'description = "test agent"',
+                'developer_instructions = """',
+                "Do not edit files.",
+                '"""',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return agent_path
+
+
+def create_consumer_repo(
+    root: Path,
+    *,
+    include_readme: bool = True,
+    root_agents_text: str | None = None,
+    codex_agents_text: str | None = None,
+    existing_profile: bool = False,
+    include_vendor: bool = True,
+    vendor_skill_names: list[str] | None = None,
+    vendor_agent_names: list[str] | None = None,
+    root_skill_names: list[str] | None = None,
+    root_agent_names: list[str] | None = None,
+    legacy_skill_names: list[str] | None = None,
+    legacy_agent_names: list[str] | None = None,
+) -> Path:
+    repo = root / "consumer"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    if include_readme:
+        (repo / "README.md").write_text("# Consumer Repo\n", encoding="utf-8")
+    if include_vendor:
+        vendor_skill_root = (
+            repo / ".codex" / "vendor" / "packetflow_foundry" / ".agents" / "skills"
+        )
+        vendor_skill_root.mkdir(parents=True)
+        for skill_name in vendor_skill_names or []:
+            create_skill_dir(vendor_skill_root, skill_name)
+        vendor_agent_root = (
+            repo / ".codex" / "vendor" / "packetflow_foundry" / ".codex" / "agents"
+        )
+        vendor_agent_root.mkdir(parents=True)
+        for agent_name in vendor_agent_names or []:
+            create_agent_file(vendor_agent_root, agent_name)
+    if root_agents_text is not None:
+        (repo / "AGENTS.md").write_text(root_agents_text, encoding="utf-8")
+    if codex_agents_text is not None:
+        codex_agents_path = repo / ".codex" / "AGENTS.md"
+        codex_agents_path.parent.mkdir(parents=True, exist_ok=True)
+        codex_agents_path.write_text(codex_agents_text, encoding="utf-8")
+    if existing_profile:
+        profile_path = repo / bootstrap.PROJECT_PROFILE_RELATIVE
+        profile_path.parent.mkdir(parents=True, exist_ok=True)
+        profile_path.write_text("{}", encoding="utf-8")
+    for skill_name in root_skill_names or []:
+        create_skill_dir(repo / bootstrap.ROOT_SKILLS_RELATIVE, skill_name)
+    for agent_name in root_agent_names or []:
+        create_agent_file(repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE, agent_name)
+    for skill_name in legacy_skill_names or []:
+        create_skill_dir(repo / bootstrap.LEGACY_PROJECT_SKILLS_RELATIVE, skill_name)
+    for agent_name in legacy_agent_names or []:
+        create_agent_file(repo / bootstrap.LEGACY_PROJECT_AGENTS_RELATIVE, agent_name)
+    return repo
+
+
+def run_bootstrap_main(
+    repo: Path,
+    *,
+    symlink_side_effect: Exception | None = None,
+) -> tuple[int, str, str, mock.Mock]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    symlink_mock = mock.Mock()
+    if symlink_side_effect is not None:
+        symlink_mock.side_effect = symlink_side_effect
+
+    with (
+        mock.patch.object(sys, "argv", ["init_consumer_codex.py", "--repo-root", str(repo)]),
+        mock.patch.object(Path, "symlink_to", symlink_mock),
+        redirect_stdout(stdout),
+        redirect_stderr(stderr),
+    ):
+        code = bootstrap.main()
+
+    return code, stdout.getvalue(), stderr.getvalue(), symlink_mock
+
+
+class ConsumerBootstrapTests(unittest.TestCase):
+    def test_script_compiles(self) -> None:
+        py_compile.compile(
+            str(SCRIPT_DIR / "init_consumer_codex.py"),
+            doraise=True,
+        )
+
+    def test_init_creates_codex_scaffold_without_root_agents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+            vendor_skill_dir = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            vendor_wrapper_files = sorted(
+                str(path.relative_to(vendor_skill_dir)).replace("\\", "/")
+                for path in vendor_skill_dir.rglob("*")
+                if path.is_file()
+            )
+            self.assertEqual(vendor_wrapper_files, ["SKILL.md", "agents/openai.yaml"])
+            vendor_agent_dir = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+            )
+            vendor_agent_files = sorted(
+                path.name for path in vendor_agent_dir.iterdir() if path.is_file()
+            )
+            self.assertEqual(vendor_agent_files, ["vendor-agent.toml"])
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertIn("root AGENTS.md: not present", stdout)
+            self.assertIn(".codex/AGENTS.md: created", stdout)
+            self.assertIn(".codex/agents: ready", stdout)
+            self.assertIn("agent bridge:", stdout)
+            self.assertIn("vendor-agent", stdout)
+            self.assertIn(".agents/skills: ready", stdout)
+            self.assertIn("skill bridge:", stdout)
+            self.assertIn("vendor-skill", stdout)
+            self.assertEqual(symlink_mock.call_count, 2)
+            self.assertFalse((repo / "AGENTS.md").exists())
+            self.assertTrue((repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE).is_dir())
+            self.assertTrue((repo / bootstrap.ROOT_SKILLS_RELATIVE).is_dir())
+
+            codex_agents = (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn(bootstrap.BOOTSTRAP_MARKER_START, codex_agents)
+            self.assertIn(".codex/agents/", codex_agents)
+            self.assertIn(
+                ".codex/vendor/packetflow_foundry/.codex/agents/",
+                codex_agents,
+            )
+            self.assertIn(".agents/skills/", codex_agents)
+            self.assertIn("thin discovery-wrapper surface", codex_agents)
+            self.assertIn(
+                ".codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/",
+                codex_agents,
+            )
+            self.assertIn(
+                ".codex/project/profiles/default/profile.json",
+                codex_agents,
+            )
+            self.assertIn(
+                ".codex/project/profiles/<skill-name>/profile.json",
+                codex_agents,
+            )
+
+            profile = json.loads(
+                (repo / bootstrap.PROJECT_PROFILE_RELATIVE).read_text(encoding="utf-8")
+            )
+            self.assertEqual(profile["kind"], bootstrap.PROJECT_LOCAL_PROFILE_KIND)
+            self.assertEqual(
+                profile["profile_path"],
+                bootstrap.PROJECT_PROFILE_RELATIVE.as_posix(),
+            )
+            self.assertEqual(profile["repo_match"]["root_markers"], [".git", "README.md"])
+            self.assertIn("project-local scaffold", profile["summary"].lower())
+            self.assertTrue(
+                any(
+                    "not a reusable foundry overlay" in note
+                    for note in profile["notes"]
+                )
+            )
+            self.assertTrue(
+                any(
+                    ".codex/project/profiles/<skill-name>/profile.json" in note
+                    for note in profile["notes"]
+                )
+            )
+            self.assertEqual(stderr.strip(), "")
+
+    def test_root_markers_skip_readme_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                include_readme=False,
+                vendor_skill_names=["vendor-skill"],
+            )
+
+            code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(code, 0)
+
+            profile = json.loads(
+                (repo / bootstrap.PROJECT_PROFILE_RELATIVE).read_text(encoding="utf-8")
+            )
+            self.assertEqual(profile["repo_match"]["root_markers"], [".git"])
+
+    def test_existing_agents_files_append_once_then_stay_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                root_agents_text="# Root AGENTS\n",
+                codex_agents_text="# Local Codex AGENTS\n",
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, first_stdout, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+            create_skill_dir(repo / bootstrap.ROOT_SKILLS_RELATIVE, "vendor-skill")
+            create_agent_file(repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE, "vendor-agent")
+            (repo / bootstrap.PROJECT_PROFILE_RELATIVE).unlink()
+
+            second_code, second_stdout, _, _ = run_bootstrap_main(repo)
+
+            self.assertEqual(second_code, 0)
+            self.assertIn("root AGENTS.md: appended foundry block", first_stdout)
+            self.assertIn(".codex/AGENTS.md: appended foundry block", first_stdout)
+            self.assertIn("root AGENTS.md: unchanged", second_stdout)
+            self.assertIn(".codex/AGENTS.md: unchanged", second_stdout)
+            self.assertIn("skipped agent bridge:", second_stdout)
+            self.assertIn("skipped skill bridge:", second_stdout)
+
+            root_agents = (repo / "AGENTS.md").read_text(encoding="utf-8")
+            codex_agents = (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertEqual(root_agents.count(bootstrap.BOOTSTRAP_MARKER_START), 1)
+            self.assertEqual(codex_agents.count(bootstrap.BOOTSTRAP_MARKER_START), 1)
+
+    def test_existing_agents_with_foundry_keywords_stay_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                root_agents_text=(
+                    "# Root AGENTS\n\nVendor path: .codex/vendor/packetflow_foundry\n"
+                ),
+                codex_agents_text="# Local Codex AGENTS\n\npacketflow_foundry note\n",
+                vendor_skill_names=["vendor-skill"],
+            )
+
+            root_before = (repo / "AGENTS.md").read_text(encoding="utf-8")
+            codex_before = (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+
+            code, stdout, _, _ = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertIn("root AGENTS.md: unchanged", stdout)
+            self.assertIn(".codex/AGENTS.md: unchanged", stdout)
+            self.assertEqual((repo / "AGENTS.md").read_text(encoding="utf-8"), root_before)
+            self.assertEqual(
+                (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8"),
+                codex_before,
+            )
+
+    def test_generated_profile_is_reader_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(Path(tmp), vendor_skill_names=["vendor-skill"])
+            code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(code, 0)
+
+            profile_path = repo / bootstrap.PROJECT_PROFILE_RELATIVE
+            worktree_profile = worktree_collect.load_repo_profile(profile_path)
+            reword_profile = reword_collect.load_repo_profile_document(profile_path)
+
+            self.assertEqual(worktree_profile["kind"], bootstrap.PROJECT_LOCAL_PROFILE_KIND)
+            self.assertEqual(
+                reword_profile["profile_path"],
+                bootstrap.PROJECT_PROFILE_RELATIVE.as_posix(),
+            )
+
+    def test_skill_specific_project_profile_is_preferred_by_vendored_collector_logic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(Path(tmp), vendor_skill_names=["vendor-skill"])
+            code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(code, 0)
+
+            skill_profile = (
+                repo
+                / ".codex"
+                / "project"
+                / "profiles"
+                / "reword-recent-commits"
+                / "profile.json"
+            )
+            skill_profile.parent.mkdir(parents=True, exist_ok=True)
+            skill_profile.write_text("{}", encoding="utf-8")
+
+            self.assertEqual(
+                reword_collect.default_repo_profile_path(repo),
+                skill_profile.resolve(),
+            )
+            self.assertEqual(
+                reword_collect.resolve_profile_path(
+                    ".codex/project/profiles/reword-recent-commits/profile.json",
+                    repo,
+                ),
+                skill_profile.resolve(),
+            )
+
+    def test_existing_root_skill_and_agent_skip_vendor_bridges(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+                root_skill_names=["vendor-skill"],
+                root_agent_names=["vendor-agent"],
+            )
+
+            code, stdout, _, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("skipped agent bridge:", stdout)
+            self.assertIn("vendor-agent", stdout)
+            self.assertIn("skipped skill bridge:", stdout)
+            self.assertIn("vendor-skill", stdout)
+
+    def test_legacy_project_skills_are_bridged_with_notice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["shared-skill"],
+                legacy_skill_names=["shared-skill", "legacy-only"],
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 2)
+            self.assertIn("legacy skill bridge:", stdout)
+            self.assertIn("legacy-only", stdout)
+            self.assertIn("shared-skill", stderr)
+            self.assertIn("Legacy `.codex/project/skills/` is deprecated", stderr)
+
+    def test_legacy_project_agents_are_bridged_with_notice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_agent_names=["shared-agent"],
+                legacy_agent_names=["shared-agent", "legacy-only"],
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 2)
+            self.assertIn("legacy agent bridge:", stdout)
+            self.assertIn("legacy-only.toml", stdout)
+            self.assertIn("shared-agent", stderr)
+            self.assertIn("Legacy `.codex/project/agents/` is deprecated", stderr)
+
+    def test_conflicting_generated_output_aborts_without_touching_agents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                root_agents_text="# Root AGENTS\n",
+                codex_agents_text="# Local Codex AGENTS\n",
+                existing_profile=True,
+                vendor_skill_names=["vendor-skill"],
+            )
+
+            code, _, stderr, _ = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertIn("Refusing to overwrite existing bootstrap outputs", stderr)
+            self.assertNotIn(
+                bootstrap.BOOTSTRAP_MARKER_START,
+                (repo / "AGENTS.md").read_text(encoding="utf-8"),
+            )
+            self.assertNotIn(
+                bootstrap.BOOTSTRAP_MARKER_START,
+                (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8"),
+            )
+            self.assertFalse((repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE).exists())
+
+    def test_symlink_failure_produces_clear_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(Path(tmp), vendor_skill_names=["vendor-skill"])
+
+            code, _, stderr, _ = run_bootstrap_main(
+                repo,
+                symlink_side_effect=OSError("no symlink permission"),
+            )
+
+            self.assertEqual(code, 1)
+            self.assertIn("Failed to create directory symlink", stderr)
+            self.assertIn("Enable Windows Developer Mode", stderr)
+
+    def test_missing_vendor_subtree_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(Path(tmp), include_vendor=False)
+
+            code, _, stderr, _ = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertIn("Missing PacketFlow Foundry vendor subtree", stderr)
+            self.assertFalse((repo / ".codex" / "AGENTS.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/builders/consumer-bootstrap/tests/test_consumer_bootstrap.py
+++ b/builders/consumer-bootstrap/tests/test_consumer_bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import py_compile
+import shutil
 import sys
 import tempfile
 import unittest
@@ -75,6 +76,7 @@ def create_consumer_repo(
     root: Path,
     *,
     include_readme: bool = True,
+    gitignore_text: str | None = None,
     root_agents_text: str | None = None,
     codex_agents_text: str | None = None,
     existing_profile: bool = False,
@@ -91,6 +93,8 @@ def create_consumer_repo(
     (repo / ".git").mkdir()
     if include_readme:
         (repo / "README.md").write_text("# Consumer Repo\n", encoding="utf-8")
+    if gitignore_text is not None:
+        (repo / ".gitignore").write_text(gitignore_text, encoding="utf-8")
     if include_vendor:
         vendor_skill_root = (
             repo / ".codex" / "vendor" / "packetflow_foundry" / ".agents" / "skills"
@@ -128,16 +132,24 @@ def create_consumer_repo(
 def run_bootstrap_main(
     repo: Path,
     *,
-    symlink_side_effect: Exception | None = None,
+    bridge_mode: str = bootstrap.BRIDGE_MODE_COPY,
 ) -> tuple[int, str, str, mock.Mock]:
     stdout = io.StringIO()
     stderr = io.StringIO()
     symlink_mock = mock.Mock()
-    if symlink_side_effect is not None:
-        symlink_mock.side_effect = symlink_side_effect
 
     with (
-        mock.patch.object(sys, "argv", ["init_consumer_codex.py", "--repo-root", str(repo)]),
+        mock.patch.object(
+            sys,
+            "argv",
+            [
+                "init_consumer_codex.py",
+                "--repo-root",
+                str(repo),
+                "--bridge-mode",
+                bridge_mode,
+            ],
+        ),
         mock.patch.object(Path, "symlink_to", symlink_mock),
         redirect_stdout(stdout),
         redirect_stderr(stderr),
@@ -145,6 +157,14 @@ def run_bootstrap_main(
         code = bootstrap.main()
 
     return code, stdout.getvalue(), stderr.getvalue(), symlink_mock
+
+
+def relative_files(root: Path) -> list[str]:
+    return sorted(
+        str(path.relative_to(root)).replace("\\", "/")
+        for path in root.rglob("*")
+        if path.is_file()
+    )
 
 
 class ConsumerBootstrapTests(unittest.TestCase):
@@ -192,18 +212,25 @@ class ConsumerBootstrapTests(unittest.TestCase):
             code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
 
             self.assertEqual(code, 0)
+            self.assertIn("bridge mode: copy", stdout)
             self.assertIn("root AGENTS.md: not present", stdout)
             self.assertIn(".codex/AGENTS.md: created", stdout)
+            self.assertIn(".gitignore: created with .codex/tmp/", stdout)
             self.assertIn(".codex/agents: ready", stdout)
-            self.assertIn("agent bridge:", stdout)
+            self.assertIn("copied agent bridge:", stdout)
             self.assertIn("vendor-agent", stdout)
             self.assertIn(".agents/skills: ready", stdout)
-            self.assertIn("skill bridge:", stdout)
+            self.assertIn("copied skill bridge:", stdout)
             self.assertIn("vendor-skill", stdout)
-            self.assertEqual(symlink_mock.call_count, 2)
+            self.assertEqual(symlink_mock.call_count, 0)
             self.assertFalse((repo / "AGENTS.md").exists())
             self.assertTrue((repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE).is_dir())
             self.assertTrue((repo / bootstrap.ROOT_SKILLS_RELATIVE).is_dir())
+            self.assertEqual(
+                (repo / ".gitignore").read_text(encoding="utf-8"),
+                ".codex/tmp/\n",
+            )
+            self.assertTrue((repo / bootstrap.BRIDGE_STATE_RELATIVE).is_file())
 
             codex_agents = (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
             self.assertIn(bootstrap.BOOTSTRAP_MARKER_START, codex_agents)
@@ -271,6 +298,7 @@ class ConsumerBootstrapTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             repo = create_consumer_repo(
                 Path(tmp),
+                gitignore_text="bin/\n",
                 root_agents_text="# Root AGENTS\n",
                 codex_agents_text="# Local Codex AGENTS\n",
                 vendor_skill_names=["vendor-skill"],
@@ -279,24 +307,39 @@ class ConsumerBootstrapTests(unittest.TestCase):
 
             first_code, first_stdout, _, _ = run_bootstrap_main(repo)
             self.assertEqual(first_code, 0)
-            create_skill_dir(repo / bootstrap.ROOT_SKILLS_RELATIVE, "vendor-skill")
-            create_agent_file(repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE, "vendor-agent")
-            (repo / bootstrap.PROJECT_PROFILE_RELATIVE).unlink()
 
             second_code, second_stdout, _, _ = run_bootstrap_main(repo)
 
             self.assertEqual(second_code, 0)
             self.assertIn("root AGENTS.md: appended foundry block", first_stdout)
             self.assertIn(".codex/AGENTS.md: appended foundry block", first_stdout)
+            self.assertIn(".gitignore: appended .codex/tmp/", first_stdout)
             self.assertIn("root AGENTS.md: unchanged", second_stdout)
             self.assertIn(".codex/AGENTS.md: unchanged", second_stdout)
-            self.assertIn("skipped agent bridge:", second_stdout)
-            self.assertIn("skipped skill bridge:", second_stdout)
+            self.assertIn(".gitignore: unchanged", second_stdout)
 
             root_agents = (repo / "AGENTS.md").read_text(encoding="utf-8")
             codex_agents = (repo / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+            gitignore = (repo / ".gitignore").read_text(encoding="utf-8")
             self.assertEqual(root_agents.count(bootstrap.BOOTSTRAP_MARKER_START), 1)
             self.assertEqual(codex_agents.count(bootstrap.BOOTSTRAP_MARKER_START), 1)
+            self.assertEqual(gitignore.count(".codex/tmp/"), 1)
+
+    def test_existing_gitignore_with_codex_tmp_stays_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                gitignore_text="bin/\n.codex/tmp\n",
+                vendor_skill_names=["vendor-skill"],
+            )
+
+            before = (repo / ".gitignore").read_text(encoding="utf-8")
+
+            code, stdout, _, _ = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertIn(".gitignore: unchanged", stdout)
+            self.assertEqual((repo / ".gitignore").read_text(encoding="utf-8"), before)
 
     def test_existing_agents_with_foundry_keywords_stay_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -398,8 +441,8 @@ class ConsumerBootstrapTests(unittest.TestCase):
             code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
 
             self.assertEqual(code, 0)
-            self.assertEqual(symlink_mock.call_count, 2)
-            self.assertIn("legacy skill bridge:", stdout)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("legacy copied skill bridge:", stdout)
             self.assertIn("legacy-only", stdout)
             self.assertIn("shared-skill", stderr)
             self.assertIn("Legacy `.codex/project/skills/` is deprecated", stderr)
@@ -415,8 +458,8 @@ class ConsumerBootstrapTests(unittest.TestCase):
             code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
 
             self.assertEqual(code, 0)
-            self.assertEqual(symlink_mock.call_count, 2)
-            self.assertIn("legacy agent bridge:", stdout)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("legacy copied agent bridge:", stdout)
             self.assertIn("legacy-only.toml", stdout)
             self.assertIn("shared-agent", stderr)
             self.assertIn("Legacy `.codex/project/agents/` is deprecated", stderr)
@@ -445,18 +488,904 @@ class ConsumerBootstrapTests(unittest.TestCase):
             )
             self.assertFalse((repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE).exists())
 
-    def test_symlink_failure_produces_clear_error(self) -> None:
+    def test_copy_alias_is_accepted(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            repo = create_consumer_repo(Path(tmp), vendor_skill_names=["vendor-skill"])
-
-            code, _, stderr, _ = run_bootstrap_main(
-                repo,
-                symlink_side_effect=OSError("no symlink permission"),
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
             )
 
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(
+                repo,
+                bridge_mode=bootstrap.BRIDGE_MODE_COPY_ON_FAIL,
+            )
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("bridge mode: copy", stdout)
+            self.assertIn("copied agent bridge:", stdout)
+            self.assertIn("copied skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+
+    def test_copied_vendor_skill_rewrites_wrapper_paths_to_vendor_subtree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+                / "SKILL.md"
+            )
+            vendor_skill.write_text(
+                "\n".join(
+                    [
+                        "---",
+                        "name: vendor-skill",
+                        "description: test skill",
+                        "---",
+                        "",
+                        "Use `../../../builders/packet-workflow/retained-skills/vendor-skill/SKILL.md`.",
+                        "Run `python ../../../builders/packet-workflow/scripts/init_packet_skill.py`.",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            code, _, _, _ = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            copied_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "SKILL.md"
+            copied_text = copied_skill.read_text(encoding="utf-8")
+            self.assertIn(
+                "../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/vendor-skill/SKILL.md",
+                copied_text,
+            )
+            self.assertIn(
+                "python ../../../.codex/vendor/packetflow_foundry/builders/packet-workflow/scripts/init_packet_skill.py",
+                copied_text,
+            )
+            self.assertNotIn(
+                "Use `../../../builders/packet-workflow/retained-skills/vendor-skill/SKILL.md`.",
+                copied_text,
+            )
+
+    def test_default_copy_creates_managed_copies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("bridge mode: copy", stdout)
+            self.assertIn("copied agent bridge:", stdout)
+            self.assertIn("copied skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            copied_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            self.assertEqual(
+                copied_agent.read_text(encoding="utf-8"),
+                vendor_agent.read_text(encoding="utf-8"),
+            )
+
+            copied_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill"
+            self.assertEqual(relative_files(copied_skill), ["SKILL.md", "agents/openai.yaml"])
+
+            bridge_state = json.loads(
+                (repo / bootstrap.BRIDGE_STATE_RELATIVE).read_text(encoding="utf-8")
+            )
+            self.assertEqual(bridge_state["kind"], bootstrap.BRIDGE_STATE_KIND)
+            self.assertIn("vendor-agent.toml", bridge_state["agents"])
+            self.assertIn("vendor-skill", bridge_state["skills"])
+
+    def test_copy_refreshes_managed_copies_when_vendor_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_agent.write_text(
+                vendor_agent.read_text(encoding="utf-8") + "# updated\n",
+                encoding="utf-8",
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+                / "agents"
+                / "openai.yaml"
+            )
+            vendor_skill.write_text('display_name: "Updated"\n', encoding="utf-8")
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("refreshed copied agent bridge:", stdout)
+            self.assertIn("refreshed copied skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+
+            copied_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            copied_skill = (
+                repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "agents" / "openai.yaml"
+            )
+            self.assertIn("# updated", copied_agent.read_text(encoding="utf-8"))
+            self.assertEqual(
+                copied_skill.read_text(encoding="utf-8"),
+                'display_name: "Updated"\n',
+            )
+
+    def test_sync_managed_file_copy_recreates_missing_target_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            source_path = create_agent_file(repo_root / "vendor", "vendor-agent")
+            target_path = repo_root / "consumer" / "vendor-agent.toml"
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+            state_group = {
+                "vendor-agent.toml": bootstrap.build_file_copy_state_entry(repo_root, source_path)
+            }
+
+            target_path.unlink()
+
+            with mock.patch.object(bootstrap, "write_bytes", wraps=bootstrap.write_bytes) as write_mock:
+                status, detail, notice = bootstrap.sync_managed_file_copy(
+                    repo_root,
+                    source_path,
+                    target_path,
+                    bridge_name="vendor-agent.toml",
+                    state_group=state_group,
+                )
+
+            self.assertEqual(status, "copied")
+            self.assertEqual(detail, f"{target_path.as_posix()} <- {source_path.as_posix()}")
+            self.assertIsNone(notice)
+            self.assertEqual(write_mock.call_count, 1)
+            self.assertEqual(
+                target_path.read_text(encoding="utf-8"),
+                source_path.read_text(encoding="utf-8"),
+            )
+
+    def test_sync_managed_directory_copy_restores_missing_files_and_prunes_stale_managed_files(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            source_root = create_skill_dir(repo_root / "vendor", "vendor-skill")
+            obsolete_source_file = source_root / "obsolete.txt"
+            obsolete_source_file.write_text("obsolete\n", encoding="utf-8")
+            target_root = repo_root / "consumer" / "vendor-skill"
+            shutil.copytree(source_root, target_root)
+            copied_files = bootstrap.build_skill_bridge_files(
+                repo_root,
+                source_root,
+                target_root,
+            )
+            state_group = {
+                "vendor-skill": bootstrap.build_directory_copy_state_entry(
+                    repo_root,
+                    source_root,
+                    copied_files,
+                )
+            }
+
+            missing_file = target_root / "agents" / "openai.yaml"
+            stale_file = target_root / "obsolete.txt"
+            obsolete_source_file.unlink()
+            missing_file.unlink()
+
+            status, detail, notice = bootstrap.sync_managed_directory_copy(
+                repo_root,
+                source_root,
+                target_root,
+                bridge_name="vendor-skill",
+                state_group=state_group,
+            )
+
+            self.assertEqual(status, "refreshed")
+            self.assertEqual(detail, f"{target_root.as_posix()} <- {source_root.as_posix()}")
+            self.assertIsNone(notice)
+            self.assertTrue(missing_file.is_file())
+            self.assertFalse(stale_file.exists())
+
+    def test_copy_keeps_locally_added_skill_files_on_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            copied_skill_root = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill"
+            copied_skill = copied_skill_root / "agents" / "openai.yaml"
+            local_file = copied_skill_root / "local-notes.txt"
+            local_file.write_text("local override\n", encoding="utf-8")
+
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+                / "agents"
+                / "openai.yaml"
+            )
+            vendor_skill.write_text('display_name: "Updated"\n', encoding="utf-8")
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("skipped skill bridge:", stdout)
+            self.assertIn("modified locally", stderr)
+            self.assertTrue(local_file.is_file())
+            self.assertEqual(
+                copied_skill.read_text(encoding="utf-8"),
+                'display_name: "Test"\n',
+            )
+
+    def test_copy_rejects_symlinked_skill_wrapper_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+            )
+            symlinked_file = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+                / "agents"
+                / "openai.yaml"
+            )
+            real_is_symlink = Path.is_symlink
+
+            def fake_is_symlink(path: Path) -> bool:
+                if path == symlinked_file:
+                    return True
+                return real_is_symlink(path)
+
+            with mock.patch.object(Path, "is_symlink", fake_is_symlink):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
             self.assertEqual(code, 1)
-            self.assertIn("Failed to create directory symlink", stderr)
-            self.assertIn("Enable Windows Developer Mode", stderr)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("copied skill bridge:", stdout)
+            self.assertIn("unsupported symlinked file", stderr)
+            self.assertFalse(
+                (repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill").exists()
+            )
+            self.assertFalse((repo / bootstrap.BRIDGE_STATE_RELATIVE).exists())
+
+    def test_copy_rejects_linked_skill_root_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+            )
+            linked_root = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            real_has_reparse_point = bootstrap.path_has_reparse_point
+
+            def fake_has_reparse_point(path: Path) -> bool:
+                if path == linked_root:
+                    return True
+                return real_has_reparse_point(path)
+
+            with mock.patch.object(bootstrap, "path_has_reparse_point", fake_has_reparse_point):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("copied skill bridge:", stdout)
+            self.assertIn("unsupported linked directory", stderr)
+            self.assertFalse(
+                (repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill").exists()
+            )
+            self.assertFalse((repo / bootstrap.BRIDGE_STATE_RELATIVE).exists())
+
+    def test_copy_rejects_symlinked_agent_source_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_agent_names=["vendor-agent"],
+            )
+            symlinked_file = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            real_is_symlink = Path.is_symlink
+
+            def fake_is_symlink(path: Path) -> bool:
+                if path == symlinked_file:
+                    return True
+                return real_is_symlink(path)
+
+            with mock.patch.object(Path, "is_symlink", fake_is_symlink):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("copied agent bridge:", stdout)
+            self.assertIn("unsupported symlinked file", stderr)
+            self.assertFalse(
+                (repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml").exists()
+            )
+            self.assertFalse((repo / bootstrap.BRIDGE_STATE_RELATIVE).exists())
+
+    def test_copy_errors_cleanly_for_external_agent_source_path_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = create_consumer_repo(
+                root,
+                vendor_agent_names=["vendor-agent"],
+            )
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            external_root = root / "external"
+            external_agent = create_agent_file(external_root, "external-agent")
+            real_resolve = Path.resolve
+
+            def fake_resolve(path: Path, *args: object, **kwargs: object) -> Path:
+                if path == vendor_agent:
+                    return external_agent.resolve()
+                return real_resolve(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "resolve", fake_resolve):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("copied agent bridge:", stdout)
+            self.assertIn("resolves outside the agent root", stderr)
+            self.assertFalse(
+                (repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml").exists()
+            )
+            self.assertFalse((repo / bootstrap.BRIDGE_STATE_RELATIVE).exists())
+
+    def test_copy_errors_cleanly_for_external_skill_source_path_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = create_consumer_repo(
+                root,
+                vendor_skill_names=["vendor-skill"],
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            external_skill = create_skill_dir(root / "external-skills", "vendor-skill")
+            real_resolve = Path.resolve
+
+            def fake_resolve(path: Path, *args: object, **kwargs: object) -> Path:
+                if path == vendor_skill:
+                    return external_skill.resolve()
+                return real_resolve(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "resolve", fake_resolve):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertNotIn("copied skill bridge:", stdout)
+            self.assertIn("resolves outside the skill root", stderr)
+            self.assertFalse(
+                (repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill").exists()
+            )
+            self.assertFalse((repo / bootstrap.BRIDGE_STATE_RELATIVE).exists())
+
+    def test_copy_persists_agent_bridge_state_before_skill_pass_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_agent_names=["vendor-agent"],
+            )
+            root_agent = (
+                repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            )
+            state_path = repo / bootstrap.BRIDGE_STATE_RELATIVE
+
+            with mock.patch.object(
+                bootstrap,
+                "create_skill_bridges",
+                side_effect=RuntimeError("simulated skill bridge failure"),
+            ):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertEqual(stdout.strip(), "")
+            self.assertIn("simulated skill bridge failure", stderr)
+            self.assertTrue(root_agent.is_file())
+            bridge_state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertIn("vendor-agent.toml", bridge_state["agents"])
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_agent.write_text(
+                vendor_agent.read_text(encoding="utf-8") + "# upstream change\n",
+                encoding="utf-8",
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("refreshed copied agent bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertIn("# upstream change\n", root_agent.read_text(encoding="utf-8"))
+
+    def test_copy_persists_agent_bridge_state_before_later_agent_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_agent_names=["alpha-agent", "vendor-agent"],
+            )
+            root_agent = (
+                repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "alpha-agent.toml"
+            )
+            state_path = repo / bootstrap.BRIDGE_STATE_RELATIVE
+            real_sync = bootstrap.sync_managed_file_copy
+
+            def fake_sync_managed_file_copy(
+                repo_root: Path,
+                source_path: Path,
+                target_path: Path,
+                *,
+                bridge_name: str,
+                state_group: dict[str, object],
+            ) -> tuple[str, str, str | None]:
+                if bridge_name == "vendor-agent.toml":
+                    raise RuntimeError("simulated later agent bridge failure")
+                return real_sync(
+                    repo_root,
+                    source_path,
+                    target_path,
+                    bridge_name=bridge_name,
+                    state_group=state_group,
+                )
+
+            with mock.patch.object(
+                bootstrap,
+                "sync_managed_file_copy",
+                side_effect=fake_sync_managed_file_copy,
+            ):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertEqual(stdout.strip(), "")
+            self.assertIn("simulated later agent bridge failure", stderr)
+            self.assertTrue(root_agent.is_file())
+            bridge_state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertIn("alpha-agent.toml", bridge_state["agents"])
+            self.assertNotIn("vendor-agent.toml", bridge_state["agents"])
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "alpha-agent.toml"
+            )
+            vendor_agent.write_text(
+                vendor_agent.read_text(encoding="utf-8") + "# upstream change\n",
+                encoding="utf-8",
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("refreshed copied agent bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertIn("# upstream change\n", root_agent.read_text(encoding="utf-8"))
+
+    def test_copy_persists_skill_bridge_state_before_later_skill_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["alpha-skill", "vendor-skill"],
+            )
+            root_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "alpha-skill" / "SKILL.md"
+            state_path = repo / bootstrap.BRIDGE_STATE_RELATIVE
+            real_sync = bootstrap.sync_managed_directory_copy
+
+            def fake_sync_managed_directory_copy(
+                repo_root: Path,
+                source_root: Path,
+                target_root: Path,
+                *,
+                bridge_name: str,
+                state_group: dict[str, object],
+            ) -> tuple[str, str, str | None]:
+                if bridge_name == "vendor-skill":
+                    raise RuntimeError("simulated later skill bridge failure")
+                return real_sync(
+                    repo_root,
+                    source_root,
+                    target_root,
+                    bridge_name=bridge_name,
+                    state_group=state_group,
+                )
+
+            with mock.patch.object(
+                bootstrap,
+                "sync_managed_directory_copy",
+                side_effect=fake_sync_managed_directory_copy,
+            ):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 1)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertEqual(stdout.strip(), "")
+            self.assertIn("simulated later skill bridge failure", stderr)
+            self.assertTrue(root_skill.is_file())
+            bridge_state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertIn("alpha-skill", bridge_state["skills"])
+            self.assertNotIn("vendor-skill", bridge_state["skills"])
+
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "alpha-skill"
+                / "SKILL.md"
+            )
+            vendor_skill.write_text(
+                "---\nname: alpha-skill\ndescription: updated skill\n---\n",
+                encoding="utf-8",
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("refreshed copied skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertIn("updated skill", root_skill.read_text(encoding="utf-8"))
+
+    def test_copy_skips_locally_modified_managed_copies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            copied_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            copied_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "SKILL.md"
+            copied_agent.write_text("# local edit\n", encoding="utf-8")
+            copied_skill.write_text("local skill override\n", encoding="utf-8")
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_agent.write_text(
+                vendor_agent.read_text(encoding="utf-8") + "# upstream change\n",
+                encoding="utf-8",
+            )
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("skipped agent bridge:", stdout)
+            self.assertIn("skipped skill bridge:", stdout)
+            self.assertIn("modified locally", stderr)
+            self.assertEqual(copied_agent.read_text(encoding="utf-8"), "# local edit\n")
+            self.assertEqual(copied_skill.read_text(encoding="utf-8"), "local skill override\n")
+
+    def test_existing_vendor_symlink_bridges_are_migrated_to_managed_copies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            root_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            root_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill"
+            root_agent.parent.mkdir(parents=True, exist_ok=True)
+            root_agent.write_text(vendor_agent.read_text(encoding="utf-8"), encoding="utf-8")
+            shutil.copytree(vendor_skill, root_skill)
+
+            real_is_symlink = Path.is_symlink
+            real_resolve = Path.resolve
+            real_unlink = Path.unlink
+
+            def fake_is_symlink(path: Path) -> bool:
+                if path in {root_agent, root_skill}:
+                    return True
+                return real_is_symlink(path)
+
+            def fake_resolve(path: Path, *args: object, **kwargs: object) -> Path:
+                if path == root_agent:
+                    return vendor_agent.resolve()
+                if path == root_skill:
+                    return vendor_skill.resolve()
+                return real_resolve(path, *args, **kwargs)
+
+            def fake_unlink(path: Path, *args: object, **kwargs: object) -> None:
+                if path == root_agent:
+                    real_unlink(path, *args, **kwargs)
+                    return None
+                if path == root_skill:
+                    shutil.rmtree(path)
+                    return None
+                real_unlink(path, *args, **kwargs)
+                return None
+
+            with (
+                mock.patch.object(Path, "is_symlink", fake_is_symlink),
+                mock.patch.object(Path, "resolve", fake_resolve),
+                mock.patch.object(Path, "unlink", fake_unlink),
+            ):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("migrated copied agent bridge:", stdout)
+            self.assertIn("migrated copied skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertTrue((repo / bootstrap.BRIDGE_STATE_RELATIVE).is_file())
+
+    def test_copy_prunes_deleted_managed_vendor_entries_on_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            vendor_agent.unlink()
+            shutil.rmtree(vendor_skill)
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("removed agent bridge:", stdout)
+            self.assertIn("removed skill bridge:", stdout)
+            self.assertEqual(stderr.strip(), "")
+            self.assertFalse(
+                (repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml").exists()
+            )
+            self.assertFalse((repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill").exists())
+            self.assertFalse((repo / bootstrap.BRIDGE_STATE_RELATIVE).exists())
+
+    def test_copy_keeps_locally_modified_deleted_managed_entries_on_rerun(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+                vendor_agent_names=["vendor-agent"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            copied_agent = repo / bootstrap.PROJECT_AGENT_DISCOVERY_RELATIVE / "vendor-agent.toml"
+            copied_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "SKILL.md"
+            copied_agent.write_text("# local edit\n", encoding="utf-8")
+            copied_skill.write_text("local skill override\n", encoding="utf-8")
+
+            vendor_agent = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".codex"
+                / "agents"
+                / "vendor-agent.toml"
+            )
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            vendor_agent.unlink()
+            shutil.rmtree(vendor_skill)
+
+            code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("skipped agent bridge:", stdout)
+            self.assertIn("skipped skill bridge:", stdout)
+            self.assertIn("after upstream deletion", stderr)
+            self.assertEqual(copied_agent.read_text(encoding="utf-8"), "# local edit\n")
+            self.assertEqual(copied_skill.read_text(encoding="utf-8"), "local skill override\n")
+            bridge_state = json.loads(
+                (repo / bootstrap.BRIDGE_STATE_RELATIVE).read_text(encoding="utf-8")
+            )
+            self.assertIn("vendor-agent.toml", bridge_state["agents"])
+            self.assertIn("vendor-skill", bridge_state["skills"])
+
+    def test_copy_keeps_symlinked_skill_files_after_upstream_deletion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = create_consumer_repo(
+                Path(tmp),
+                vendor_skill_names=["vendor-skill"],
+            )
+
+            first_code, _, _, _ = run_bootstrap_main(repo)
+            self.assertEqual(first_code, 0)
+
+            vendor_skill = (
+                repo
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / ".agents"
+                / "skills"
+                / "vendor-skill"
+            )
+            copied_skill = repo / bootstrap.ROOT_SKILLS_RELATIVE / "vendor-skill" / "SKILL.md"
+            shutil.rmtree(vendor_skill)
+
+            real_is_symlink = Path.is_symlink
+            real_sha256_path = bootstrap.sha256_path
+
+            def fake_is_symlink(path: Path) -> bool:
+                if path == copied_skill:
+                    return True
+                return real_is_symlink(path)
+
+            def fake_sha256_path(path: Path) -> str:
+                if path == copied_skill:
+                    raise OSError("symlink targets should not be hashed during prune")
+                return real_sha256_path(path)
+
+            with (
+                mock.patch.object(Path, "is_symlink", fake_is_symlink),
+                mock.patch.object(bootstrap, "sha256_path", fake_sha256_path),
+            ):
+                code, stdout, stderr, symlink_mock = run_bootstrap_main(repo)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(symlink_mock.call_count, 0)
+            self.assertIn("skipped skill bridge:", stdout)
+            self.assertIn("after upstream deletion", stderr)
+            self.assertTrue(copied_skill.is_file())
+            bridge_state = json.loads(
+                (repo / bootstrap.BRIDGE_STATE_RELATIVE).read_text(encoding="utf-8")
+            )
+            self.assertIn("vendor-skill", bridge_state["skills"])
 
     def test_missing_vendor_subtree_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/builders/packet-workflow/README.md
+++ b/builders/packet-workflow/README.md
@@ -1,0 +1,49 @@
+# Packet Workflow Builder
+
+This builder scaffolds packet-driven repo workflow skills.
+
+Authoritative ownership:
+- shared contracts live under `../../core/contracts/packet-workflow/`
+- shared templates live under `../../core/templates/packet-workflow/`
+- shared default semantics live under `../../core/defaults/packet-workflow/`
+- this builder consumes those assets and is not their authoritative owner
+
+Use this directory for:
+- `builder-contract.md`
+- builder-specific evaluation schema
+- scaffold generation scripts
+- builder tests
+- authoritative retained skill kernels under `retained-skills/`
+- generated collectors should prefer `.codex/project/profiles/<skill-name>/profile.json`, then `.codex/project/profiles/default/profile.json`, before falling back to the retained skill-local profile scaffold
+
+Do not define contract semantics here first.
+- If validator/apply rules, stop taxonomy, common-path behavior, worker-family semantics, or profile boundaries change, update `core/` first.
+- Then update this builder so generation output and tests match the new core semantics.
+
+Primary entrypoint:
+- `scripts/init_packet_skill.py`
+  - generates an authoritative retained kernel under `retained-skills/<skill-name>/`
+  - generates a thin discovery wrapper under `../../.agents/skills/<skill-name>/`
+
+Generated operator docs:
+- retained `SKILL.md` files are the operator-facing execution contract for bundled helper scripts
+- generated script invocations must use `<python-bin> -B <skill-dir>/scripts/...`
+- generated docs must not prescribe launcher-specific shims such as bare `python` or `py`
+
+Companion references:
+- `builder-contract.md`
+- `builder-evaluation-contract.md`
+- `../../core/contracts/packet-workflow/pattern-catalog.md`
+
+Supported retained pattern:
+- weekly-update-like retained skills stay in this builder family
+- use `decision_ready_packets=true`,
+  `worker_return_contract=classification-oriented`, and
+  `worker_output_shape=hierarchical`
+- keep repo-specific weekly-update conventions in
+  `repo_profile.extra.weekly_update`
+
+Guarded invalid combinations:
+- explicit `candidate_field_bundles` with `worker_return_contract=generic`
+- `classification-oriented` without `decision_ready_packets=true`
+- explicit `worker_footer_fields` without decision-ready hierarchical output

--- a/builders/packet-workflow/builder-contract.md
+++ b/builders/packet-workflow/builder-contract.md
@@ -219,6 +219,11 @@ Generated runtime metadata:
 - thin discovery wrapper:
   - `.agents/skills/<skill-name>/`
 
+Generated skills must also reserve `<repo-root>/.codex/tmp/` as the only repo-local scratch tree for temporary, helper, runtime-artifact, and ad hoc operator-input files that are not meant to be tracked:
+- keep packet runtime artifacts under `.codex/tmp/packet-workflow/<skill-name>/`
+- keep repo-local fallbacks such as evaluation logs or helper inputs under `.codex/tmp/`
+- do not place repo-local temp files at the repo root or inside tracked source directories
+
 Wrapper rules:
 - wrapper subtree may contain only `SKILL.md` and `agents/openai.yaml`
 - wrapper must point operators at the retained kernel

--- a/builders/packet-workflow/builder-contract.md
+++ b/builders/packet-workflow/builder-contract.md
@@ -1,0 +1,486 @@
+# Builder Contract
+
+Use this file when drafting `builder-spec.json` for `scripts/init_packet_skill.py`.
+
+Boundary note:
+- the thin-entrypoint intent for `.agents/skills/` predates the retained-kernel split
+- earlier drift happened because the original generator and tests still emitted bundled skills under `.agents/skills/`
+- the current contract is enforced by generation output and tests: retained kernels live under `retained-skills/`, wrappers live under `.agents/skills/`
+
+Authoritative ownership:
+- shared contracts, templates, and default semantics live under [`../../core/`](../../core/)
+- this builder consumes those assets and is not their authoritative owner
+- behavior meaning changes should be defined in `core/` first, then reflected here
+
+This builder separates:
+- the generic adjudication contract shared by packet-driven workflows
+- reusable worker-family routing hooks
+- a default repo-profile scaffold for repo-specific path bindings, packet review docs, and lint toggles
+- optional domain overlays that rename or specialize semantics without changing the shared structure
+
+Repo profiles are intentionally data-only. Keep only declarative bindings, globs, doc lists, booleans, notes, and generated compatibility metadata there. Do not treat `profile.json` as a place for executable hooks, prompt fragments, or worker-routing behavior.
+
+## Required Fields
+
+- `builder_versioning`
+  - Object copied from `version.json` when the skill is current.
+  - Required keys:
+    - `builder_family`
+    - `builder_semver`
+    - `compatibility_epoch`
+    - `builder_spec_schema_version`
+    - `repo_profile_schema_version`
+  - Generation rejects missing or invalid version blocks.
+  - Semver-only drift is allowed.
+  - Epoch or schema mismatch requires manual migration instead of silent auto-bump.
+- `skill_name`
+  - Hyphen-case skill folder name and SKILL frontmatter name.
+- `description`
+  - Full SKILL description sentence that explains what the generated skill does and when to use it.
+- `domain_slug`
+  - Snake-case token used in script names such as `collect_<domain_slug>_context.py`.
+- `workflow_family`
+  - Short family label such as `github-review`, `release-copy`, `git-history`, or `repo-audit`.
+- `archetype`
+  - One of:
+    - `audit-only`
+    - `audit-and-apply`
+    - `plan-validate-apply`
+- `primary_goal`
+  - One sentence used in the generated SKILL body and UI prompt.
+- `trigger_phrases`
+  - Array of concrete user-intent phrases the generated skill should respond to.
+
+## Optional Fields
+
+- `task_packet_names`
+  - Array of focused packet basenames without `.json`.
+  - Default: `["task_packet"]`
+- `orchestrator_profile`
+  - Enum:
+    - `standard`
+    - `packet-heavy-orchestrator`
+  - Default: `standard`
+  - `standard` keeps only the common reference-grade contract layer.
+  - `packet-heavy-orchestrator` adds `synthesis_packet.json`, `packet_metrics.json`, `shared_local_packet`, and `common_path_contract`.
+- `uses_batch_packets`
+  - Boolean.
+  - Default: `false`
+- `needs_lint`
+  - Boolean. Default depends on archetype.
+- `needs_validate`
+  - Boolean. Default depends on archetype.
+- `needs_apply`
+  - Boolean. Default depends on archetype.
+  - `needs_apply=true` requires `needs_validate=true`.
+- `optional_local_helper`
+  - Object with:
+    - `path`
+    - `description`
+  - Generated skills must treat this helper as optional and non-authoritative.
+- `authority_order`
+  - Array of strings describing which inputs outrank others.
+- `stop_conditions`
+  - Array of strings.
+- `review_mode_overrides`
+  - Array of strings.
+- `decision_ready_packets`
+  - Boolean.
+  - Default: `false`
+  - Enable when focused packets should be directly usable for local adjudication instead of hint-only evidence pointers.
+- `worker_return_contract`
+  - Enum:
+    - `generic`
+    - `classification-oriented`
+  - Default:
+    - `classification-oriented` when `decision_ready_packets=true`
+    - otherwise `generic`
+  - Guard:
+    - `classification-oriented` requires `decision_ready_packets=true`
+- `worker_output_shape`
+  - Enum:
+    - `flat`
+    - `hierarchical`
+  - Default:
+    - `hierarchical` when `decision_ready_packets=true` or `worker_return_contract=classification-oriented`
+    - otherwise `flat`
+  - `hierarchical` requires `worker_return_contract=classification-oriented`.
+- `xhigh_reread_policy`
+  - String.
+  - Default:
+    - packet-first local adjudication with raw rereads allowed only for explicit exception reasons
+- `candidate_field_bundles`
+  - Ordered array of bundle objects for decision-ready candidate semantics.
+  - Each bundle object supports:
+    - `name`
+    - `description`
+    - `required`
+    - `fields`
+  - Guard:
+    - explicit `candidate_field_bundles` require `worker_return_contract=classification-oriented`
+- `worker_footer_fields`
+  - Ordered array of footer field names for hierarchical worker output.
+  - Guard:
+    - explicit `worker_footer_fields` require `decision_ready_packets=true`
+    - explicit `worker_footer_fields` require `worker_output_shape=hierarchical`
+- `reread_reason_values`
+  - Ordered array of allowed reread reasons.
+- `required_candidate_fields`
+  - Legacy shorthand.
+  - Still accepted for backward compatibility.
+  - When `candidate_field_bundles` is omitted, the builder normalizes this list into a single required bundle rather than rejecting older specs.
+- `preferred_worker_families`
+  - Optional worker-family registry for generated docs and packet metadata.
+  - Supported keys:
+    - `context_findings`
+    - `candidate_producers`
+    - `verifiers`
+  - Default:
+    - `context_findings`: `["repo_mapper", "packet_explorer", "docs_verifier"]`
+    - `candidate_producers`: `["evidence_summarizer", "large_diff_auditor", "log_triager"]`
+    - `verifiers`: `["docs_verifier"]`
+  - Family-internal order is preserved.
+  - Duplicate agent types inside one family list are invalid.
+  - Cross-family overlap is allowed.
+- `packet_worker_map`
+  - Optional concrete routing map for generated `recommended_workers`.
+  - Shape:
+    - packet basename -> ordered agent type list
+  - Allowed keys:
+    - declared `task_packet_names`
+    - `batch-packet-01` only when `uses_batch_packets=true`
+  - Values must use only known worker agent types.
+  - Duplicate agent types inside one packet list are invalid.
+  - The same agent type may appear on multiple packet assignments.
+- `domain_overlay`
+  - Optional nested domain-semantics container.
+  - Supported keys:
+    - `proposal_enum_values`
+    - `candidate_field_aliases`
+    - `reference_only_candidate_values`
+    - `output_inclusion_rules`
+    - `bundle_overrides`
+- `repo_profile`
+  - Optional default repo-profile scaffold for generated skills.
+  - Generated at `profiles/<name>/profile.json`.
+  - Keep it data-only end to end.
+  - `metadata.versioning` is generated automatically and is not authored through this field.
+  - Supported keys:
+    - `name`
+    - `summary`
+    - `repo_match`
+      - `root_markers`
+      - `remote_patterns`
+    - `bindings`
+      - `primary_readme_path`
+      - `settings_source_path`
+      - `publish_config_path`
+    - `packet_defaults`
+      - `review_docs`
+      - `source_path_globs`
+    - `lint_rules`
+      - `require_readme_settings_table`
+      - `missing_review_docs_are_errors`
+    - `extra`
+      - arbitrary data-only JSON for skill-specific profile fields that do not
+        fit the baseline bindings/packet-defaults/lint-rules scaffold
+      - values must remain declarative data only
+      - do not use this for executable hooks, prompt fragments, routing
+        authority, or validator/apply behavior
+      - example:
+        - keep repo-specific weekly-update conventions in
+          `repo_profile.extra.weekly_update`
+    - `notes`
+  - Default intent:
+    - keep repo-specific file layout and packet ownership out of the generic core
+    - keep repo-specific configuration declarative so the generated scripts own executable behavior
+    - let future repo ports add or replace profile folders without rewriting the core contract or templates
+
+## Builder Versioning
+
+Canonical current builder metadata lives in `version.json`.
+
+Compatibility expectations:
+- `compatibility_epoch` must match for generation to proceed
+- `builder_spec_schema_version` must match for generation to proceed
+- `repo_profile_schema_version` must match for generation to proceed
+- `builder_semver` may trail current builder semver when the skill is still structurally compatible
+
+Generated runtime metadata:
+- `builder_versioning` is copied into generated `SPEC_METADATA`
+- `profiles/<name>/profile.json` gets `metadata.versioning`
+- runtime collectors should record builder compatibility and warn when the active skill or profile is not current
+
+## Output Layout
+
+`scripts/init_packet_skill.py --output-dir <repo-root>` generates two coordinated trees:
+- authoritative retained kernel:
+  - `builders/packet-workflow/retained-skills/<skill-name>/`
+- thin discovery wrapper:
+  - `.agents/skills/<skill-name>/`
+
+Wrapper rules:
+- wrapper subtree may contain only `SKILL.md` and `agents/openai.yaml`
+- wrapper must point operators at the retained kernel
+- wrapper must not carry `builder-spec.json`, profiles, references, scripts, tests, or migration worksheets
+
+Generated operator-doc rules:
+- generated retained `SKILL.md` files must define the execution contract in terms of `<python-bin>` and `<skill-dir>`
+- generated helper invocations must use `<python-bin> -B <skill-dir>/scripts/...`
+- generated docs must not prescribe launcher-specific shims such as bare `python` or `py`
+
+Bump rules:
+- bump `compatibility_epoch` when generated skills or profiles require manual migration
+- do not bump the epoch for docs-only, tests-only, or additive backward-compatible changes
+- use `versioning-policy.md` for the authoritative bump and migration-record rules
+
+## Known Worker Agent Types
+
+The authoritative allowlist lives in the builder generator, not in the global agents directory scan.
+
+- Source of truth:
+  - `KNOWN_WORKER_AGENT_TYPES` constant in `scripts/init_packet_skill.py`
+- Current managed set:
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `packet_worker_map` validation uses this constant only.
+- Managed-agent registry lookup order:
+  - explicit `--managed-agents-dir` or function override
+  - environment override via `CODEX_MANAGED_AGENTS_DIR`
+  - environment-derived default via `CODEX_HOME/agents`
+  - standard install default derived from the builder location
+  - bundled `tests/fixtures/agents` fallback for portable tests
+- The registry scan is a subset consistency check only.
+- Required behavior:
+  - every managed worker above must exist as a real TOML agent
+  - unrelated extra global agents are allowed
+  - missing managed worker agents are hard failure
+
+## Generic Adjudication Contract
+
+Use the generic adjudication contract when the local orchestrator must classify, rank, or gate work across structured packets without reopening most raw artifacts.
+
+Recommended pairing:
+- `decision_ready_packets=true`
+- `worker_return_contract=classification-oriented`
+- `worker_output_shape=hierarchical`
+
+Retained weekly-update-like pattern:
+- use this same pairing for retained hierarchical adjudication workflows
+- keep repo-specific review markers, release-title conventions, and similar
+  data-only overrides in `repo_profile.extra.weekly_update`
+- do not create a new builder family when the workflow still fits this shape
+
+Forbidden retained-shape combinations:
+- `candidate_field_bundles` with `worker_return_contract=generic`
+- `worker_footer_fields` without `decision_ready_packets=true`
+- `worker_footer_fields` with `worker_output_shape=flat`
+- `domain_overlay` with `worker_return_contract=generic`
+
+Shared structure:
+- `candidates[]`
+  - fixed container for candidate-level worker output
+  - candidate-level factual summaries stay inside candidates
+- `footer`
+  - fixed worker-level batch summary container
+  - `footer.primary_outcome` is worker batch summary only
+  - `footer.overall_confidence` is worker batch confidence only
+
+Default generic candidate semantics:
+- `fact_summary`
+- `proposal_classification`
+- `classification_rationale`
+- `supporting_references`
+- `ambiguity`
+- `confidence`
+- `reread_control`
+
+Default generic footer semantics:
+- `packet_ids`
+- `candidate_ids`
+- `primary_outcome`
+- `overall_confidence`
+- `coverage_gaps`
+- `overall_risk`
+
+Confidence layering:
+- worker confidence stays worker-local
+- final plan confidence is recomputed locally during synthesis
+- generated skills should not copy worker/footer confidence through unchanged into the final plan
+
+Reread control:
+- raw rereads stay off by default after packet generation
+- rereads are allowed only when candidate-level reread control points to an allowed reason
+
+## Worker-Family Routing Contract
+
+Use worker families to keep named specialist workers reusable without hardcoding one downstream skill contract into the builder.
+
+Family intent:
+- `context_findings`
+  - mapping, packet-scoped code analysis, touched-surface, packet-membership, and authority findings
+- `candidate_producers`
+  - decision-ready candidate production for local adjudication-heavy workflows
+- `verifiers`
+  - narrow claim verification or version-sensitive checks
+
+`optional_workers` derivation:
+1. choose active family order
+2. concatenate family lists in that order
+3. apply first-occurrence stable dedupe
+4. remove agent types already present in `recommended_workers`
+
+Active family order:
+- `generic`
+  - `context_findings`
+  - `verifiers`
+- `classification-oriented`
+  - `context_findings`
+  - `candidate_producers`
+  - `verifiers`
+
+Implications:
+- a worker may belong to multiple families
+- surfaced `optional_workers` is still a deduped list
+- when `packet_worker_map` is configured, generated delegation docs should surface the delegated-mode `optional_workers` view after subtracting explicitly mapped recommended worker types
+- generated docs should describe both:
+  - family membership
+  - surfaced deduped optional worker list
+
+`recommended_workers` derivation:
+- concrete routing exists only when `packet_worker_map` is configured
+- without `packet_worker_map`, generated `recommended_workers` stays empty
+- `worker_selection_guidance` remains explanatory only
+- `packet_worker_map` is the routing authority when present
+
+Budget trim rules:
+- trim by `packet_order`, not by family
+- ignore `global_packet.json`
+- if `uses_batch_packets=true`, `batch-packet-01` is considered before singleton packets
+- within a packet, preserve the declared `packet_worker_map` order
+- dedupe only exact `(agent_type, packet)` pairs
+- the same agent type may still appear on multiple packets
+
+## Domain Overlay Contract
+
+Use `domain_overlay` only for domain semantics. Do not use it to change shared structural keys such as `candidates` or `footer`.
+
+Overlay precedence:
+1. Generic structural keys are fixed and never overridden by overlays.
+2. Generic `candidate_field_bundles` establish the semantic slots required by the workflow.
+3. Overlay `bundle_overrides` adjust bundle composition or requiredness.
+4. Overlay `candidate_field_aliases` apply last, mapping resolved semantic slots to domain field names.
+5. If no alias is provided for a resolved semantic slot, keep the generic slot name.
+
+Interpretation rules:
+- `candidate_field_aliases` rename semantics only. They do not remove required slots.
+- `bundle_overrides` may narrow, expand, or regroup candidate semantics for the domain, but they must still resolve back to the shared generic structure.
+- `proposal_enum_values` defines domain proposal states without hardcoding them into the base builder.
+- `reference_only_candidate_values` marks proposal values that are reference-only by default.
+- `output_inclusion_rules` groups proposal values into:
+  - standalone output items
+  - reference-only support items
+  - excluded-by-default items
+
+## Archetype Defaults
+
+- `audit-only`
+  - `needs_lint=false`
+  - `needs_validate=false`
+  - `needs_apply=false`
+- `audit-and-apply`
+  - `needs_lint=true`
+  - `needs_validate=true`
+  - `needs_apply=true`
+- `plan-validate-apply`
+  - `needs_lint=false`
+  - `needs_validate=true`
+  - `needs_apply=true`
+
+## Mutation Baseline
+
+Generated mutating scaffolds should inherit these defaults:
+- validator and apply stay separate
+- apply accepts validator output, not raw plan input
+- apply must consume validator-normalized output only
+- `--dry-run` must use the same validator-normalized input path as real apply
+- stale-context, apply-gate, and fingerprint checks belong in validator/apply before domain mutations are added
+
+## Generated Files
+
+Every generated retained kernel includes:
+- `SKILL.md`
+- `agents/openai.yaml`
+- `references/core-contract.md`
+- `references/delegation-playbook.md`
+- `references/<domain>-contract.md`
+- `references/evaluation-log-contract.md`
+- `references/<domain>-evaluation-contract.md`
+- `profiles/<profile-name>/profile.json`
+- `scripts/collect_<domain_slug>_context.py`
+- `scripts/build_<domain_slug>_packets.py`
+- `scripts/write_evaluation_log.py`
+
+Optional generated files:
+- `scripts/lint_<domain_slug>.py`
+- `scripts/validate_<domain_slug>.py`
+- `scripts/apply_<domain_slug>.py`
+
+Every generated wrapper includes:
+- `SKILL.md`
+- `agents/openai.yaml`
+
+## Generated Packet Conventions
+
+Every scaffold uses:
+- `orchestrator.json`
+- `global_packet.json`
+- the focused packet files named by `task_packet_names`
+- a generated repo-profile scaffold at `profiles/<profile-name>/profile.json`
+
+If `uses_batch_packets=true`, the scaffold also reserves `batch-packet-01.json` for grouped work items.
+
+If `orchestrator_profile=packet-heavy-orchestrator`, the scaffold also emits:
+- runtime:
+  - `synthesis_packet.json`
+- evaluation/regression:
+  - `packet_metrics.json`
+
+Runtime contract metadata and evaluation/regression metadata stay separate:
+- keep routing, authority, stop conditions, and common-path runtime signals in `orchestrator.json` / `global_packet.json`
+- keep packet sizing, byte proxies, and token-efficiency estimates in `packet_metrics.json` and evaluation logs
+- keep repo-specific path bindings and packet-review defaults in the repo profile instead of hardcoding them into the generic core contract
+
+Generated `orchestrator.json` and `global_packet.json` keep:
+- worker return contract
+- worker output shape
+- decision-ready packet metadata
+- candidate/footer/reread contract metadata
+- preferred worker families
+- packet worker map when configured
+- worker selection guidance
+
+When `orchestrator_profile=packet-heavy-orchestrator`, generated `orchestrator.json` also keeps:
+- `shared_local_packet`
+- `common_path_contract`
+- no packet-size or token-efficiency counters
+
+When `worker_output_shape=hierarchical`, generated focused packet stubs also reserve:
+- `candidates`
+- `footer`
+- `candidate_template`
+- `worker_footer_fields`
+- `reread_reason_values`
+- `domain_overlay`
+
+## Notes
+
+- The generated scripts are skeletons, not finished domain implementations.
+- Older builder specs remain valid; the richer adjudication and worker-family fields are optional.
+- The generator does not create shared runtime modules.
+- The generator does not infer packet-to-agent routing from packet names alone.
+- The generated core/profile split is structural. Domain-specific scripts still need to decide how strongly the repo profile should influence deterministic collection and lint logic.

--- a/builders/packet-workflow/builder-evaluation-contract.md
+++ b/builders/packet-workflow/builder-evaluation-contract.md
@@ -1,0 +1,18 @@
+# Packet Workflow Skill Builder Evaluation Contract
+
+Use the shared envelope in [`../../core/contracts/packet-workflow/evaluation-log-contract.md`](../../core/contracts/packet-workflow/evaluation-log-contract.md) and keep builder-only metrics under `skill_specific.data`.
+
+Suggested builder-specific fields:
+
+- `requested_archetype`
+- `requested_orchestrator_profile`
+- `requested_domain_slug`
+- `generated_file_count`
+- `includes_optional_local_helper`
+- `template_validation_passed`
+
+Guidance:
+
+- Treat generated-file counts and chosen archetype as observed metrics.
+- Mark `template_validation_passed` only after `quick_validate.py` and `py_compile` succeed on the generated sample.
+- Keep domain semantics out of this schema. This skill evaluates scaffold generation quality, not the generated workflow's runtime behavior.

--- a/builders/packet-workflow/retained-skills/draft-release-copy/SKILL.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/SKILL.md
@@ -119,7 +119,7 @@ This is a packet-driven repo workflow skill:
 - Use `phase` updates for deterministic lint, validate, and apply results when those outputs exist.
 - Use `finalize` after the run to merge token usage, actual worker mix, final usability, outputs, and notes.
 - Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
-- Keep packet artifacts and other helper temp files under the fixed gitignored `.codex/tmp/packet-workflow/` root.
+- Keep any repo-local temporary, helper, scratch, or ad hoc input file under the fixed gitignored `.codex/tmp/` tree; packet artifacts stay under `.codex/tmp/packet-workflow/`.
 - Read `references/evaluation-log-contract.md` for the shared envelope and `references/release_copy-evaluation-contract.md` for workflow-specific fields.
 
 ## Scripts

--- a/builders/packet-workflow/retained-skills/draft-release-copy/SKILL.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: draft-release-copy
+description: Draft and validate reusable release-copy updates by collecting release evidence, preparing publish configuration and README updates, and normalizing release-issue create or edit actions. Use when Codex must turn tracked repo state plus release evidence into guarded release-copy edits without encoding project-specific release policy in the retained kernel.
+---
+
+# Draft Release Copy
+
+Use this skill to prepare reusable release-copy updates with packet-heavy local synthesis and validator-normalized apply actions.
+
+This is a packet-driven repo workflow skill:
+- keep orchestration, final synthesis, and mutation local
+- use deterministic scripts to collect context before reading raw artifacts broadly
+- use `gpt-5.4-mini` workers only for narrow packet analysis
+- stop on low confidence, stale snapshots, or ambiguous ownership instead of guessing
+- keep generic packet rules in `references/core-contract.md` and repo-specific layout assumptions in `profiles/default/profile.json`
+- keep repo profiles data-only: paths, globs, doc lists, booleans, and notes only; executable logic stays in scripts and contracts
+- prefer a project-local override at `.codex/project/profiles/draft-release-copy/profile.json` when the repo carries release-copy-specific bindings or review docs
+- Orchestrator profile: `packet-heavy-orchestrator`.
+- Keep runtime contract metadata lean. Put packet sizing, byte proxies, and delegation-efficiency counters in `packet_metrics.json` and evaluation logs instead of `orchestrator.json`.
+- Read `synthesis_packet.json` as the shared local drafting packet before reopening raw artifacts.
+- Retained neutral profile scaffold: `profiles/default/profile.json`.
+- Preferred project-local override path: `.codex/project/profiles/draft-release-copy/profile.json`.
+- Keep repo-specific paths, packet review docs, and deterministic lint toggles in the repo profile instead of hardcoding them into the generic core templates.
+- Keep the repo profile data-only: paths, globs, doc lists, booleans, and notes only. Do not add executable hooks, prompt text, or worker-routing logic there.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/draft-release-copy/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/draft-release-copy/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/draft-release-copy/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Collect structured context.
+- Review `references/core-contract.md` before changing shared packet semantics.
+- Review the active repo profile before trusting repo-specific path bindings, review-doc lists, or deterministic lint toggles.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_release_copy_context.py --repo-root <repo-root> --output <context-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/lint_release_copy.py --context <context-json> --output <lint-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_release_copy_packets.py --context <context-json> --lint <lint-json> --output-dir <packet-dir>`.
+- - Recommended: add `--result-output <build-result-json>` so evaluation logging can merge build-phase packet metrics without expanding runtime contract metadata.
+- Read `<packet-dir>/orchestrator.json` first.
+- Keep `<packet-dir>/global_packet.json` in view before reading any focused packet.
+- Packet-heavy common path contract:
+  - read `global_packet.json` first
+  - keep `synthesis_packet.json` open for local drafting
+  - reopen at most one focused packet in the common path
+  - treat packet insufficiency as a build/contract failure instead of compensating with broad raw rereads
+
+2. Follow the review mode.
+- `local-only`: keep the work local.
+- `targeted-delegation`: use 1-2 `gpt-5.4-mini` workers on narrow packets.
+- `broad-delegation`: use 3-4 `gpt-5.4-mini` workers and add QA only when findings conflict.
+- Escalate to the next larger mode when churn is high, core runtime/config/process files span groups, or generated files are not the majority.
+
+3. Keep packet analysis narrow.
+- Treat `references/core-contract.md` as the generic workflow contract and the active repo profile as the repo-specific overlay.
+- Read `references/release-copy-contract.md` before drafting domain outputs.
+- Read `references/delegation-playbook.md` only when `review_mode` is not `local-only`.
+- Worker return contract for this skill: `generic`.
+- Worker output shape for this skill: `flat`.
+- Decision-ready packets enabled: `false`.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Keep final adjudication local.
+- Keep worker outputs narrow and use them as inputs to local synthesis, not as final decisions.
+- Recompute final plan confidence locally during synthesis from packet evidence, worker outputs, unresolved reread exceptions, and authority conflicts.
+- Use the named context/findings worker family when delegation is needed and keep candidate-producing workers optional unless the workflow becomes adjudication-heavy.
+- Preferred worker families for this skill:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+- Use `worker_selection_guidance` as explanatory family guidance only. When configured, `packet_worker_map` owns concrete packet routing.
+- Focus packet set for this skill:
+- `publish_packet.json`
+- `readme_packet.json`
+- `changes_packet.json`
+- `checklist_packet.json`
+- `evidence_packet.json`
+- Additional runtime packet:
+  - `synthesis_packet.json` for common-path local drafting and synthesis.
+- This scaffold defaults to singleton focused packets only.
+
+4. Respect authority and stop conditions.
+- Authority order for this skill:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+- No optional local helper is configured for this scaffold.
+- Packet-first adjudication guidance:
+- Start from packetized evidence first and only widen to raw artifact rereads when the reread policy is triggered.
+- Stop and report instead of mutating when:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+5. Validate before mutating.
+- Run `<python-bin> -B <skill-dir>/scripts/validate_release_copy.py --context <context-json> --plan <plan-json> --output <validation-json>`.
+- Stop if validation reports errors, stale context, low-confidence findings, or an apply-gate failure.
+
+6. Apply only after local verification.
+- Run `<python-bin> -B <skill-dir>/scripts/apply_release_copy.py --validation <validation-json>` after the validation output is locally reviewed.
+- Apply must consume validator-normalized output only; do not wire raw plan JSON directly into the mutation step.
+- If the user asked for `dry-run`, keep the same validation path and stop before any external mutation.
+
+## Evaluation
+
+- Use `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>` after packet generation.
+- Evaluation-only sidecar:
+  - `packet_metrics.json` for packet sizing, byte proxies, and regression-oriented token-efficiency estimates.
+- Use `phase` updates for deterministic lint, validate, and apply results when those outputs exist.
+- Use `finalize` after the run to merge token usage, actual worker mix, final usability, outputs, and notes.
+- Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
+- Keep packet artifacts and other helper temp files under the fixed gitignored `.codex/tmp/packet-workflow/` root.
+- Read `references/evaluation-log-contract.md` for the shared envelope and `references/release_copy-evaluation-contract.md` for workflow-specific fields.
+
+## Scripts
+
+- `scripts/collect_release_copy_context.py`
+  - Collect the structured inputs and repo artifacts for this workflow, including the active repo profile.
+- `scripts/lint_release_copy.py`
+  - Run deterministic checks and emit warnings, errors, and override signals.
+- `scripts/build_release_copy_packets.py`
+  - Build `orchestrator.json`, `global_packet.json`, and focused packets for local synthesis and optional mini-worker analysis.
+- `scripts/write_evaluation_log.py`
+  - Emit and update the shared evaluation log for efficiency, quality, and safety tracking.
+- `scripts/validate_release_copy.py`
+  - Validate the planned actions against the collected context, normalize the plan, and emit apply-gate status before apply.
+- `scripts/apply_release_copy.py`
+  - Dry-run or apply only from validator-normalized output after local verification.
+
+## Output
+
+- Tell the user which packets drove the decision.
+- Tell the user whether the run stayed local or used mini workers.
+- Tell the user which repo profile was active when repo-specific bindings mattered.
+- Tell the user whether final plan confidence was recomputed locally or a reread exception blocked that conclusion.
+- Tell the user whether the run stopped at planning, validation, or apply.

--- a/builders/packet-workflow/retained-skills/draft-release-copy/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Draft Release Copy"
+  short_description: "prepare reusable release-copy updates with packet..."
+  default_prompt: "prepare reusable release-copy updates with packet-heavy local synthesis and validator-normalized apply actions"

--- a/builders/packet-workflow/retained-skills/draft-release-copy/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/builder-spec.json
@@ -1,0 +1,155 @@
+{
+    "skill_name":  "draft-release-copy",
+    "description":  "Draft and validate reusable release-copy updates by collecting release evidence, preparing publish configuration and README updates, and normalizing release-issue create or edit actions. Use when Codex must turn tracked repo state plus release evidence into guarded release-copy edits without encoding project-specific release policy in the retained kernel.",
+    "domain_slug":  "release_copy",
+    "workflow_family":  "release-copy",
+    "archetype":  "audit-and-apply",
+    "primary_goal":  "prepare reusable release-copy updates with packet-heavy local synthesis and validator-normalized apply actions",
+    "trigger_phrases":  [
+                            "draft release copy",
+                            "prepare release notes and README updates",
+                            "sync release copy",
+                            "create or update release issue"
+                        ],
+    "task_packet_names":  [
+                              "publish_packet",
+                              "readme_packet",
+                              "changes_packet",
+                              "checklist_packet",
+                              "evidence_packet"
+                          ],
+    "orchestrator_profile":  "packet-heavy-orchestrator",
+    "needs_lint":  true,
+    "needs_validate":  true,
+    "needs_apply":  true,
+    "worker_return_contract":  "generic",
+    "worker_output_shape":  "flat",
+    "packet_worker_map":  {
+                              "publish_packet":  [
+                                                     "packet_explorer"
+                                                 ],
+                              "readme_packet":  [
+                                                    "packet_explorer"
+                                                ],
+                              "changes_packet":  [
+                                                     "evidence_summarizer"
+                                                 ],
+                              "checklist_packet":  [
+                                                       "docs_verifier"
+                                                   ],
+                              "evidence_packet":  [
+                                                      "docs_verifier"
+                                                  ]
+                          },
+    "repo_profile":  {
+                         "name":  "default",
+                         "summary":  "Neutral reusable profile scaffold for release-copy drafting. Add repo layout bindings, review docs, and declarative release metadata in project-local profiles when vendored.",
+                         "repo_match":  {
+                                            "root_markers":  [
+                                                                 ".git",
+                                                                 "README.md"
+                                                             ],
+                                            "remote_patterns":  [
+
+                                                                ]
+                                        },
+                         "bindings":  {
+                                          "primary_readme_path":  "README.md",
+                                          "settings_source_path":  null,
+                                          "publish_config_path":  null
+                                      },
+                         "packet_defaults":  {
+                                                 "review_docs":  {
+                                                                     "publish_packet":  [
+                                                                                            "README.md",
+                                                                                            "MAINTAINING.md"
+                                                                                        ],
+                                                                     "readme_packet":  [
+                                                                                           "README.md",
+                                                                                           "MAINTAINING.md",
+                                                                                           ".github/ISSUE_TEMPLATE/release_checklist.yml"
+                                                                                       ],
+                                                                     "changes_packet":  [
+                                                                                            "README.md",
+                                                                                            "MAINTAINING.md",
+                                                                                            ".github/workflows/release.yml"
+                                                                                        ],
+                                                                     "checklist_packet":  [
+                                                                                              ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                                                                              ".github/workflows/release.yml",
+                                                                                              "MAINTAINING.md"
+                                                                                          ],
+                                                                     "evidence_packet":  [
+                                                                                             "README.md",
+                                                                                             "MAINTAINING.md",
+                                                                                             ".github/workflows/release.yml"
+                                                                                         ]
+                                                                 },
+                                                 "source_path_globs":  {
+                                                                           "publish_packet":  [
+                                                                                                  "**/PublishConfiguration.xml"
+                                                                                              ],
+                                                                           "readme_packet":  [
+                                                                                                 "README.md",
+                                                                                                 "MAINTAINING.md",
+                                                                                                 ".github/ISSUE_TEMPLATE/*.yml"
+                                                                                             ],
+                                                                           "changes_packet":  [
+                                                                                                  "src/**",
+                                                                                                  "release/**",
+                                                                                                  ".github/workflows/release.yml"
+                                                                                              ],
+                                                                           "checklist_packet":  [
+                                                                                                    ".github/ISSUE_TEMPLATE/*.yml",
+                                                                                                    ".github/workflows/release.yml",
+                                                                                                    "docs/**"
+                                                                                                ],
+                                                                           "evidence_packet":  [
+                                                                                                   ".github/**",
+                                                                                                   "docs/**",
+                                                                                                   "README.md"
+                                                                                               ]
+                                                                       }
+                                             },
+                         "lint_rules":  {
+                                            "require_readme_settings_table":  false,
+                                            "missing_review_docs_are_errors":  false
+                                        },
+                         "extra":  {
+                                       "release_copy":  {
+                                                            "maintaining_path":  "MAINTAINING.md",
+                                                            "release_checklist_template_path":  ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                                            "release_workflow_path":  ".github/workflows/release.yml",
+                                                            "allowed_publish_fields":  [
+                                                                                           "short_description",
+                                                                                           "long_description",
+                                                                                           "mod_version",
+                                                                                           "change_log"
+                                                                                       ],
+                                                            "allowed_readme_sections":  [
+                                                                                            "Current Release",
+                                                                                            "Current Status"
+                                                                                        ],
+                                                            "issue_defaults":  {
+                                                                                   "title_prefix":  "[Release]",
+                                                                                   "label_names":  [
+                                                                                                       "release"
+                                                                                                   ],
+                                                                                   "project_mode":  "none"
+                                                                               }
+                                                        }
+                                   },
+                         "notes":  [
+                                       "Keep release gates, helper handoff policy, and repo-specific wording constraints in the consumer-local wrapper.",
+                                       "Do not encode validator or apply behavior in this profile.",
+                                       "The retained default scaffold keeps repo-specific bindings null; add them in a project-local override before running the workflow."
+                                   ]
+                     },
+    "builder_versioning":  {
+                               "builder_family":  "packet-workflow",
+                               "builder_semver":  "0.1.0",
+                               "compatibility_epoch":  1,
+                               "builder_spec_schema_version":  1,
+                               "repo_profile_schema_version":  1
+                           }
+}

--- a/builders/packet-workflow/retained-skills/draft-release-copy/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/migration-worksheet.md
@@ -1,0 +1,6 @@
+# Migration Worksheet: draft-release-copy
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/draft-release-copy/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/profiles/default/profile.json
@@ -1,0 +1,113 @@
+{
+    "bindings":  {
+                     "primary_readme_path":  "README.md",
+                     "publish_config_path":  null,
+                     "settings_source_path":  null
+                 },
+    "extra":  {
+                  "release_copy":  {
+                                       "allowed_publish_fields":  [
+                                                                      "short_description",
+                                                                      "long_description",
+                                                                      "mod_version",
+                                                                      "change_log"
+                                                                  ],
+                                       "allowed_readme_sections":  [
+                                                                       "Current Release",
+                                                                       "Current Status"
+                                                                   ],
+                                       "issue_defaults":  {
+                                                              "label_names":  [
+                                                                                  "release"
+                                                                              ],
+                                                              "project_mode":  "none",
+                                                              "title_prefix":  "[Release]"
+                                                          },
+                                       "maintaining_path":  "MAINTAINING.md",
+                                       "release_checklist_template_path":  ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                       "release_workflow_path":  ".github/workflows/release.yml"
+                                   }
+              },
+    "lint_rules":  {
+                       "missing_review_docs_are_errors":  false,
+                       "require_readme_settings_table":  false
+                   },
+    "name":  "default",
+    "notes":  [
+                  "Keep release gates, helper handoff policy, and repo-specific wording constraints in the consumer-local wrapper.",
+                  "Do not encode validator or apply behavior in this profile.",
+                  "The retained default scaffold keeps repo-specific bindings null; add them in a project-local override before running the workflow."
+              ],
+    "packet_defaults":  {
+                            "review_docs":  {
+                                                "changes_packet":  [
+                                                                       "README.md",
+                                                                       "MAINTAINING.md",
+                                                                       ".github/workflows/release.yml"
+                                                                   ],
+                                                "checklist_packet":  [
+                                                                         ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                                                         ".github/workflows/release.yml",
+                                                                         "MAINTAINING.md"
+                                                                     ],
+                                                "evidence_packet":  [
+                                                                        "README.md",
+                                                                        "MAINTAINING.md",
+                                                                        ".github/workflows/release.yml"
+                                                                    ],
+                                                "publish_packet":  [
+                                                                       "README.md",
+                                                                       "MAINTAINING.md"
+                                                                   ],
+                                                "readme_packet":  [
+                                                                      "README.md",
+                                                                      "MAINTAINING.md",
+                                                                      ".github/ISSUE_TEMPLATE/release_checklist.yml"
+                                                                  ]
+                                            },
+                            "source_path_globs":  {
+                                                      "changes_packet":  [
+                                                                             "src/**",
+                                                                             "release/**",
+                                                                             ".github/workflows/release.yml"
+                                                                         ],
+                                                      "checklist_packet":  [
+                                                                               ".github/ISSUE_TEMPLATE/*.yml",
+                                                                               ".github/workflows/release.yml",
+                                                                               "docs/**"
+                                                                           ],
+                                                      "evidence_packet":  [
+                                                                              ".github/**",
+                                                                              "docs/**",
+                                                                              "README.md"
+                                                                          ],
+                                                      "publish_packet":  [
+                                                                             "**/PublishConfiguration.xml"
+                                                                         ],
+                                                      "readme_packet":  [
+                                                                            "README.md",
+                                                                            "MAINTAINING.md",
+                                                                            ".github/ISSUE_TEMPLATE/*.yml"
+                                                                        ]
+                                                  }
+                        },
+    "profile_path":  "profiles/default/profile.json",
+    "repo_match":  {
+                       "remote_patterns":  [
+
+                                           ],
+                       "root_markers":  [
+                                            ".git",
+                                            "README.md"
+                                        ]
+                   },
+    "summary":  "Neutral reusable profile scaffold for release-copy drafting. Add repo layout bindings, review docs, and declarative release metadata in project-local profiles when vendored.",
+    "metadata":  {
+                     "versioning":  {
+                                        "builder_family":  "packet-workflow",
+                                        "builder_semver":  "0.1.0",
+                                        "compatibility_epoch":  1,
+                                        "repo_profile_schema_version":  1
+                                    }
+                 }
+}

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/architecture-note.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/architecture-note.md
@@ -1,0 +1,91 @@
+# Prepare Release Copy Architecture Note
+
+This note explains why `draft-release-copy` keeps a `packet-heavy-orchestrator` shape instead of collapsing into either a flat-contract mutation skill or a fully hierarchical candidate workflow.
+
+## Why This Profile Exists
+
+Flat-contract skills are the default and usually simpler. `draft-release-copy` is an exception because the local agent must synthesize all of these together before mutation:
+
+- release-gate applicability
+- publish metadata drift
+- README current-state drift
+- shipped-change evidence
+- existing release-issue delta
+- helper handoff policy
+
+That combination is too broad for a single worker-facing packet and too coupled to leave final wording outside a local decision packet. The result is:
+
+- compact focused packets for narrow worker analysis
+- one local-only `synthesis_packet.json` for final drafting
+- validator/apply remaining deterministic and narrow
+
+## Why Not A Flat Mutation Profile
+
+A flat mutation profile would force the local agent to reread raw release sources too often. That works operationally, but it weakens the packet workflow by making raw reread compensatory instead of exceptional.
+
+## Why Not A Fully Hierarchical Candidate Profile
+
+This skill still does not want worker-authored candidate inventories. Final release wording, final issue wording, and mutation authority remain local. A hierarchical candidate/result contract would add structure that the apply boundary does not need.
+
+## Common-Path Rule
+
+`synthesis_packet.json must be sufficient for local final drafting in the common path; raw reread should be exceptional, not compensatory.`
+
+Common path means:
+
+- read `global_packet.json`
+- read `synthesis_packet.json`
+- open at most one focused packet
+- finish local final drafting without reopening raw release sources
+
+If this path fails because the packet set is not sufficient, treat that as packet insufficiency and stop. Do not silently compensate with broad rereads.
+
+## Runtime Vs Eval Split
+
+- runtime contract:
+  - `orchestrator.json`
+  - runtime packets
+  - validator/apply inputs and outputs
+- eval contract:
+  - `packet_metrics.json`
+  - `eval-log.json`
+  - smoke summaries
+
+Token-efficiency data belongs to the eval side. It is for regression visibility, not routing authority.
+
+## Field Role Rule
+
+- authority:
+  - `authority_order`
+  - `packet_worker_map`
+  - `common_path_contract`
+- metadata:
+  - `preferred_worker_families`
+- derived convenience:
+  - `recommended_workers`
+  - `optional_workers`
+- explanatory:
+  - `worker_selection_guidance`
+
+If these drift, the authority fields win.
+
+## Out Of Scope
+
+This skill intentionally does not do:
+
+- unsupported XML layout rewrites
+- broad README structure rewrites
+- narrative-only prose mutation outside deterministic apply
+- helper execution
+- worker-authored final release wording
+
+## Maintenance Note
+
+If you change packet names, authority order, smoke schema, or runtime/eval boundaries, update all of these in the same patch:
+
+- `release_copy_plan_contract.py`
+- `build_release_copy_packets.py`
+- `release-copy-contract.md`
+- `SKILL.md`
+- smoke output expectations
+- packet/build/eval tests

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/core-contract.md
@@ -147,6 +147,7 @@ Stop conditions:
 
 - Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/core-contract.md
@@ -1,0 +1,154 @@
+﻿# Draft Release Copy Core Contract
+
+This file captures the reusable packet-workflow core for the generated `draft-release-copy` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+
+## Core Metadata
+
+- `workflow_family`: `release-copy`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `packet-heavy-orchestrator`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `publish_packet.json`
+- `readme_packet.json`
+- `changes_packet.json`
+- `checklist_packet.json`
+- `evidence_packet.json`
+- Additional runtime packet:
+  - `synthesis_packet.json` for common-path local drafting and synthesis.
+
+Review mode overrides inherited by default:
+- diff churn exceeds a configured threshold
+- core runtime, config, or process files span multiple groups
+- generated files are present but are not the majority of the change
+
+Authority order:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+## Generic Worker Contract
+
+## Generic Adjudication Structure
+
+- This scaffold uses the `generic` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Generic flat mode does not require hierarchical `candidates[]` plus `footer` worker output.
+
+## Worker Families
+
+- The builder keeps worker-family structure generic and reusable across packet-driven workflows.
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+
+- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:
+- `repo_mapper`
+- `packet_explorer`
+- `docs_verifier`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `publish_packet`
+  - `packet_explorer`
+- `readme_packet`
+  - `packet_explorer`
+- `changes_packet`
+  - `evidence_summarizer`
+- `checklist_packet`
+  - `docs_verifier`
+- `evidence_packet`
+  - `docs_verifier`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Summary: Neutral reusable profile scaffold for release-copy drafting. Add repo layout bindings, review docs, and declarative release metadata in project-local profiles when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `publish_packet`
+    - `README.md`
+    - `MAINTAINING.md`
+
+  - `readme_packet`
+    - `README.md`
+    - `MAINTAINING.md`
+    - `.github/ISSUE_TEMPLATE/release_checklist.yml`
+  - `changes_packet`
+    - `README.md`
+    - `MAINTAINING.md`
+    - `.github/workflows/release.yml`
+  - `checklist_packet`
+    - `.github/ISSUE_TEMPLATE/release_checklist.yml`
+    - `.github/workflows/release.yml`
+    - `MAINTAINING.md`
+  - `evidence_packet`
+    - `README.md`
+    - `MAINTAINING.md`
+    - `.github/workflows/release.yml`
+- source path globs:
+  - `publish_packet`
+    - `**/PublishConfiguration.xml`
+  - `readme_packet`
+    - `README.md`
+    - `MAINTAINING.md`
+    - `.github/ISSUE_TEMPLATE/*.yml`
+  - `changes_packet`
+    - `src/**`
+    - `release/**`
+    - `.github/workflows/release.yml`
+  - `checklist_packet`
+    - `.github/ISSUE_TEMPLATE/*.yml`
+    - `.github/workflows/release.yml`
+    - `docs/**`
+  - `evidence_packet`
+    - `.github/**`
+    - `docs/**`
+    - `README.md`
+- Default lint rules:
+- `require_readme_settings_table`: false
+- `missing_review_docs_are_errors`: false
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes`r`n`r`n- Optional local helpers remain non-authoritative even when collected.`r`n- Final plan confidence is recomputed locally even when worker confidence signals are present.`r`n- The retained default scaffold keeps repo-specific bindings null and is expected to be specialized by a project-local override before runtime collection.
+

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/delegation-playbook.md
@@ -1,0 +1,124 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`: no workers
+- `targeted-delegation`: 1-2 analysis workers
+- `broad-delegation`: 3-4 analysis workers
+- Optional QA worker: only when packet findings conflict or broad mutation needs a final coverage pass
+
+## Packet Order
+
+- Every worker reads `global_packet.json` first.
+- Prefer `batch-packet-*.json` when it exists and the orchestrator points to grouped work.
+- Read singleton focused packets only for work not covered by a batch.
+- Keep each worker on one small packet slice.
+
+## Shared Context
+
+`global_packet.json` keeps all workers aligned on:
+- workflow family
+- primary goal
+- authority order
+- stop conditions
+- review mode overrides
+- preferred worker families
+- packet worker map when configured
+- worker selection guidance
+- worker return contract
+- worker output shape
+- xHigh reread policy
+- candidate field bundles when decision-ready packets are enabled
+- worker footer fields when hierarchical output is enabled
+- reread reason values when decision-ready packets are enabled
+- domain overlay semantics when configured
+- optional local helper policy
+
+## Worker Return Modes
+
+- `generic`
+  - Use for simple workflows where the local orchestrator mainly needs a narrow outcome and evidence pointers.
+- `classification-oriented`
+  - Use for adjudication-heavy workflows where final adjudication stays local but workers must return proposal-grade candidate records.
+  - Prefer hierarchical `candidates[] + footer` output.
+
+## Worker Families
+
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+- Surfaced optional worker list below is the delegated-mode exposed list after stable dedupe and after subtracting explicitly mapped recommended worker types:
+- `repo_mapper`
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `publish_packet`
+  - `packet_explorer`
+- `readme_packet`
+  - `packet_explorer`
+- `changes_packet`
+  - `evidence_summarizer`
+- `checklist_packet`
+  - `docs_verifier`
+- `evidence_packet`
+  - `docs_verifier`
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Analysis Worker Contract
+
+Prefer the named worker families above before falling back to an unspecified narrow `gpt-5.4-mini` worker.
+
+- Active worker return contract: `generic`.
+- Active worker output shape: `flat`.
+- Return exactly:
+  - `packet ids`
+  - `primary outcome`
+  - `evidence files`
+  - `recommended next step`
+  - `risk`
+  - `tests or checks`
+
+Do not draft the final user-facing response in worker output. The main agent owns final synthesis.
+Final plan confidence is recomputed locally even when worker confidence signals are present.
+
+## Mutation Guardrails
+
+- Keep final mutation local unless the generated skill explicitly narrows a safe worker-owned edit slice.
+- If the skill handles repo or remote mutations, do not ask a worker to own the whole mutation path from scratch.
+- If findings conflict, keep the result local and add QA instead of widening worker scope.
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $draft-release-copy to analyze packet-driven workflow inputs.
+
+Read only:
+- <global-packet>
+- <focused-packet-or-batch-packet>
+- <specific file slice if needed>
+
+Return exactly:
+- packet ids
+- primary outcome
+- evidence files
+- recommended next step
+- risk
+- tests or checks
+```
+
+Keep each worker narrow. Do not ask a worker to rediscover the whole repo state from scratch.

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/maintenance-note.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/maintenance-note.md
@@ -1,0 +1,36 @@
+# Prepare Release Copy Maintenance Note
+
+Use this note when updating the skill as a reference packet workflow, not just as an operational tool.
+
+## Keep These Surfaces In Sync
+
+- `scripts/release_copy_plan_contract.py`
+- `scripts/build_release_copy_packets.py`
+- `scripts/smoke_prepare_release_copy.py`
+- `SKILL.md`
+- `references/release-copy-contract.md`
+- `references/architecture-note.md`
+- tests that lock packet interface, runtime/eval split, and authority-vs-convenience fields
+
+## Change Checklist
+
+When changing packet or contract structure, confirm all of these:
+
+- packet names still match the canonical interface
+- authority fields and derived convenience fields are still clearly separated
+- runtime artifacts did not absorb eval-only metrics
+- smoke output schema still matches the documented fields
+- out-of-scope boundaries are still documented
+- tests still lock the changed contract shape
+
+## Reference-Grade Standard
+
+This skill counts as reference-grade only when the same shape appears in code, docs, and tests:
+
+- packet interface
+- authority order
+- common-path semantics
+- runtime/eval artifact split
+- smoke output schema
+- out-of-scope note
+- maintenance note

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/release-copy-contract.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/release-copy-contract.md
@@ -1,0 +1,222 @@
+# Release Copy Contract
+
+This file is the canonical top-level interface reference for `draft-release-copy`.
+
+Read [`architecture-note.md`](architecture-note.md) for why this skill keeps the current `packet-heavy-orchestrator` profile. Read [`maintenance-note.md`](maintenance-note.md) before changing packet names, authority order, or runtime/eval boundaries.
+
+## Canonical Interface
+
+### Runtime Artifacts
+
+- `orchestrator.json`
+- `global_packet.json`
+- `publish_packet.json`
+- `readme_packet.json`
+- `changes_packet.json`
+- `checklist_packet.json`
+- `synthesis_packet.json`
+- optional `evidence_packet.json`
+
+### Eval Artifacts
+
+- `packet_metrics.json`
+- `eval-log.json`
+
+### Canonical Local Interfaces
+
+- local draft: `release-copy-plan.json`
+- validator output: normalized validation JSON from `validate_release_copy.py`
+- apply input: validator output only
+- apply result: JSON from `apply_release_copy.py --result-output ...`
+
+## Builder Metadata
+
+- `workflow_family`: `release-copy`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `packet-heavy-orchestrator`
+- `decision_ready_packets`: `local-only synthesis packet plus compact worker packets`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+Trigger phrases:
+- prepare release copy
+- update release changelog
+- draft release checklist issue
+- verify release gate evidence
+
+## Packet Interface
+
+- `global_packet.json`
+  - shared operational context
+  - authority order
+  - gate summary
+  - helper policy
+  - disallowed claims
+- `publish_packet.json`
+  - current publish fields
+  - prior release changelog
+  - rewrite-required publish fields
+- `readme_packet.json`
+  - README intro
+  - current release/status sections
+  - settings-default drift
+- `changes_packet.json`
+  - shipped-change topic signals
+  - top churn files
+  - representative files
+  - condensed commit subjects
+- `checklist_packet.json`
+  - release issue delta
+  - template structure
+  - unresolved placeholders
+- `evidence_packet.json`
+  - normalized evidence fields only
+  - missing evidence summary only
+- `synthesis_packet.json`
+  - local final drafting packet
+  - common-path decision basis
+  - publish/readme/issue rewrite guidance
+  - explicit stop risks
+
+## Authority Order
+
+Use this order when sources disagree:
+
+1. tracked release rules and metadata
+2. tracked runtime defaults
+3. tracked release diff since the base tag
+4. optional evidence input
+5. optional repo-relative local helper
+
+The local helper is never the authority for player-facing wording.
+
+## Runtime Vs Eval Split
+
+- `orchestrator.json` is the runtime contract.
+  - Keep worker routing, common-path drafting, and validator/apply guardrails here.
+- `packet_metrics.json` is eval-only.
+  - Keep packet sizes, token-proxy estimates, and savings here.
+- `eval-log.json` is the accumulated regression and run-quality artifact.
+  - Merge `packet_metrics.json` during the build phase instead of treating sizing metrics as runtime routing inputs.
+
+## Field Roles
+
+### Authority Fields
+
+- `authority_order`
+- `packet_worker_map`
+- `common_path_contract`
+- `shared_packet`
+- `shared_local_packet`
+
+### Registry Metadata
+
+- `preferred_worker_families`
+
+### Derived Convenience Fields
+
+- `recommended_workers`
+- `optional_workers`
+
+### Explanatory Fields
+
+- `worker_selection_guidance`
+
+Rules:
+- `packet_worker_map` is the routing authority.
+- `preferred_worker_families` is descriptive registry metadata only.
+- `recommended_workers` and `optional_workers` are derived convenience fields only.
+- `worker_selection_guidance` is explanatory only and must not be treated as a routing source.
+
+## Common-Path Semantics
+
+- common-path local drafting must finish from:
+  - `global_packet.json`
+  - `synthesis_packet.json`
+  - at most one focused packet
+- `synthesis_packet.json` must be sufficient for local final drafting in the common path.
+- raw reread is exceptional, not compensatory.
+- `packet insufficiency` is a failure, not a normal fallback.
+- deterministic apply is narrower than local drafting:
+  - `PublishConfiguration.xml`: allowlisted field replacement only
+  - `README.md`: intro text and allowlisted section replacement only
+  - release issue: validator-normalized issue action only
+
+## Required Release Copy Properties
+
+- Keep `PublishConfiguration.xml` and `README.md` aligned on what is shipped now.
+- Treat `PublishConfiguration.xml` `ChangeLog` as first-class release copy.
+- Treat `ChangeLog` as release-scoped, not cumulative.
+- Keep setting-default claims aligned with `Setting.cs`.
+- Keep `ChangeLog` bullets supported by the diff since the base tag.
+- Keep helper wording local and optional.
+
+## Freshness Before Apply
+
+- Treat collected context, lint output, packets, and any auto-discovered existing release issue snapshot as stale once `HEAD`, `base_tag`, `target_version`, evidence inputs, or the open release issue title/body changes.
+- Refresh `collect -> lint -> build` before editing files or invoking `create_release_issue.py` after a stale change.
+- Validator/apply must compare the collected freshness tuple and source fingerprints against live repo state before mutation.
+
+## Plan / Validate / Apply Contract
+
+- Local draft output is `release-copy-plan.json`.
+- Validator normalizes and strips unknown extra fields.
+- Local input-contract failures must stop before any `gh` command runs.
+- Validator fails closed on:
+  - stale `HEAD`
+  - stale release source fingerprints
+  - stale existing issue snapshots
+  - missing auth
+  - missing required project scope
+  - packet insufficiency / compensatory rereads
+- Apply consumes validator-normalized output only.
+- `--dry-run` uses the same normalized input path as real apply.
+
+## Release Checklist Issue Contract
+
+- Title format: `[Release] vX.Y.Z`
+- Label: `release`
+- Prefer reusing an existing open `[Release] vX.Y.Z` issue over creating a duplicate.
+- Template section order:
+  - `Target version`
+  - `Included changes`
+  - `Release-gate evidence / validation`
+  - `Checklist`
+
+## Gate Policy
+
+- Determine applicable release-gate or validation tracks from shipped change scope.
+- Software-track changes require software evidence when applicable.
+- Telemetry validation never replaces software evidence when both apply.
+- If no scoped gate applies, say so explicitly instead of inventing one.
+
+## Smoke Output Schema
+
+`smoke_prepare_release_copy.py` should emit:
+
+- `status`
+- `reason`
+- `repo_root`
+- `next_action`
+
+It may include additional run details such as packet counts and token-proxy metrics.
+
+## Out Of Scope
+
+- broad README restructuring
+- unsupported XML layout rewrites
+- narrative-only release prose that cannot be expressed through deterministic apply
+- executing the local helper
+- treating worker output as final player-facing text
+
+## Maintenance Note
+
+When changing this skill, keep these in sync:
+
+- `release_copy_plan_contract.py`
+- `build_release_copy_packets.py`
+- `SKILL.md`
+- `architecture-note.md`
+- this contract file
+- smoke output expectations
+- tests that lock field roles, packet interface, and eval/runtime split

--- a/builders/packet-workflow/retained-skills/draft-release-copy/references/release-copy-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/references/release-copy-evaluation-contract.md
@@ -1,0 +1,77 @@
+# Release Copy Evaluation Contract
+
+Use the shared envelope in `references/evaluation-log-contract.md` and keep workflow-specific metrics under `skill_specific.data`.
+
+## Skill-Specific Focus
+
+Record the signals that matter for release-copy preparation:
+- release tag and branch context
+- review mode and packet mix
+- packet count and packet-size concentration
+- token-proxy savings estimates
+- common-path reread behavior
+- changelog rewrite scope
+- release issue creation status
+- project scope availability and project add policy
+- local helper handoff availability
+
+## Skill-Specific Data
+
+Keep these values in `skill_specific.data` when they are available:
+- `release_tag`
+- `branch`
+- `review_mode`
+- `selected_packets`
+- `worker_count`
+- `worker_mix`
+- `packet_count`
+- `largest_packet_bytes`
+- `largest_two_packets_bytes`
+- `estimated_local_only_tokens`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+- `changelog_lines`
+- `publish_fields_changed`
+- `readme_sections_changed`
+- `release_issue_url`
+- `issue_creation_status`
+- `project_mode`
+- `project_scope_available`
+- `project_flag_used`
+- `local_release_helper_status`
+- `local_release_helper_handoff_available`
+- `stop_reasons`
+- `raw_reread_count`
+- `compensatory_reread_detected`
+- `deterministic_file_edit_count`
+- `issue_action_attempted`
+
+## Phase Guidance
+
+- `init`
+  - capture the release context, lint report, and packet orchestration snapshot
+- `build`
+  - merge `packet_metrics.json` so token-efficiency and packet-size metrics live in evaluation data instead of the runtime contract
+- `phase`
+  - record lint, validate, dry-run, rewrite, or issue-action results
+- `finalize`
+  - record the final release issue URL and the helper handoff status
+
+## Runtime Vs Eval Reminder
+
+- runtime packet fields belong in `orchestrator.json` and the runtime packets
+- packet sizing and token-proxy metrics belong in `packet_metrics.json`
+- smoke summaries should keep a short operator schema and may append additional detail fields without replacing the core smoke keys
+
+## Safety Signals
+
+Prefer recording these when validator/apply runs are present:
+- `validation_run`
+- `validation_passed`
+- `fingerprint_match`
+- `apply_succeeded`
+- `rollback_needed`
+- `mutation_type`
+- `stop_reasons`
+- `raw_reread_count`
+- `compensatory_reread_detected`

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/apply_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/apply_release_copy.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Apply a validated release-copy plan using normalized validator output only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import create_release_issue as issue_tools
+import release_copy_plan_tools as plan_tools
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--validation", required=True, help="Path to validator output JSON")
+    parser.add_argument("--dry-run", action="store_true", help="Plan mutations without writing files or mutating GitHub")
+    parser.add_argument("--result-output", help="Optional path to write the apply result JSON")
+    return parser.parse_args()
+
+
+def fail(payload: dict[str, Any], output_path: Path | None, reason: str, message: str, **extra: Any) -> int:
+    payload.update(extra)
+    payload["apply_succeeded"] = False
+    payload["stop_reason"] = reason
+    payload["stop_reasons"] = [reason]
+    if output_path is not None:
+        plan_tools.write_json(output_path, payload)
+    print(f"apply_release_copy.py: {message}")
+    return 1
+
+
+def normalized_plan_from_validation(validation: dict[str, Any]) -> dict[str, Any]:
+    normalized_plan = validation.get("normalized_plan")
+    if not isinstance(normalized_plan, dict):
+        raise RuntimeError("validator output is missing `normalized_plan`")
+    expected_fingerprint = str(validation.get("normalized_plan_fingerprint") or "").strip()
+    if not expected_fingerprint:
+        raise RuntimeError("validator output is missing `normalized_plan_fingerprint`")
+    if plan_tools.json_fingerprint(normalized_plan) != expected_fingerprint:
+        raise RuntimeError("validator mismatch: normalized-plan fingerprint changed")
+    if not validation.get("valid"):
+        raise RuntimeError("refusing to apply validator output marked invalid")
+    if not validation.get("can_apply"):
+        raise RuntimeError("refusing to apply validator output marked not apply-safe")
+    gate = validation.get("apply_gate_status") or {}
+    if gate.get("uncovered_stop_categories"):
+        raise RuntimeError("refusing to apply while applicable stop categories remain uncovered")
+    return normalized_plan
+
+
+def check_source_fingerprints(normalized_plan: dict[str, Any]) -> list[str]:
+    stale_sources: list[str] = []
+    source_fingerprints = normalized_plan.get("source_fingerprints") or {}
+    rule_files = normalized_plan.get("rule_files") or {}
+    for key in ("publish_configuration", "readme"):
+        path_text = str(rule_files.get(key) or "").strip()
+        expected = str(source_fingerprints.get(key) or "").strip()
+        if not path_text or not expected:
+            continue
+        current_text = Path(path_text).read_text(encoding="utf-8")
+        if plan_tools.json_fingerprint(current_text) != expected:
+            stale_sources.append(key)
+    return stale_sources
+
+
+def main() -> int:
+    args = parse_args()
+    validation = plan_tools.load_json(Path(args.validation).resolve())
+    result_output = Path(args.result_output).resolve() if args.result_output else None
+    payload: dict[str, Any] = {
+        "dry_run": args.dry_run,
+        "validation_source": "validator_normalized_plan",
+        "mutation_type": "release_copy_apply",
+        "mutations": [],
+        "rollback_needed": False,
+        "rolled_back_files": [],
+        "deterministic_file_edit_count": 0,
+        "issue_action_attempted": False,
+        "raw_reread_count": 0,
+        "compensatory_reread_detected": False,
+    }
+
+    try:
+        normalized_plan = normalized_plan_from_validation(validation)
+    except Exception as exc:
+        return fail(payload, result_output, "validator_mismatch", str(exc))
+
+    repo_root = Path(str(normalized_plan.get("repo_root") or ".")).resolve()
+    payload["normalized_plan_fingerprint"] = str(validation.get("normalized_plan_fingerprint") or "")
+    payload["validation_commands"] = list(normalized_plan.get("validation_commands") or [])
+    draft_basis = normalized_plan.get("draft_basis") or {}
+    payload["raw_reread_count"] = int(draft_basis.get("raw_reread_count", 0) or 0)
+    payload["compensatory_reread_detected"] = bool(draft_basis.get("compensatory_reread_detected"))
+
+    try:
+        current_head = plan_tools.current_head_commit(repo_root)
+    except Exception as exc:
+        return fail(payload, result_output, "stale_context", str(exc))
+
+    expected_head = str((normalized_plan.get("freshness_tuple") or {}).get("head_commit") or "").strip()
+    if expected_head and current_head != expected_head:
+        return fail(
+            payload,
+            result_output,
+            "stale_context",
+            "HEAD changed after validation; rerun collect -> lint -> validate before apply",
+            current_head=current_head,
+            expected_head=expected_head,
+        )
+
+    stale_sources = check_source_fingerprints(normalized_plan)
+    if stale_sources:
+        return fail(
+            payload,
+            result_output,
+            "stale_context",
+            "Release source files changed after validation; rerun validation before apply",
+            stale_sources=stale_sources,
+        )
+
+    issue_action = normalized_plan.get("issue_action") or {}
+    issue_mode = str(issue_action.get("mode") or "noop").strip()
+    repo_slug = normalized_plan.get("repo_slug")
+    validated_issue_snapshot = normalized_plan.get("validated_existing_issue_snapshot")
+
+    if issue_mode != "noop":
+        try:
+            auth_status = issue_tools.run_command(["gh", "auth", "status"], cwd=repo_root)
+        except Exception as exc:
+            return fail(payload, result_output, "missing_auth", str(exc))
+        if str(issue_action.get("project_mode") or "") == "require-scope" and "project" not in auth_status.lower():
+            return fail(
+                payload,
+                result_output,
+                "project_scope_required",
+                "validated issue action requires project scope, but current gh auth status does not include it",
+            )
+        if issue_mode in {"reuse-existing", "sync-existing-body"} and isinstance(validated_issue_snapshot, dict):
+            issue_number = int(validated_issue_snapshot.get("number") or 0)
+            live_issue = plan_tools.fetch_issue_snapshot(repo_root, repo_slug, issue_number)
+            live_snapshot = plan_tools.existing_issue_snapshot(live_issue)
+            if live_snapshot != validated_issue_snapshot:
+                return fail(
+                    payload,
+                    result_output,
+                    "stale_issue_snapshot",
+                    "release issue snapshot changed after validation; rerun validation before apply",
+                )
+
+    backups: dict[Path, str] = {}
+
+    def remember_backup(path: Path) -> None:
+        if path not in backups:
+            backups[path] = path.read_text(encoding="utf-8")
+
+    mutations: list[dict[str, Any]] = []
+    try:
+        publish_update = normalized_plan.get("publish_update") or {}
+        if publish_update.get("mode") == "replace-fields":
+            publish_path = Path(str((normalized_plan.get("rule_files") or {}).get("publish_configuration") or "")).resolve()
+            remember_backup(publish_path)
+            mutations.append(
+                plan_tools.apply_publish_update(
+                    publish_path,
+                    dict(publish_update.get("fields") or {}),
+                    args.dry_run,
+                )
+            )
+
+        readme_update = normalized_plan.get("readme_update") or {}
+        if readme_update.get("mode") == "replace-sections":
+            readme_path = Path(str((normalized_plan.get("rule_files") or {}).get("readme") or "")).resolve()
+            remember_backup(readme_path)
+            mutations.append(
+                plan_tools.apply_readme_update(
+                    readme_path,
+                    readme_update.get("intro_text"),
+                    dict(readme_update.get("sections") or {}),
+                    args.dry_run,
+                )
+            )
+
+        if issue_mode != "noop":
+            payload["issue_action_attempted"] = True
+            body_markdown = str(issue_action.get("body_markdown") or "")
+            temp_root = repo_root / ".codex" / "tmp" / "packet-workflow" / "draft-release-copy"
+            temp_root.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                suffix=".md",
+                dir=temp_root,
+                delete=False,
+            ) as temp_file:
+                temp_file.write(body_markdown)
+                body_path = Path(temp_file.name)
+            try:
+                issue_payload = issue_tools.execute_issue_action(
+                    title=str(issue_action.get("title") or ""),
+                    body_path=body_path,
+                    repo_root=repo_root,
+                    project_title=str(issue_action.get("project_title") or issue_tools.DEFAULT_PROJECT_TITLE),
+                    project_mode=str(issue_action.get("project_mode") or "auto-add-first"),
+                    local_release_helper_status=str(normalized_plan.get("local_release_helper_status") or "unknown"),
+                    reuse_existing=issue_mode in {"reuse-existing", "sync-existing-body"},
+                    sync_existing_body=issue_mode == "sync-existing-body",
+                    dry_run=args.dry_run,
+                    result_output=None,
+                )
+            finally:
+                body_path.unlink(missing_ok=True)
+
+            mutations.append(
+                {
+                    "kind": "issue_action",
+                    "mode": issue_mode,
+                    "url": issue_payload.get("created_issue_url"),
+                    "issue_number": issue_payload.get("existing_issue_number"),
+                    "changed": True,
+                    "command": issue_payload.get("command"),
+                }
+            )
+            payload["release_issue_url"] = issue_payload.get("created_issue_url")
+
+    except Exception as exc:
+        payload["deterministic_file_edit_count"] = sum(
+            1 for item in mutations if item.get("kind") in {"publish_configuration", "readme"}
+        )
+        if not args.dry_run:
+            for path, original in backups.items():
+                path.write_text(original, encoding="utf-8")
+            payload["rolled_back_files"] = [str(path) for path in backups]
+            payload["rollback_needed"] = bool(backups)
+        return fail(payload, result_output, "apply_failed", str(exc), mutations=mutations)
+
+    payload["mutations"] = mutations
+    payload["deterministic_file_edit_count"] = sum(
+        1 for item in mutations if item.get("kind") in {"publish_configuration", "readme"}
+    )
+    payload["apply_succeeded"] = True
+    payload["primary_artifact"] = payload.get("release_issue_url")
+    if result_output is not None:
+        plan_tools.write_json(result_output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/build_release_copy_packets.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/build_release_copy_packets.py
@@ -1,0 +1,794 @@
+#!/usr/bin/env python3
+"""Build compact yet drafting-sufficient packets for draft-release-copy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import lint_release_copy as lint_tools
+import release_copy_plan_contract as contract
+
+
+GENERATED_FILE_PATTERNS = (
+    re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
+    re.compile(r"\.(g|generated)\.[^.]+$"),
+    re.compile(r"\.designer\.[^.]+$"),
+    re.compile(r"(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|cargo\.lock)$"),
+    re.compile(r"\.min\.(js|css)$"),
+)
+
+SYNTHESIS_REQUIRED_KEYS = {
+    "target_version",
+    "base_tag",
+    "applicable_gate_tracks",
+    "evidence_complete",
+    "conservative_wording_requirements",
+    "publish_rewrite",
+    "readme_rewrite",
+    "shipped_change_summary",
+    "issue_recommendation",
+    "precheck_eligibility",
+    "helper_handoff",
+    "explicit_stop_risks",
+    "common_path_contract",
+    "plan_defaults",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def parse_diff_totals(diff_stat: str | None) -> dict[str, int] | None:
+    if not diff_stat:
+        return None
+    last_line = diff_stat.strip().splitlines()[-1]
+    files_match = re.search(r"(?P<files>\d+) files? changed", last_line)
+    insertions_match = re.search(r"(?P<insertions>\d+) insertions?\(\+\)", last_line)
+    deletions_match = re.search(r"(?P<deletions>\d+) deletions?\(-\)", last_line)
+    if not files_match and not insertions_match and not deletions_match:
+        return None
+    files_changed = int(files_match.group("files")) if files_match else 0
+    insertions = int(insertions_match.group("insertions")) if insertions_match else 0
+    deletions = int(deletions_match.group("deletions")) if deletions_match else 0
+    return {
+        "files_changed": files_changed,
+        "insertions": insertions,
+        "deletions": deletions,
+        "churn": insertions + deletions,
+    }
+
+
+def is_generated_file(path: str) -> bool:
+    lowered = path.replace("\\", "/").lower()
+    return any(pattern.search(lowered) for pattern in GENERATED_FILE_PATTERNS)
+
+
+def core_area_for_path(path: str) -> str | None:
+    lowered = path.replace("\\", "/").lower()
+    if lowered.startswith(("noofficedemandfix/systems/", "noofficedemandfix/patches/", "noofficedemandfix/telemetry/")):
+        return "runtime"
+    if lowered in {"noofficedemandfix/mod.cs", "noofficedemandfix/setting.cs"}:
+        return "runtime"
+    if lowered.startswith((".github/workflows/", ".github/scripts/", ".github/issue_template/", ".github/instructions/")):
+        return "process"
+    if lowered in {".github/pull_request_template.md", "contributing.md", "maintaining.md", "readme.md"}:
+        return "process"
+    if lowered.endswith((".csproj", ".props", ".targets")) or lowered in {
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "poetry.lock",
+        "cargo.lock",
+    }:
+        return "config"
+    return None
+
+
+def active_groups(group_summary: dict[str, dict[str, Any]]) -> list[str]:
+    ordered = ("runtime", "automation", "docs", "tests", "config", "other")
+    return [name for name in ordered if (group_summary.get(name) or {}).get("count", 0) > 0]
+
+
+def review_mode(file_count: int, group_count: int, override_signals: list[dict[str, str]]) -> tuple[str, int]:
+    if file_count <= contract.SMALL_FILE_LIMIT and group_count <= contract.SMALL_GROUP_LIMIT:
+        mode = "local-only"
+    elif file_count > contract.MEDIUM_FILE_LIMIT or group_count >= contract.LARGE_GROUP_LIMIT:
+        mode = "broad-delegation"
+    else:
+        mode = "targeted-delegation"
+
+    if override_signals and mode == "local-only":
+        mode = "targeted-delegation"
+    elif override_signals and mode == "targeted-delegation":
+        mode = "broad-delegation"
+
+    if mode == "local-only":
+        return mode, 0
+    if mode == "targeted-delegation":
+        return mode, 2
+    return mode, 4 if group_count >= 5 else 3
+
+
+def packet_worker_map() -> dict[str, list[str]]:
+    return contract.packet_worker_map()
+
+
+def findings_for_area(lint_report: dict[str, Any], areas: set[str]) -> dict[str, list[dict[str, str]]]:
+    findings = lint_report.get("findings", {})
+    return {
+        level: [item for item in findings.get(level, []) if item.get("area") in areas]
+        for level in ("errors", "warnings", "info")
+    }
+
+
+def handoff_command(context: dict[str, Any], lint_report: dict[str, Any]) -> str | None:
+    helper = context.get("local_release_helper", {})
+    if helper.get("status") != "present":
+        return None
+    if not lint_report.get("checks", {}).get("helper_handoff_allowed"):
+        return None
+    helper_path = str(helper.get("repo_relative_path") or "")
+    if not helper_path.lower().endswith(".ps1"):
+        return None
+    target_version = str(context.get("target_version") or "").strip()
+    version_arg = target_version if target_version.startswith("v") else f"v{target_version}"
+    helper_cli_path = ".\\" + helper_path.replace("/", "\\")
+    return f"powershell -File {helper_cli_path} -Version {version_arg}"
+
+
+def unique_commit_subjects(subjects: list[str], limit: int = 4) -> list[str]:
+    unique: list[str] = []
+    for subject in subjects:
+        text = str(subject or "").strip()
+        if text and text not in unique:
+            unique.append(text)
+        if len(unique) >= limit:
+            break
+    return unique
+
+
+def top_churn_files(changed_file_stats: dict[str, dict[str, Any]], limit: int = 3) -> list[dict[str, Any]]:
+    ranked = []
+    for path, stats in changed_file_stats.items():
+        churn = int((stats or {}).get("churn", 0) or 0)
+        ranked.append(
+            {
+                "path": str(path),
+                "churn": churn,
+            }
+        )
+    ranked.sort(key=lambda item: (-item["churn"], item["path"]))
+    return ranked[:limit]
+
+
+def representative_files(context: dict[str, Any], limit: int = 5) -> list[str]:
+    groups = context.get("changed_file_groups") or {}
+    selected: list[str] = []
+    for group_name in ("runtime", "automation", "docs", "tests", "config", "other"):
+        sample_files = ((groups.get(group_name) or {}).get("sample_files") or [])
+        for path in sample_files:
+            text = str(path or "").strip()
+            if text and text not in selected:
+                selected.append(text)
+            if len(selected) >= limit:
+                return selected
+    for path in context.get("changed_files", []):
+        text = str(path or "").strip()
+        if text and text not in selected:
+            selected.append(text)
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def setting_default_mismatches(lint_report: dict[str, Any]) -> list[str]:
+    mismatches: list[str] = []
+    for finding in lint_report.get("findings", {}).get("warnings", []):
+        if finding.get("code") == "setting_default_mismatch":
+            message = str(finding.get("message") or "").strip()
+            if message:
+                mismatches.append(message)
+    return mismatches
+
+
+def significant_topic_signals(context: dict[str, Any]) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    for signal in lint_tools.significant_changelog_topics(context):
+        matching_files = list(signal.get("matching_files") or [])
+        sample_files = [str(item.get("path") or "").strip() for item in matching_files[:2] if str(item.get("path") or "").strip()]
+        signals.append(
+            {
+                "id": signal.get("id"),
+                "label": signal.get("label"),
+                "matching_file_count": int(signal.get("matching_file_count", 0) or 0),
+                "matching_subject_count": int(signal.get("matching_subject_count", 0) or 0),
+                "churn_sum": int(signal.get("churn_sum", 0) or 0),
+                "sample_files": sample_files,
+                "evidence_anchor": sample_files[0] if sample_files else signal.get("label"),
+            }
+        )
+    return signals
+
+
+def unresolved_evidence_placeholders(context: dict[str, Any], lint_report: dict[str, Any]) -> list[str]:
+    checks = lint_report.get("checks", {}) or {}
+    if checks.get("evidence_complete"):
+        return []
+    tracks = checks.get("applicable_validation_tracks", {}) or {}
+    placeholders: list[str] = []
+    if tracks.get("software_gate"):
+        placeholders.extend(
+            [
+                "comparable software evidence",
+                "software anchor comparison summary",
+                "software release PR validation note",
+            ]
+        )
+    if tracks.get("telemetry_validation"):
+        placeholders.extend(
+            [
+                "telemetry validation artifact",
+                "telemetry validation summary",
+            ]
+        )
+    if not placeholders:
+        placeholders.append("explicit note that no scoped release gate applies")
+    return placeholders
+
+
+def conservative_wording_requirements(lint_report: dict[str, Any]) -> list[str]:
+    checks = lint_report.get("checks", {}) or {}
+    requirements = [
+        "Do not present the software path as solved without complete applicable evidence.",
+        "Keep helper wording local and optional.",
+    ]
+    if not checks.get("evidence_complete"):
+        requirements.append("Keep release wording conservative and preserve unresolved evidence placeholders.")
+    if any((checks.get("applicable_validation_tracks") or {}).values()):
+        requirements.append("Match release-gate language to the applicable software or telemetry tracks.")
+    return requirements
+
+
+def explicit_stop_risks(lint_report: dict[str, Any], context: dict[str, Any]) -> list[dict[str, str]]:
+    risks: list[dict[str, str]] = []
+    checks = lint_report.get("checks", {}) or {}
+    if not checks.get("evidence_complete"):
+        risks.append(
+            {
+                "category": "release_gate_incomplete",
+                "message": "Applicable release-gate evidence is incomplete; conservative wording and unresolved checklist placeholders remain required.",
+            }
+        )
+    if str((context.get("local_release_helper") or {}).get("status") or "") == "missing_local_release_script":
+        risks.append(
+            {
+                "category": "missing_local_release_script",
+                "message": "Local helper handoff is unavailable; the workflow may continue without helper execution guidance.",
+            }
+        )
+    for finding in lint_report.get("findings", {}).get("errors", []):
+        message = str(finding.get("message") or "").strip()
+        if message:
+            risks.append({"category": str(finding.get("code") or "lint_error"), "message": message})
+    return risks
+
+
+def issue_delta_summary(existing_issue: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(existing_issue, dict):
+        return None
+    evidence = existing_issue.get("evidence") or {}
+    return {
+        "number": existing_issue.get("number"),
+        "title": str(existing_issue.get("title") or "").strip(),
+        "url": str(existing_issue.get("url") or "").strip(),
+        "state": str(existing_issue.get("state") or "").strip(),
+        "checked_item_count": len(list(existing_issue.get("checked_labels") or [])),
+        "evidence_keys_present": sorted(key for key, value in evidence.items() if str(value or "").strip()),
+    }
+
+
+def issue_defaults(context: dict[str, Any]) -> dict[str, Any]:
+    defaults = context.get("issue_defaults")
+    return defaults if isinstance(defaults, dict) else {}
+
+
+def issue_action_recommendation(context: dict[str, Any]) -> dict[str, Any]:
+    existing_issue = context.get("existing_release_issue")
+    title_prefix = str(issue_defaults(context).get("title_prefix") or "[Release]").strip() or "[Release]"
+    title = f"{title_prefix} {contract.normalize_release_version(str(context.get('target_version') or ''))}".strip()
+    if isinstance(existing_issue, dict):
+        return {
+            "mode": "sync-existing-body",
+            "title": title,
+            "reason": "A matching open release issue already exists; prefer reusing and syncing it.",
+        }
+    return {
+        "mode": "create",
+        "title": title,
+        "reason": "No matching open release issue was discovered; create a new one if the draft reaches apply-safe status.",
+    }
+
+
+def publish_rewrite_guidance(context: dict[str, Any], lint_report: dict[str, Any], topic_signals: list[dict[str, Any]]) -> dict[str, Any]:
+    checks = lint_report.get("checks", {}) or {}
+    publish = context.get("publish_configuration", {}) or {}
+    prior = context.get("base_tag_publish_configuration", {}) or {}
+    rewrite_fields = ["change_log"]
+    if checks.get("rewrite_publish_recommended"):
+        rewrite_fields.extend(["short_description", "long_description"])
+    if publish.get("mod_version") != context.get("target_version"):
+        rewrite_fields.append("mod_version")
+    rewrite_fields = [field for index, field in enumerate(rewrite_fields) if field not in rewrite_fields[:index]]
+    return {
+        "current": {
+            "short_description": publish.get("short_description"),
+            "long_description": publish.get("long_description"),
+            "change_log": publish.get("change_log"),
+            "mod_version": publish.get("mod_version"),
+        },
+        "prior_release_change_log": prior.get("change_log"),
+        "rewrite_required_fields": rewrite_fields,
+        "topic_anchors": [
+            {
+                "topic": signal.get("label"),
+                "evidence_anchor": signal.get("evidence_anchor"),
+            }
+            for signal in topic_signals
+        ],
+        "lint_findings": findings_for_area(lint_report, {"publish"}),
+    }
+
+
+def readme_rewrite_guidance(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, Any]:
+    checks = lint_report.get("checks", {}) or {}
+    readme = context.get("readme", {}) or {}
+    rewrite_sections: list[str] = []
+    rewrite_intro = False
+    if checks.get("rewrite_readme_recommended"):
+        rewrite_sections.extend(["Current Release", "Current Status"])
+        rewrite_intro = True
+    return {
+        "current_intro": readme.get("intro_text"),
+        "current_sections": {
+            "Current Release": ((readme.get("sections") or {}).get("Current Release")),
+            "Current Status": ((readme.get("sections") or {}).get("Current Status")),
+        },
+        "rewrite_intro": rewrite_intro,
+        "rewrite_required_sections": rewrite_sections,
+        "settings_default_mismatches": setting_default_mismatches(lint_report),
+        "lint_findings": findings_for_area(lint_report, {"readme", "copy"}),
+    }
+
+
+def precheck_eligibility(context: dict[str, Any]) -> dict[str, Any]:
+    target_version = str(context.get("target_version") or "").strip()
+    configured_version = str(((context.get("publish_configuration") or {}).get("mod_version")) or "").strip()
+    return {
+        "eligible": [
+            "PublishConfiguration wording reviewed against shipped behavior",
+            "Diagnostics wording reviewed",
+            *(
+                ["Tag/version confirmed"]
+                if target_version and configured_version and target_version == configured_version
+                else []
+            ),
+        ],
+        "must_remain_unchecked": [
+            "Release build completed successfully",
+            "Applicable release-gate evidence or validation artifacts captured",
+            "Applicable comparison summaries and release PR validation notes recorded",
+            "Release notes reviewed",
+            "Local release script verified",
+        ],
+    }
+
+
+def issue_recommendation(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, Any]:
+    recommendation = issue_action_recommendation(context)
+    return {
+        "existing_issue": issue_delta_summary(context.get("existing_release_issue")),
+        "issue_action_recommendation": recommendation,
+        "unresolved_evidence_placeholders": unresolved_evidence_placeholders(context, lint_report),
+        "project_mode_default": str(issue_defaults(context).get("project_mode") or "auto-add-first"),
+    }
+
+
+def raw_local_bundle(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "publish_configuration": context.get("publish_configuration"),
+        "base_tag_publish_configuration": context.get("base_tag_publish_configuration"),
+        "readme": context.get("readme"),
+        "setting_defaults": context.get("setting_defaults"),
+        "changed_files": context.get("changed_files"),
+        "changed_file_stats": context.get("changed_file_stats"),
+        "commit_subjects": context.get("commit_subjects"),
+        "existing_release_issue": context.get("existing_release_issue"),
+        "evidence": context.get("evidence"),
+        "lint_findings": lint_report.get("findings"),
+        "lint_checks": lint_report.get("checks"),
+    }
+
+
+def synthesis_packet_common_path_ready(packet: dict[str, Any]) -> bool:
+    if not SYNTHESIS_REQUIRED_KEYS.issubset(packet):
+        return False
+    contract_payload = packet.get("common_path_contract") or {}
+    if contract_payload.get("sufficient_for_local_final_drafting") is not True:
+        return False
+    if contract_payload.get("packet_insufficiency_is_failure") is not True:
+        return False
+    if contract_payload.get("max_additional_focused_packets") != contract.COMMON_PATH_MAX_FOCUSED_PACKETS:
+        return False
+    plan_defaults = packet.get("plan_defaults") or {}
+    draft_basis = plan_defaults.get("draft_basis") or {}
+    return (
+        draft_basis.get("common_path_sufficient") is True
+        and int(draft_basis.get("raw_reread_count", 0) or 0) == 0
+        and draft_basis.get("compensatory_reread_detected") is False
+    )
+
+
+def build_synthesis_packet(context: dict[str, Any], lint_report: dict[str, Any], topic_signals: list[dict[str, Any]]) -> dict[str, Any]:
+    checks = lint_report.get("checks", {}) or {}
+    packet = {
+        "purpose": "Local-only decision packet for final release drafting. This packet must be sufficient for local final drafting in the common path.",
+        "local_only": True,
+        "target_version": context.get("target_version"),
+        "base_tag": context.get("base_tag"),
+        "revision_range": context.get("revision_range"),
+        "applicable_gate_tracks": checks.get("applicable_validation_tracks", {}),
+        "evidence_complete": bool(checks.get("evidence_complete")),
+        "conservative_wording_requirements": conservative_wording_requirements(lint_report),
+        "publish_rewrite": publish_rewrite_guidance(context, lint_report, topic_signals),
+        "readme_rewrite": readme_rewrite_guidance(context, lint_report),
+        "shipped_change_summary": {
+            "topic_signals": topic_signals,
+            "top_churn_files": top_churn_files(context.get("changed_file_stats", {}) or {}),
+            "representative_files": representative_files(context),
+            "condensed_commit_subjects": unique_commit_subjects(list(context.get("commit_subjects", []))),
+            "diff_totals": parse_diff_totals(context.get("diff_stat")),
+        },
+        "issue_recommendation": issue_recommendation(context, lint_report),
+        "precheck_eligibility": precheck_eligibility(context),
+        "helper_handoff": {
+            "status": (context.get("local_release_helper") or {}).get("status"),
+            "available": bool(lint_report.get("checks", {}).get("helper_handoff_allowed")),
+            "command": handoff_command(context, lint_report),
+        },
+        "explicit_stop_risks": explicit_stop_risks(lint_report, context),
+        "common_path_contract": {
+            "sufficient_for_local_final_drafting": True,
+            "raw_reread_should_be_exceptional": True,
+            "packet_insufficiency_is_failure": True,
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "raw_reread_allowed_reasons": contract.RAW_REREAD_ALLOWED_REASONS,
+        },
+        "plan_defaults": {
+            "context_fingerprint": context.get("context_fingerprint"),
+            "freshness_tuple": context.get("freshness_tuple"),
+            "overall_confidence": "high" if checks.get("evidence_complete") else "medium",
+            "evidence_status": "complete" if checks.get("evidence_complete") else (
+                "incomplete" if any((checks.get("applicable_validation_tracks") or {}).values()) else "not-applicable"
+            ),
+            "draft_basis": {
+                "common_path_sufficient": True,
+                "raw_reread_count": 0,
+                "reread_reasons": [],
+                "focused_packets_used": [],
+                "compensatory_reread_detected": False,
+                "synthesis_packet_fingerprint": "",
+            },
+            "issue_action_recommendation": issue_action_recommendation(context),
+        },
+    }
+    packet["plan_defaults"]["draft_basis"]["synthesis_packet_fingerprint"] = contract.json_fingerprint(packet)
+    return packet
+
+
+def build_packet_payloads(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    changed_files = list(context.get("changed_files", []))
+    group_summary = context.get("changed_file_groups", {})
+    active_group_names = active_groups(group_summary)
+    diff_totals = parse_diff_totals(context.get("diff_stat"))
+    generated_file_count = sum(1 for path in changed_files if is_generated_file(path))
+    generated_file_ratio = (generated_file_count / len(changed_files)) if changed_files else 0.0
+    core_areas_touched = sorted(
+        {
+            area
+            for path in changed_files
+            if (area := core_area_for_path(path)) is not None
+        }
+    )
+    overrides: list[dict[str, str]] = []
+    if (diff_totals or {}).get("churn", 0) >= contract.CHURN_OVERRIDE_LIMIT:
+        overrides.append(
+            {
+                "reason": "diff_stat_threshold",
+                "detail": f"Release diff churn reached {(diff_totals or {}).get('churn', 0)} lines (threshold {contract.CHURN_OVERRIDE_LIMIT}).",
+            }
+        )
+    if len(core_areas_touched) >= 2:
+        overrides.append(
+            {
+                "reason": "core_files_across_groups",
+                "detail": "Core runtime/config/process files span multiple groups: " + ", ".join(core_areas_touched),
+            }
+        )
+    if generated_file_count and generated_file_ratio < 0.5:
+        overrides.append(
+            {
+                "reason": "generated_files_not_majority",
+                "detail": f"Generated files are present but not the majority ({generated_file_count}/{len(changed_files)}).",
+            }
+        )
+    mode, worker_count = review_mode(len(changed_files), len(active_group_names), overrides)
+    topic_signals = significant_topic_signals(context)
+
+    global_packet = {
+        "workflow_family": contract.WORKFLOW_FAMILY,
+        "repo_slug": context.get("repo_slug"),
+        "branch": context.get("branch"),
+        "head_commit": context.get("head_commit"),
+        "base_tag": context.get("base_tag"),
+        "target_version": context.get("target_version"),
+        "authority_order": contract.AUTHORITY_ORDER,
+        "gate_summary": {
+            "evidence_complete": lint_report.get("checks", {}).get("evidence_complete"),
+            "applicable_tracks": lint_report.get("checks", {}).get("applicable_validation_tracks", {}),
+            "helper_status": (context.get("local_release_helper") or {}).get("status"),
+            "helper_handoff_allowed": lint_report.get("checks", {}).get("helper_handoff_allowed"),
+        },
+        "worker_return_contract": contract.WORKER_RETURN_CONTRACT,
+        "worker_output_shape": contract.WORKER_OUTPUT_SHAPE,
+        "disallowed_claims": [
+            "Do not present the software track as solved without complete applicable software-gate evidence.",
+            "Do not claim release-facing files were updated unless the current run actually edited them.",
+            "Do not describe the local helper as a shared team workflow asset.",
+        ],
+    }
+
+    publish_packet = {
+        "current_publish_fields": {
+            "short_description": (context.get("publish_configuration") or {}).get("short_description"),
+            "long_description": (context.get("publish_configuration") or {}).get("long_description"),
+            "change_log": (context.get("publish_configuration") or {}).get("change_log"),
+            "mod_version": (context.get("publish_configuration") or {}).get("mod_version"),
+        },
+        "prior_release_change_log": (context.get("base_tag_publish_configuration") or {}).get("change_log"),
+        "rewrite_required_fields": publish_rewrite_guidance(context, lint_report, topic_signals)["rewrite_required_fields"],
+        "lint_findings": findings_for_area(lint_report, {"publish"}),
+    }
+
+    readme_packet = {
+        "intro_text": (context.get("readme") or {}).get("intro_text"),
+        "current_sections": {
+            "Current Release": ((context.get("readme") or {}).get("sections") or {}).get("Current Release"),
+            "Current Status": ((context.get("readme") or {}).get("sections") or {}).get("Current Status"),
+        },
+        "settings_default_mismatches": setting_default_mismatches(lint_report),
+        "rewrite_required_sections": readme_rewrite_guidance(context, lint_report)["rewrite_required_sections"],
+        "lint_findings": findings_for_area(lint_report, {"readme", "copy"}),
+    }
+
+    changes_packet = {
+        "revision_range": context.get("revision_range"),
+        "diff_totals": diff_totals,
+        "topic_signals": topic_signals,
+        "top_churn_files": top_churn_files(context.get("changed_file_stats", {}) or {}),
+        "representative_files": representative_files(context),
+        "condensed_commit_subjects": unique_commit_subjects(list(context.get("commit_subjects", []))),
+        "active_groups": active_group_names,
+    }
+
+    checklist_packet = {
+        "issue_title": issue_action_recommendation(context)["title"],
+        "existing_issue": issue_delta_summary(context.get("existing_release_issue")),
+        "template": {
+            "title_prefix": (context.get("release_checklist") or {}).get("title_prefix"),
+            "fields": (context.get("release_checklist") or {}).get("fields"),
+            "checkbox_labels": (context.get("release_checklist") or {}).get("checkbox_labels"),
+        },
+        "unresolved_placeholders": unresolved_evidence_placeholders(context, lint_report),
+        "lint_findings": findings_for_area(lint_report, {"checklist", "evidence", "helper"}),
+    }
+
+    synthesis_packet = build_synthesis_packet(context, lint_report, topic_signals)
+
+    packet_payloads: dict[str, dict[str, Any]] = {
+        "global_packet.json": global_packet,
+        "publish_packet.json": publish_packet,
+        "readme_packet.json": readme_packet,
+        "changes_packet.json": changes_packet,
+        "checklist_packet.json": checklist_packet,
+        "synthesis_packet.json": synthesis_packet,
+    }
+    if context.get("evidence"):
+        packet_payloads["evidence_packet.json"] = {
+            "applicable_tracks": lint_report.get("checks", {}).get("applicable_validation_tracks", {}),
+            "evidence_fields": context.get("evidence"),
+            "missing_placeholders": unresolved_evidence_placeholders(context, lint_report),
+            "complete": lint_report.get("checks", {}).get("evidence_complete"),
+        }
+
+    packet_sizes = contract.packet_size_summary(packet_payloads)
+    raw_bundle_bytes = contract.packet_size_bytes(raw_local_bundle(context, lint_report))
+    packet_sizes["raw_local_source_bytes"] = raw_bundle_bytes
+    packet_sizes["estimated_raw_source_tokens"] = contract.estimate_token_proxy(raw_bundle_bytes)
+
+    recommended_workers: list[dict[str, Any]] = []
+    optional_workers: list[dict[str, Any]] = []
+    if mode == "targeted-delegation":
+        recommended_workers = [
+            {
+                "name": "rules",
+                "agent_type": "docs_verifier",
+                "packets": ["global_packet.json", "checklist_packet.json", "readme_packet.json"],
+                "responsibility": "Extract hard release checklist constraints, README wording constraints, and issue-creation policy.",
+                "reasoning_effort": "medium",
+            },
+            {
+                "name": "release-copy",
+                "agent_type": "large_diff_auditor",
+                "packets": ["global_packet.json", "publish_packet.json", "changes_packet.json"],
+                "responsibility": "Summarize release-copy drift and supported release bullets.",
+                "reasoning_effort": "medium",
+                "model": "gpt-5.4-mini",
+            },
+        ]
+    elif mode == "broad-delegation":
+        recommended_workers.extend(
+            [
+                {
+                    "name": "rules",
+                    "agent_type": "docs_verifier",
+                    "packets": ["global_packet.json", "checklist_packet.json", "readme_packet.json"],
+                    "responsibility": "Extract hard release checklist constraints, README wording constraints, and issue-creation policy.",
+                    "reasoning_effort": "medium",
+                },
+                {
+                    "name": "release-copy",
+                    "agent_type": "large_diff_auditor",
+                    "packets": ["global_packet.json", "publish_packet.json", "changes_packet.json"],
+                    "responsibility": "Summarize release-copy drift and supported release bullets.",
+                    "reasoning_effort": "medium",
+                    "model": "gpt-5.4-mini",
+                },
+                {
+                    "name": "mapping",
+                    "agent_type": "repo_mapper",
+                    "packets": ["global_packet.json", "checklist_packet.json", "changes_packet.json"],
+                    "responsibility": "Confirm authority order, packet membership, and release scope.",
+                    "reasoning_effort": "low",
+                },
+            ]
+        )
+        if context.get("evidence") and worker_count >= 4:
+            recommended_workers.append(
+                {
+                    "name": "evidence",
+                    "agent_type": "evidence_summarizer",
+                    "packets": ["global_packet.json", "evidence_packet.json"],
+                    "responsibility": "Summarize normalized release-gate evidence or validation inputs.",
+                    "reasoning_effort": "low",
+                }
+            )
+
+    packet_files = [
+        contract.SHARED_PACKET,
+        "publish_packet.json",
+        "readme_packet.json",
+        "changes_packet.json",
+        "checklist_packet.json",
+        *(["evidence_packet.json"] if "evidence_packet.json" in packet_payloads else []),
+        contract.SHARED_LOCAL_PACKET,
+        "orchestrator.json",
+    ]
+
+    packet_metrics = {
+        "worker_facing_packets": packet_sizes["worker_facing_packets"],
+        "local_only_packets": sorted(name for name in packet_payloads if name in {contract.SHARED_LOCAL_PACKET}),
+        "packet_count": len(packet_files),
+        "packet_size_bytes": {
+            "by_packet": packet_sizes["by_packet"],
+            "worker_facing_total": packet_sizes["worker_facing_total"],
+            "local_only_total": packet_sizes["local_only_total"],
+            "raw_local_source_bytes": packet_sizes["raw_local_source_bytes"],
+            "total": packet_sizes["total"],
+        },
+        "largest_packet_bytes": packet_sizes["largest_packet_bytes"],
+        "largest_two_packets_bytes": packet_sizes["largest_two_packets_bytes"],
+        "estimated_local_only_tokens": packet_sizes["estimated_local_only_tokens"],
+        "estimated_packet_tokens": packet_sizes["estimated_packet_tokens"],
+        "estimated_delegation_savings": packet_sizes["estimated_delegation_savings"],
+        "estimated_raw_source_tokens": packet_sizes["estimated_raw_source_tokens"],
+        "raw_reread_allowed_reasons": contract.RAW_REREAD_ALLOWED_REASONS,
+        "synthesis_packet_sufficient_for_common_path": synthesis_packet_common_path_ready(synthesis_packet),
+    }
+
+    packet_payloads["orchestrator.json"] = {
+        "target_version": context.get("target_version"),
+        "base_tag": context.get("base_tag"),
+        "review_mode": mode,
+        "recommended_worker_count": len(recommended_workers),
+        "worker_return_contract": contract.WORKER_RETURN_CONTRACT,
+        "worker_output_shape": contract.WORKER_OUTPUT_SHAPE,
+        "workflow_family": contract.WORKFLOW_FAMILY,
+        "archetype": contract.ARCHETYPE,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "preferred_worker_families": contract.PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": contract.packet_worker_map(),
+        "worker_selection_guidance": contract.WORKER_SELECTION_GUIDANCE,
+        "routing_contract": contract.runtime_field_roles(),
+        "shared_packet": contract.SHARED_PACKET,
+        "shared_local_packet": contract.SHARED_LOCAL_PACKET,
+        "review_overrides": overrides,
+        "helper_status": (context.get("local_release_helper") or {}).get("status"),
+        "raw_reread_allowed_reasons": contract.RAW_REREAD_ALLOWED_REASONS,
+        "common_path_contract": {
+            "required_packets": [contract.SHARED_PACKET, contract.SHARED_LOCAL_PACKET],
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "synthesis_packet_must_be_sufficient": True,
+            "raw_reread_should_be_exceptional": True,
+            "packet_insufficiency_is_failure": True,
+        },
+        "local_responsibilities": [
+            "Read global_packet.json and synthesis_packet.json first.",
+            "Keep common-path drafting on those packets plus at most one focused packet.",
+            "Treat raw reread as exceptional only for allowed reasons.",
+            "Draft a local release-copy plan before validation.",
+            "Run validator before any deterministic file or issue mutation.",
+            "Apply release-facing file edits and the issue action only from validator-normalized output.",
+            "Do not execute the local release helper.",
+        ],
+        "packet_files": packet_files,
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+    }
+    packet_payloads["packet_metrics.json"] = packet_metrics
+    return packet_payloads
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build compact release-copy packets for token-efficient release preparation."
+    )
+    parser.add_argument("--context", required=True, help="Path to JSON from collect_release_copy_context.py")
+    parser.add_argument("--lint", required=True, help="Path to JSON from lint_release_copy.py")
+    parser.add_argument("--output-dir", required=True, help="Directory for generated packets")
+    args = parser.parse_args()
+
+    context = load_json(Path(args.context))
+    lint_report = load_json(Path(args.lint))
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    packets = build_packet_payloads(context, lint_report)
+    for file_name, payload in packets.items():
+        contract.write_json(output_dir / file_name, payload)
+
+    orchestrator = packets["orchestrator.json"]
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output_dir),
+                "review_mode": orchestrator["review_mode"],
+                "packet_files": orchestrator["packet_files"],
+                "recommended_worker_count": orchestrator["recommended_worker_count"],
+                "packet_metrics_file": str(output_dir / "packet_metrics.json"),
+                "estimated_delegation_savings": packets["packet_metrics.json"]["estimated_delegation_savings"],
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/collect_release_copy_context.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/collect_release_copy_context.py
@@ -1,0 +1,986 @@
+#!/usr/bin/env python3
+"""Collect release-copy context for packet-based release preparation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+
+
+GROUP_SAMPLE_LIMIT = 16
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates = [
+            (repo_root / candidate).resolve(),
+            (skill_root() / candidate).resolve(),
+        ]
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise RuntimeError(f"missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("repo profile must be a JSON object")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def run_command(args: list[str], cwd: Path, check: bool = True) -> str:
+    result = subprocess.run(
+        args,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        detail = stderr or stdout or "command failed"
+        raise RuntimeError(f"{' '.join(args)}: {detail}")
+    return result.stdout
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return read_text(path)
+
+
+def load_json_file(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def json_fingerprint(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def merge_optional_dicts(*sources: dict[str, Any] | None) -> dict[str, Any] | None:
+    merged: dict[str, Any] = {}
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key, value in source.items():
+            if isinstance(value, str):
+                if value.strip():
+                    merged[key] = value.strip()
+                continue
+            if value is not None:
+                merged[key] = value
+    return merged or None
+
+
+def normalize_repo_relative_path(value: str) -> str:
+    return value.replace("\\", "/").strip("/")
+
+
+def resolve_repo_binding(repo_root: Path, raw_value: str | None, label: str) -> tuple[str, Path]:
+    text = normalize_repo_relative_path(str(raw_value or ""))
+    if not text:
+        raise RuntimeError(f"missing required repo profile binding: {label}")
+    candidate = Path(text)
+    if candidate.is_absolute():
+        raise RuntimeError(f"repo profile binding `{label}` must be repo-relative, not absolute")
+    resolved = (repo_root / candidate).resolve()
+    repo_root_resolved = repo_root.resolve()
+    common = Path(os.path.commonpath([str(repo_root_resolved), str(resolved)]))
+    if common != repo_root_resolved:
+        raise RuntimeError(f"repo profile binding `{label}` must stay inside the repository root")
+    return text, resolved
+
+
+def require_repo_binding_file(path: Path, repo_relative: str, label: str) -> None:
+    if path.is_file():
+        return
+    raise RuntimeError(f"repo profile binding `{label}` points to a missing file: {repo_relative}")
+
+
+def validate_local_helper_path(repo_root: Path, helper_path: str) -> tuple[str, Path]:
+    candidate = Path(helper_path)
+    if candidate.is_absolute():
+        raise RuntimeError("local release helper path must be repo-relative, not absolute")
+    resolved = (repo_root / candidate).resolve()
+    repo_root_resolved = repo_root.resolve()
+    common = Path(os.path.commonpath([str(repo_root_resolved), str(resolved)]))
+    if common != repo_root_resolved:
+        raise RuntimeError("local release helper path must stay inside the repository root")
+    return normalize_repo_relative_path(str(candidate)), resolved
+
+
+def infer_repo_slug(repo_root: Path) -> str | None:
+    try:
+        payload = json.loads(run_command(["gh", "repo", "view", "--json", "nameWithOwner"], cwd=repo_root))
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        slug = str(payload.get("nameWithOwner") or "").strip()
+        if slug:
+            return slug
+
+    try:
+        remote = run_command(["git", "config", "--get", "remote.origin.url"], cwd=repo_root).strip()
+    except RuntimeError:
+        return None
+    match = re.search(r"github\.com[:/](?P<slug>[^/]+/[^/.]+)(?:\.git)?$", remote)
+    return match.group("slug") if match else None
+
+
+def gh_repo_args(repo_slug: str | None) -> list[str]:
+    return ["--repo", repo_slug] if repo_slug else []
+
+
+def normalized_release_version(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return text if text.startswith("v") else f"v{text}"
+
+
+def git_branch(repo_root: Path) -> str:
+    return run_command(["git", "branch", "--show-current"], cwd=repo_root, check=False).strip()
+
+
+def git_head_commit(repo_root: Path) -> str:
+    return run_command(["git", "rev-parse", "--short", "HEAD"], cwd=repo_root).strip()
+
+
+def latest_reachable_tag(repo_root: Path) -> str | None:
+    output = run_command(
+        ["git", "tag", "--merged", "HEAD", "--list", "v*", "--sort=-creatordate"],
+        cwd=repo_root,
+        check=False,
+    )
+    tags = [line.strip() for line in output.splitlines() if line.strip()]
+    return tags[0] if tags else None
+
+
+def git_commit_subjects(repo_root: Path, revision_range: str) -> list[str]:
+    output = run_command(["git", "log", "--format=%s", revision_range], cwd=repo_root, check=False)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def git_commit_count(repo_root: Path, revision_range: str) -> int:
+    output = run_command(["git", "rev-list", "--count", revision_range], cwd=repo_root, check=False).strip()
+    return int(output) if output.isdigit() else 0
+
+
+def git_changed_files(repo_root: Path, revision_range: str) -> list[str]:
+    output = run_command(["git", "diff", "--name-only", revision_range], cwd=repo_root, check=False)
+    return [line.strip().replace("\\", "/") for line in output.splitlines() if line.strip()]
+
+
+def parse_numstat_int(raw: str) -> int:
+    raw = raw.strip()
+    if raw == "-" or not raw:
+        return 0
+    return int(raw) if raw.isdigit() else 0
+
+
+def git_changed_file_stats(repo_root: Path, revision_range: str) -> dict[str, dict[str, int]]:
+    output = run_command(["git", "diff", "--numstat", revision_range], cwd=repo_root, check=False)
+    stats: dict[str, dict[str, int]] = {}
+    for line in output.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        insertions = parse_numstat_int(parts[0])
+        deletions = parse_numstat_int(parts[1])
+        path = parts[-1].strip().replace("\\", "/")
+        if not path:
+            continue
+        stats[path] = {
+            "insertions": insertions,
+            "deletions": deletions,
+            "churn": insertions + deletions,
+        }
+    return stats
+
+
+def git_diff_stat(repo_root: Path, revision_range: str) -> str | None:
+    output = run_command(["git", "diff", "--stat", revision_range], cwd=repo_root, check=False).strip()
+    return output or None
+
+
+def classify_changed_files(paths: list[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {
+        "runtime": [],
+        "automation": [],
+        "docs": [],
+        "tests": [],
+        "config": [],
+        "other": [],
+    }
+    for raw_path in paths:
+        path = raw_path.replace("\\", "/")
+        lower = path.lower()
+        if (
+            "/tests/" in lower
+            or lower.endswith("_test.py")
+            or lower.endswith(".tests.cs")
+            or lower.endswith(".spec.ts")
+            or lower.startswith(".github/scripts/tests/")
+        ):
+            groups["tests"].append(path)
+        elif (
+            lower.startswith(".github/workflows/")
+            or lower.startswith(".github/scripts/")
+            or lower.startswith(".github/issue_template/")
+            or lower.startswith(".github/instructions/")
+        ):
+            groups["automation"].append(path)
+        elif lower.endswith(".md") or lower.startswith("docs/"):
+            groups["docs"].append(path)
+        elif lower.endswith((".yml", ".yaml", ".toml", ".json", ".csproj", ".props", ".targets", ".xml")):
+            groups["config"].append(path)
+        elif lower.endswith((".cs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java")):
+            groups["runtime"].append(path)
+        else:
+            groups["other"].append(path)
+    return groups
+
+
+def sample_parent(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else "."
+
+
+def select_representative_files(paths: list[str], limit: int = GROUP_SAMPLE_LIMIT) -> list[str]:
+    ordered_paths: list[str] = []
+    for path in paths:
+        if path not in ordered_paths:
+            ordered_paths.append(path)
+    if len(ordered_paths) <= limit:
+        return ordered_paths
+
+    buckets: dict[str, list[str]] = {}
+    bucket_order: list[str] = []
+    for path in ordered_paths:
+        parent = sample_parent(path)
+        if parent not in buckets:
+            buckets[parent] = []
+            bucket_order.append(parent)
+        buckets[parent].append(path)
+
+    selected: list[str] = []
+    while len(selected) < limit:
+        progressed = False
+        for parent in bucket_order:
+            bucket = buckets[parent]
+            if not bucket:
+                continue
+            selected.append(bucket.pop(0))
+            progressed = True
+            if len(selected) >= limit:
+                break
+        if not progressed:
+            break
+    original_index = {path: index for index, path in enumerate(ordered_paths)}
+    return sorted(selected, key=original_index.__getitem__)
+
+
+def summarize_groups(groups: dict[str, list[str]]) -> dict[str, dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = {}
+    for name, paths in groups.items():
+        sample_files = select_representative_files(paths)
+        summary[name] = {
+            "count": len(paths),
+            "sample_files": sample_files,
+            "omitted_file_count": max(len(paths) - len(sample_files), 0),
+            "sample_strategy": "directory_round_robin",
+        }
+    return summary
+
+
+def parse_markdown_sections(markdown_text: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                sections[current] = "\n".join(buffer).strip()
+            current = line[3:].strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        sections[current] = "\n".join(buffer).strip()
+    return sections
+
+
+def parse_readme_settings_table(section_body: str) -> dict[str, dict[str, str]]:
+    defaults: dict[str, dict[str, str]] = {}
+    lines = section_body.splitlines()
+    in_table = False
+    for line in lines:
+        if line.strip().startswith("| Setting | Default | Purpose |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.strip().startswith("|"):
+            break
+        if set(line.replace("|", "").strip()) <= {"-", " "}:
+            continue
+        parts = [part.strip() for part in line.split("|")[1:-1]]
+        if len(parts) != 3:
+            continue
+        setting_name = parts[0].strip("`")
+        defaults[setting_name] = {
+            "default": parts[1].strip("`"),
+            "purpose": parts[2],
+        }
+    return defaults
+
+
+def first_heading_block(markdown_text: str, heading: str) -> str | None:
+    lines = markdown_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == heading:
+            start = index
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def element_text(element: ET.Element | None) -> str:
+    if element is None:
+        return ""
+    return "".join(element.itertext()).replace("\r\n", "\n").strip()
+
+
+def parse_publish_configuration(path: Path) -> dict[str, Any]:
+    return parse_publish_configuration_text(read_text(path), str(path))
+
+
+def parse_publish_configuration_text(text: str, source_path: str) -> dict[str, Any]:
+    root = ET.fromstring(text)
+
+    def value_of(tag_name: str) -> str:
+        element = root.find(tag_name)
+        if element is None:
+            return ""
+        return element.attrib.get("Value", "").strip()
+
+    return {
+        "path": source_path,
+        "mod_id": value_of("ModId"),
+        "display_name": value_of("DisplayName"),
+        "short_description": value_of("ShortDescription"),
+        "long_description": element_text(root.find("LongDescription")),
+        "thumbnail": value_of("Thumbnail"),
+        "tags": [tag.attrib.get("Value", "").strip() for tag in root.findall("Tag") if tag.attrib.get("Value")],
+        "forum_link": value_of("ForumLink"),
+        "mod_version": value_of("ModVersion"),
+        "game_version": value_of("GameVersion"),
+        "change_log": element_text(root.find("ChangeLog")),
+        "external_links": [
+            {
+                "type": link.attrib.get("Type", "").strip(),
+                "url": link.attrib.get("Url", "").strip(),
+            }
+            for link in root.findall("ExternalLink")
+        ],
+        "access_level": value_of("AccessLevel"),
+    }
+
+
+def publish_configuration_at_tag(repo_root: Path, tag: str, repo_relative_path: str) -> dict[str, Any] | None:
+    try:
+        text = run_command(["git", "show", f"{tag}:{repo_relative_path}"], cwd=repo_root, check=False)
+    except RuntimeError:
+        return None
+    if not text.strip():
+        return None
+    try:
+        return parse_publish_configuration_text(text, f"{tag}:{repo_relative_path}")
+    except ET.ParseError:
+        return None
+
+
+def parse_release_checklist(text: str) -> dict[str, Any]:
+    labels_match = re.search(r"^labels:\s*\[(?P<body>.+?)\]\s*$", text, re.MULTILINE)
+    labels: list[str] = []
+    if labels_match:
+        labels = [item.strip().strip("\"'") for item in labels_match.group("body").split(",") if item.strip()]
+
+    current_id = None
+    fields: list[dict[str, str]] = []
+    checkbox_labels: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("id:"):
+            current_id = stripped.split(":", 1)[1].strip()
+            continue
+        if stripped.startswith("label:"):
+            label = stripped.split(":", 1)[1].strip().strip("\"'")
+            if current_id == "checks":
+                continue
+            if current_id:
+                fields.append({"id": current_id, "label": label})
+            continue
+        if stripped.startswith("- label:"):
+            checkbox_labels.append(stripped.split(":", 1)[1].strip().strip("\"'"))
+
+    title_match = re.search(r"^title:\s*\"(?P<title>.+?)\"\s*$", text, re.MULTILINE)
+    return {
+        "title_prefix": title_match.group("title") if title_match else "[Release] ",
+        "labels": labels,
+        "fields": fields,
+        "checkbox_labels": checkbox_labels,
+    }
+
+
+def parse_release_issue_evidence(section_text: str) -> dict[str, str]:
+    evidence: dict[str, str] = {}
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        content = stripped[2:].strip()
+        if ":" not in content:
+            continue
+        key, value = [part.strip() for part in content.split(":", 1)]
+        normalized_key = re.sub(r"\s+", " ", key).strip().lower()
+        if normalized_key == "software track status":
+            evidence["software_track_status"] = value
+        elif normalized_key == "current software anchor evidence entry":
+            evidence["current_software_anchor_evidence"] = value
+        elif normalized_key.startswith("comparable software evidence"):
+            evidence["comparable_evidence"] = value
+        elif normalized_key.startswith("software anchor comparison summary"):
+            evidence["anchor_comparison"] = value
+        elif normalized_key == "software release pr validation note":
+            evidence["release_pr_validation_note"] = value
+        elif normalized_key in {
+            "performance telemetry validation artifact",
+            "telemetry validation artifact",
+            "performance telemetry issue or validation artifact",
+        }:
+            evidence["telemetry_validation_artifact"] = value
+        elif normalized_key in {
+            "performance telemetry validation summary",
+            "telemetry validation summary",
+        }:
+            evidence["telemetry_validation_summary"] = value
+    return evidence
+
+
+def parse_existing_release_issue(issue: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(issue, dict):
+        return None
+    body = str(issue.get("body") or "")
+    sections = parse_markdown_sections(body)
+    evidence_section = sections.get("Release-gate evidence / validation", "")
+    checklist_section = sections.get("Checklist", "")
+    checked_labels = [
+        line[6:].strip()
+        for line in checklist_section.splitlines()
+        if line.strip().startswith("- [x] ")
+    ]
+    return {
+        "number": issue.get("number"),
+        "title": str(issue.get("title") or "").strip(),
+        "url": str(issue.get("url") or "").strip(),
+        "state": str(issue.get("state") or "").strip(),
+        "body": body,
+        "evidence": parse_release_issue_evidence(evidence_section),
+        "checked_labels": checked_labels,
+    }
+
+
+def existing_issue_snapshot(existing_issue: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(existing_issue, dict):
+        return None
+    body = str(existing_issue.get("body") or "")
+    snapshot = {
+        "number": existing_issue.get("number"),
+        "title": str(existing_issue.get("title") or "").strip(),
+        "state": str(existing_issue.get("state") or "").strip(),
+        "url": str(existing_issue.get("url") or "").strip(),
+        "body_fingerprint": json_fingerprint(body),
+    }
+    return snapshot
+
+
+def freshness_tuple(context: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "head_commit": str(context.get("head_commit") or "").strip(),
+        "base_tag": str(context.get("base_tag") or "").strip(),
+        "target_version": str(context.get("target_version") or "").strip(),
+        "evidence_fingerprint": json_fingerprint(context.get("evidence") or {}),
+        "existing_release_issue": existing_issue_snapshot(context.get("existing_release_issue")),
+    }
+
+
+def release_issue_by_number(repo_root: Path, repo_slug: str | None, number: int) -> dict[str, Any] | None:
+    args = [
+        "gh",
+        "issue",
+        "view",
+        str(number),
+        "--json",
+        "number,title,body,url,state",
+        *gh_repo_args(repo_slug),
+    ]
+    try:
+        payload = json.loads(run_command(args, cwd=repo_root))
+    except Exception:
+        return None
+    return parse_existing_release_issue(payload)
+
+
+def find_existing_release_issue(repo_root: Path, repo_slug: str | None, target_version: str) -> dict[str, Any] | None:
+    release_title = f"[Release] {normalized_release_version(target_version)}"
+    args = [
+        "gh",
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--label",
+        "release",
+        "--json",
+        "number,title,body,url,state",
+        *gh_repo_args(repo_slug),
+    ]
+    try:
+        payload = json.loads(run_command(args, cwd=repo_root, check=False) or "[]")
+    except Exception:
+        return None
+    if not isinstance(payload, list):
+        return None
+    matches = [
+        issue
+        for issue in payload
+        if str(issue.get("title") or "").strip() == release_title
+    ]
+    if not matches:
+        return None
+    latest = max(matches, key=lambda issue: int(issue.get("number") or 0))
+    return parse_existing_release_issue(latest)
+
+
+def parse_release_workflow(text: str) -> dict[str, Any]:
+    tag_patterns: list[str] = []
+    in_tags = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "tags:":
+            in_tags = True
+            continue
+        if in_tags:
+            if stripped.startswith("- "):
+                tag_patterns.append(stripped[2:].strip().strip("\"'"))
+                continue
+            if stripped and not stripped.startswith("#"):
+                in_tags = False
+    return {
+        "tag_patterns": tag_patterns,
+        "generate_release_notes": "generate_release_notes: true" in text.lower(),
+    }
+
+
+def parse_setting_defaults(text: str) -> dict[str, str]:
+    defaults: dict[str, str] = {}
+    match = re.search(r"public override void SetDefaults\(\)\s*\{(?P<body>.*?)^\s*\}", text, re.DOTALL | re.MULTILINE)
+    body = match.group("body") if match else ""
+    for line in body.splitlines():
+        assignment = re.match(r"^\s*(?P<name>[A-Za-z0-9_]+)\s*=\s*(?P<value>[^;]+);", line)
+        if not assignment:
+            continue
+        defaults[assignment.group("name")] = normalize_literal(assignment.group("value"))
+    return defaults
+
+
+def normalize_literal(value: str) -> str:
+    cleaned = value.strip()
+    lowered = cleaned.lower()
+    if lowered in {"true", "false"}:
+        return lowered
+    if lowered.endswith("f"):
+        lowered = lowered[:-1]
+    try:
+        if "." in lowered:
+            number = float(lowered)
+            return f"{number:.1f}" if number.is_integer() else str(number)
+        return str(int(lowered))
+    except ValueError:
+        return cleaned
+
+
+def parse_local_helper(text: str, repo_relative_path: str) -> dict[str, Any]:
+    required_parameters = re.findall(
+        r"\[Parameter\(Mandatory\)\]\s*\[string\]\$(?P<name>[A-Za-z0-9_]+)",
+        text,
+        re.MULTILINE,
+    )
+    optional_string_parameters = re.findall(
+        r"^\s*\[string\]\$(?P<name>[A-Za-z0-9_]+)",
+        text,
+        re.MULTILINE,
+    )
+    switch_parameters = re.findall(
+        r"^\s*\[switch\]\$(?P<name>[A-Za-z0-9_]+)",
+        text,
+        re.MULTILINE,
+    )
+    required_env_vars = sorted(
+        {
+            *re.findall(r'Get-RequiredEnvironmentValue -Name "(?P<name>[^"]+)"', text),
+            *re.findall(r'Assert-PathValue -Name "(?P<name>[^"]+)"', text),
+        }
+    )
+    preflight_notes: list[str] = []
+    if "Working tree is not clean" in text:
+        preflight_notes.append("Requires a clean working tree unless SkipGitChecks is used.")
+    if "Local tag $tag already exists." in text or "Remote tag $tag already exists." in text:
+        preflight_notes.append("Refuses to reuse an existing release tag unless SkipGitTag is used.")
+    if "PublishConfiguration.xml has ModVersion" in text:
+        preflight_notes.append("Requires PublishConfiguration.xml ModVersion to match the requested release version.")
+
+    return {
+        "repo_relative_path": repo_relative_path,
+        "script_kind": "powershell" if repo_relative_path.lower().endswith(".ps1") else "unknown",
+        "required_parameters": sorted(set(required_parameters)),
+        "optional_parameters": sorted(set(optional_string_parameters + switch_parameters)),
+        "required_env_vars": required_env_vars,
+        "preflight_notes": preflight_notes,
+    }
+
+
+def project_title_default(*texts: str) -> str | None:
+    for text in texts:
+        match = re.search(r"\[(?P<title>[^\]]+Tracker)\]\(", text)
+        if match:
+            return match.group("title")
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect release-copy context for packet-based release preparation."
+    )
+    parser.add_argument("--repo-root", required=True, help="Repository root")
+    parser.add_argument("--output", required=True, help="Output JSON path")
+    parser.add_argument("--base-tag", default=None, help="Optional base release tag such as v0.2.1")
+    parser.add_argument("--target-version", default=None, help="Optional release version override")
+    parser.add_argument("--evidence-file", default=None, help="Optional evidence JSON file")
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained neutral scaffold."
+        ),
+    )
+    parser.add_argument(
+        "--release-issue-number",
+        type=int,
+        default=None,
+        help="Optional existing release checklist issue number to read evidence from",
+    )
+    parser.add_argument(
+        "--local-release-helper",
+        default="scripts/release.ps1",
+        help="Repo-relative local release helper path",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        profile_path = resolve_profile_path(args.profile, repo_root)
+        repo_profile = load_repo_profile(profile_path)
+        bindings = repo_profile.get("bindings") if isinstance(repo_profile.get("bindings"), dict) else {}
+        extra_root = repo_profile.get("extra") if isinstance(repo_profile.get("extra"), dict) else {}
+        release_extra = extra_root.get("release_copy") if isinstance(extra_root.get("release_copy"), dict) else {}
+        publish_repo_relative, publish_path = resolve_repo_binding(
+            repo_root,
+            bindings.get("publish_config_path"),
+            "bindings.publish_config_path",
+        )
+        readme_repo_relative, readme_path = resolve_repo_binding(
+            repo_root,
+            bindings.get("primary_readme_path"),
+            "bindings.primary_readme_path",
+        )
+        maintaining_repo_relative, maintaining_path = resolve_repo_binding(
+            repo_root,
+            release_extra.get("maintaining_path"),
+            "extra.release_copy.maintaining_path",
+        )
+        checklist_repo_relative, checklist_path = resolve_repo_binding(
+            repo_root,
+            release_extra.get("release_checklist_template_path"),
+            "extra.release_copy.release_checklist_template_path",
+        )
+        workflow_repo_relative, workflow_path = resolve_repo_binding(
+            repo_root,
+            release_extra.get("release_workflow_path"),
+            "extra.release_copy.release_workflow_path",
+        )
+        settings_repo_relative, setting_path = resolve_repo_binding(
+            repo_root,
+            bindings.get("settings_source_path"),
+            "bindings.settings_source_path",
+        )
+        for repo_relative, path, label in (
+            (publish_repo_relative, publish_path, "bindings.publish_config_path"),
+            (readme_repo_relative, readme_path, "bindings.primary_readme_path"),
+            (maintaining_repo_relative, maintaining_path, "extra.release_copy.maintaining_path"),
+            (
+                checklist_repo_relative,
+                checklist_path,
+                "extra.release_copy.release_checklist_template_path",
+            ),
+            (workflow_repo_relative, workflow_path, "extra.release_copy.release_workflow_path"),
+            (settings_repo_relative, setting_path, "bindings.settings_source_path"),
+        ):
+            require_repo_binding_file(path, repo_relative, label)
+        issue_defaults = (
+            release_extra.get("issue_defaults")
+            if isinstance(release_extra.get("issue_defaults"), dict)
+            else {}
+        )
+        helper_repo_relative, helper_resolved = validate_local_helper_path(repo_root, args.local_release_helper)
+        base_tag = args.base_tag or latest_reachable_tag(repo_root)
+        if not base_tag:
+            raise RuntimeError("no reachable v* tag was found; supply --base-tag explicitly")
+    except RuntimeError as exc:
+        print(f"collect_release_copy_context.py: {exc}", file=sys.stderr)
+        return 1
+
+    revision_range = f"{base_tag}..HEAD"
+
+    publish = parse_publish_configuration(publish_path)
+    base_tag_publish = publish_configuration_at_tag(repo_root, base_tag, publish_repo_relative)
+    target_version = (args.target_version or publish["mod_version"]).strip()
+    repo_slug = infer_repo_slug(repo_root)
+    readme_text = read_text(readme_path)
+    readme_sections = parse_markdown_sections(readme_text)
+    maintaining_text = read_text(maintaining_path)
+    checklist_text = read_text(checklist_path)
+    workflow_text = read_text(workflow_path)
+    setting_text = read_text(setting_path)
+
+    changed_files = git_changed_files(repo_root, revision_range)
+    changed_file_stats = git_changed_file_stats(repo_root, revision_range)
+    changed_groups = summarize_groups(classify_changed_files(changed_files))
+    evidence_file_payload = load_json_file(Path(args.evidence_file)) if args.evidence_file else None
+    existing_release_issue = (
+        release_issue_by_number(repo_root, repo_slug, args.release_issue_number)
+        if args.release_issue_number
+        else find_existing_release_issue(repo_root, repo_slug, target_version)
+    )
+    evidence = merge_optional_dicts(
+        existing_release_issue.get("evidence") if isinstance(existing_release_issue, dict) else None,
+        evidence_file_payload if isinstance(evidence_file_payload, dict) else None,
+    )
+
+    local_helper: dict[str, Any] = {
+        "requested_path": helper_repo_relative,
+        "path": str(helper_resolved),
+        "repo_relative_path": helper_repo_relative,
+        "status": "missing_local_release_script",
+    }
+    if helper_resolved.is_file():
+        local_helper.update(parse_local_helper(read_text(helper_resolved), helper_repo_relative))
+        local_helper["status"] = "present"
+
+    context = {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "branch": git_branch(repo_root),
+        "head_commit": git_head_commit(repo_root),
+        "base_tag": base_tag,
+        "revision_range": revision_range,
+        "repo_profile_name": repo_profile.get("name"),
+        "repo_profile_path": profile_path.as_posix(),
+        "repo_profile_summary": repo_profile.get("summary"),
+        "repo_profile": repo_profile,
+        "builder_compatibility": build_builder_compatibility(repo_profile),
+        "target_version": target_version,
+        "rule_files": {
+            "publish_configuration": str(publish_path),
+            "readme": str(readme_path),
+            "maintaining": str(maintaining_path),
+            "release_checklist_template": str(checklist_path),
+            "release_workflow": str(workflow_path),
+            "setting_defaults": str(setting_path),
+        },
+        "publish_configuration": publish,
+        "base_tag_publish_configuration": base_tag_publish,
+        "readme": {
+            "path": str(readme_path),
+            "intro_text": readme_text.split("\n## ", 1)[0].strip(),
+            "sections": readme_sections,
+            "settings_defaults": parse_readme_settings_table(readme_sections.get("Settings", "")),
+        },
+        "maintaining": {
+            "path": str(maintaining_path),
+            "release_operations_excerpt": first_heading_block(maintaining_text, "## Release Operations"),
+        },
+        "release_checklist": {
+            "path": str(checklist_path),
+            **parse_release_checklist(checklist_text),
+        },
+        "release_workflow": {
+            "path": str(workflow_path),
+            **parse_release_workflow(workflow_text),
+        },
+        "setting_defaults": parse_setting_defaults(setting_text),
+        "changed_files": changed_files,
+        "changed_file_stats": changed_file_stats,
+        "changed_file_groups": changed_groups,
+        "diff_stat": git_diff_stat(repo_root, revision_range),
+        "commit_subjects": git_commit_subjects(repo_root, revision_range),
+        "commit_count": git_commit_count(repo_root, revision_range),
+        "evidence_file": str(Path(args.evidence_file).resolve()) if args.evidence_file else None,
+        "existing_release_issue": existing_release_issue,
+        "evidence": evidence,
+        "project_title_default": (
+            str(issue_defaults.get("project_title") or "").strip()
+            or project_title_default(readme_text, maintaining_text)
+        ),
+        "issue_defaults": issue_defaults,
+        "local_release_helper": local_helper,
+        "source_fingerprints": {
+            "publish_configuration": json_fingerprint(read_text(publish_path)),
+            "readme": json_fingerprint(readme_text),
+            "maintaining": json_fingerprint(maintaining_text),
+            "release_checklist_template": json_fingerprint(checklist_text),
+            "release_workflow": json_fingerprint(workflow_text),
+            "setting_defaults": json_fingerprint(setting_text),
+        },
+    }
+
+    context["freshness_tuple"] = freshness_tuple(context)
+    context["context_fingerprint"] = json_fingerprint(
+        {
+            key: value
+            for key, value in context.items()
+            if key != "context_fingerprint"
+        }
+    )
+
+    if context["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(context["builder_compatibility"]), file=sys.stderr)
+    output_path.write_text(json.dumps(context, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/create_release_issue.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/create_release_issue.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Create a release checklist issue with conservative project-add behavior."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_PROJECT_TITLE = "Release Tracker"
+
+
+def run_command(args: list[str], cwd: Path, check: bool = True) -> str:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"{args[0]} not found") from exc
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        detail = stderr or stdout or "command failed"
+        raise RuntimeError(f"{' '.join(args)}: {detail}")
+    return result.stdout
+
+
+def write_json_output(path: Path | None, payload: dict[str, object]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def repo_slug(repo_root: Path) -> str | None:
+    try:
+        payload = json.loads(run_command(["gh", "repo", "view", "--json", "nameWithOwner"], cwd=repo_root))
+    except Exception:
+        return None
+    slug = str(payload.get("nameWithOwner") or "").strip()
+    return slug or None
+
+
+def gh_repo_args(slug: str | None) -> list[str]:
+    return ["--repo", slug] if slug else []
+
+
+def find_existing_issue(repo_root: Path, slug: str | None, title: str) -> dict[str, object] | None:
+    args = [
+        "gh",
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--label",
+        "release",
+        "--json",
+        "number,title,url,state",
+        *gh_repo_args(slug),
+    ]
+    try:
+        payload = json.loads(run_command(args, cwd=repo_root, check=False) or "[]")
+    except Exception:
+        return None
+    if not isinstance(payload, list):
+        return None
+    matches = [issue for issue in payload if str(issue.get("title") or "").strip() == title]
+    if not matches:
+        return None
+    return max(matches, key=lambda issue: int(issue.get("number") or 0))
+
+
+def build_create_command(
+    slug: str | None,
+    title: str,
+    body_path: Path,
+    use_project_flag: bool,
+    project_title: str,
+) -> list[str]:
+    command = ["gh", "issue", "create", "--title", title, "--body-file", str(body_path), "--label", "release"]
+    if slug:
+        command.extend(["--repo", slug])
+    if use_project_flag:
+        command.extend(["--project", project_title])
+    return command
+
+
+def build_edit_command(
+    slug: str | None,
+    issue_number: object,
+    title: str,
+    body_path: Path,
+    use_project_flag: bool,
+    project_title: str,
+) -> list[str]:
+    command = ["gh", "issue", "edit", str(issue_number), "--title", title, "--body-file", str(body_path), "--add-label", "release"]
+    if slug:
+        command.extend(["--repo", slug])
+    if use_project_flag:
+        command.extend(["--add-project", project_title])
+    return command
+
+
+def has_project_scope(repo_root: Path) -> bool:
+    try:
+        status = run_command(["gh", "auth", "status"], cwd=repo_root, check=False)
+    except RuntimeError:
+        return False
+    return "project" in status.lower()
+
+
+def validate_input_contract(body_path: Path, sync_existing_body: bool, reuse_existing: bool) -> str | None:
+    if not body_path.is_file():
+        return f"create_release_issue.py: body file not found: {body_path}"
+    if sync_existing_body and not reuse_existing:
+        return "create_release_issue.py: --sync-existing-body requires --reuse-existing"
+    return None
+
+
+def execute_issue_action(
+    *,
+    title: str,
+    body_path: Path,
+    repo_root: Path,
+    project_title: str,
+    project_mode: str,
+    local_release_helper_status: str,
+    reuse_existing: bool,
+    sync_existing_body: bool,
+    dry_run: bool,
+    result_output: Path | None = None,
+) -> dict[str, object]:
+    input_error = validate_input_contract(body_path, sync_existing_body, reuse_existing)
+    if input_error:
+        raise RuntimeError(input_error)
+
+    project_scope_available = has_project_scope(repo_root)
+
+    use_project_flag = False
+    if project_mode == "require-scope":
+        if not project_scope_available:
+            raise RuntimeError(
+                "create_release_issue.py: project scope is required but not available; run `gh auth refresh -s project` first"
+            )
+        use_project_flag = bool(project_title)
+    elif project_mode == "auto-add-first":
+        use_project_flag = bool(project_title and project_scope_available)
+
+    slug = repo_slug(repo_root)
+    existing_issue = find_existing_issue(repo_root, slug, title) if reuse_existing else None
+
+    command = build_create_command(slug, title, body_path, use_project_flag, project_title)
+    payload: dict[str, object] = {
+        "repo_slug": slug,
+        "checklist_issue_title": title,
+        "project_mode": project_mode,
+        "project_scope_available": project_scope_available,
+        "project_flag_used": use_project_flag,
+        "local_release_helper_handoff_available": local_release_helper_status == "present",
+        "dry_run": dry_run,
+        "mutation_type": "gh_issue_create",
+        "command": command,
+    }
+
+    if existing_issue:
+        payload.update(
+            {
+                "existing_issue_number": existing_issue.get("number"),
+                "created_issue_url": str(existing_issue.get("url") or "").strip(),
+            }
+        )
+        if sync_existing_body:
+            edit_command = build_edit_command(
+                slug,
+                existing_issue.get("number"),
+                title,
+                body_path,
+                use_project_flag,
+                project_title,
+            )
+            payload.update(
+                {
+                    "mutation_type": "gh_issue_edit_existing",
+                    "command": edit_command,
+                }
+            )
+            if dry_run:
+                payload["apply_succeeded"] = True
+                write_json_output(result_output, payload)
+                return payload
+            run_command(edit_command, cwd=repo_root)
+            payload["apply_succeeded"] = True
+            write_json_output(result_output, payload)
+            return payload
+
+        payload.update(
+            {
+                "apply_succeeded": True,
+                "mutation_type": "gh_issue_reuse_existing",
+            }
+        )
+        write_json_output(result_output, payload)
+        return payload
+
+    if dry_run:
+        payload["apply_succeeded"] = True
+        write_json_output(result_output, payload)
+        return payload
+
+    output = run_command(command, cwd=repo_root)
+    issue_url = output.strip().splitlines()[-1].strip() if output.strip() else ""
+    payload["created_issue_url"] = issue_url
+    payload["apply_succeeded"] = True
+    write_json_output(result_output, payload)
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a release checklist issue with label `release`."
+    )
+    parser.add_argument("--title", required=True, help="Issue title")
+    parser.add_argument("--body-file", required=True, help="Path to markdown body file")
+    parser.add_argument("--repo-root", required=True, help="Repository root")
+    parser.add_argument(
+        "--project-title",
+        default=DEFAULT_PROJECT_TITLE,
+        help="Optional project title for explicit add when project scope is available",
+    )
+    parser.add_argument(
+        "--project-mode",
+        choices=("auto-add-first", "require-scope", "issue-only"),
+        default="auto-add-first",
+        help="Project add policy",
+    )
+    parser.add_argument(
+        "--local-release-helper-status",
+        default="unknown",
+        help="Optional local helper status for result reporting",
+    )
+    parser.add_argument(
+        "--result-output",
+        type=Path,
+        help="Optional path to write the JSON result payload.",
+    )
+    parser.add_argument(
+        "--reuse-existing",
+        action="store_true",
+        help="Return an already-open release issue with the same title instead of creating a duplicate",
+    )
+    parser.add_argument(
+        "--sync-existing-body",
+        action="store_true",
+        help="When reusing an existing open release issue, update its title/body from --body-file via `gh issue edit`",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned gh command without creating the issue")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    body_path = Path(args.body_file).resolve()
+    input_error = validate_input_contract(body_path, args.sync_existing_body, args.reuse_existing)
+    if input_error:
+        print(input_error, file=sys.stderr)
+        return 1
+
+    try:
+        payload = execute_issue_action(
+            title=args.title,
+            body_path=body_path,
+            repo_root=repo_root,
+            project_title=args.project_title,
+            project_mode=args.project_mode,
+            local_release_helper_status=args.local_release_helper_status,
+            reuse_existing=args.reuse_existing,
+            sync_existing_body=args.sync_existing_body,
+            dry_run=args.dry_run,
+            result_output=args.result_output,
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/lint_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/lint_release_copy.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Lint release-facing copy against tracked release sources and helper status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+STOPWORDS = {
+    "the",
+    "and",
+    "with",
+    "that",
+    "this",
+    "from",
+    "into",
+    "then",
+    "when",
+    "while",
+    "were",
+    "have",
+    "has",
+    "keep",
+    "keeps",
+    "plus",
+    "after",
+    "before",
+    "into",
+    "only",
+    "more",
+    "still",
+    "current",
+    "release",
+    "default",
+}
+
+CHANGELOG_TOPIC_RULES = (
+    {
+        "id": "diagnostics",
+        "label": "diagnostics or troubleshooting",
+        "file_keywords": (
+            "officedemanddiagnosticssystem.cs",
+            "setting.cs",
+            "readme.md",
+        ),
+        "subject_keywords": ("diagnostic", "diagnostics", "troubleshooting", "logging"),
+        "bullet_keywords": ("diagnostic", "diagnostics", "troubleshooting", "logging"),
+        "min_churn": 120,
+        "min_subject_matches": 1,
+        "allow_subject_only": False,
+    },
+    {
+        "id": "telemetry",
+        "label": "performance telemetry",
+        "file_keywords": (
+            "performancetelemetry",
+            "perf_reporting.md",
+            "perf-telemetry",
+        ),
+        "subject_keywords": ("telemetry", "perf"),
+        "bullet_keywords": ("telemetry", "performance"),
+        "min_churn": 160,
+        "min_subject_matches": 2,
+        "allow_subject_only": True,
+    },
+    {
+        "id": "seller",
+        "label": "outside-connection seller fallback",
+        "file_keywords": (
+            "outsideconnectionvirtualsellerfixpatch.cs",
+            "seller",
+        ),
+        "subject_keywords": ("seller", "outside-connection", "outside connection"),
+        "bullet_keywords": ("seller", "outside-connection", "outside connection"),
+        "min_churn": 20,
+        "min_subject_matches": 1,
+        "allow_subject_only": False,
+    },
+    {
+        "id": "buyer",
+        "label": "virtual office buyer fallback",
+        "file_keywords": (
+            "virtualofficeresourcebuyerfixsystem.cs",
+            "correctivesoftwarebuyerprovenance.cs",
+            "buyer",
+        ),
+        "subject_keywords": ("buyer", "resourcebuyer"),
+        "bullet_keywords": ("buyer",),
+        "min_churn": 120,
+        "min_subject_matches": 1,
+        "allow_subject_only": False,
+    },
+    {
+        "id": "signature",
+        "label": "signature phantom-vacancy cleanup",
+        "file_keywords": (
+            "signaturepropertymarketguardsystem.cs",
+            "signature",
+            "phantom",
+        ),
+        "subject_keywords": ("signature", "phantom"),
+        "bullet_keywords": ("signature", "phantom vacancy", "market cleanup"),
+        "min_churn": 60,
+        "min_subject_matches": 1,
+        "allow_subject_only": False,
+    },
+    {
+        "id": "office_ai",
+        "label": "office AI hotfix",
+        "file_keywords": (
+            "officeaihotfixsystem.cs",
+            "officeaihotfixpatch.cs",
+            "office ai",
+        ),
+        "subject_keywords": ("office ai", "chunk-iteration", "low stock"),
+        "bullet_keywords": ("office ai", "chunk-iteration", "low stock"),
+        "min_churn": 140,
+        "min_subject_matches": 1,
+        "allow_subject_only": False,
+    },
+)
+
+SOFTWARE_GATE_TOPIC_IDS = {"diagnostics", "seller", "buyer"}
+TELEMETRY_VALIDATION_TOPIC_IDS = {"telemetry"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def add_finding(bucket: list[dict[str, str]], code: str, area: str, message: str) -> None:
+    bucket.append({"code": code, "area": area, "message": message})
+
+
+def applicable_validation_tracks(context: dict[str, Any]) -> dict[str, bool]:
+    active_topic_ids = {
+        str(signal.get("id"))
+        for signal in significant_changelog_topics(context)
+    }
+    return {
+        "software_gate": bool(active_topic_ids & SOFTWARE_GATE_TOPIC_IDS),
+        "telemetry_validation": bool(active_topic_ids & TELEMETRY_VALIDATION_TOPIC_IDS),
+    }
+
+
+def evidence_complete(evidence: dict[str, Any] | None, tracks: dict[str, bool]) -> bool:
+    if not any(tracks.values()):
+        return True
+    if not evidence:
+        return False
+
+    if tracks.get("software_gate"):
+        required_software_fields = (
+            "software_track_status",
+            "comparable_evidence",
+            "anchor_comparison",
+            "release_pr_validation_note",
+        )
+        if any(not str(evidence.get(field) or "").strip() for field in required_software_fields):
+            return False
+        if str(evidence.get("software_track_status") or "").strip().lower() in {"unknown", ""}:
+            return False
+
+    if tracks.get("telemetry_validation"):
+        required_telemetry_fields = (
+            "telemetry_validation_artifact",
+            "telemetry_validation_summary",
+        )
+        if any(not str(evidence.get(field) or "").strip() for field in required_telemetry_fields):
+            return False
+
+    return True
+
+
+def normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def has_experimental_language(text: str) -> bool:
+    normalized = normalize_text(text)
+    keywords = (
+        "experimental",
+        "under investigation",
+        "investigational",
+        "does not claim",
+        "not a proven fix",
+        "remains under investigation",
+    )
+    return any(keyword in normalized for keyword in keywords)
+
+
+def has_strong_software_claim(text: str) -> bool:
+    normalized = normalize_text(text)
+    patterns = (
+        r"software.{0,20}(solved|stable|fixed)",
+        r"(solved|stable|fixed).{0,20}software",
+        r"confirmed fix.{0,20}software",
+    )
+    return any(re.search(pattern, normalized) for pattern in patterns)
+
+
+def change_log_bullets(change_log: str) -> list[str]:
+    bullets: list[str] = []
+    for line in change_log.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+    return bullets
+
+
+def normalize_substring(value: str) -> str:
+    return normalize_text(value).replace("`", "")
+
+
+def bullet_matches_keywords(bullets: list[str], keywords: tuple[str, ...]) -> bool:
+    normalized_bullets = [normalize_substring(bullet) for bullet in bullets]
+    return any(any(keyword in bullet for keyword in keywords) for bullet in normalized_bullets)
+
+
+def overlapping_prior_release_bullets(current_bullets: list[str], prior_bullets: list[str]) -> list[str]:
+    normalized_prior = {normalize_substring(bullet): bullet for bullet in prior_bullets}
+    overlaps: list[str] = []
+    for bullet in current_bullets:
+        normalized = normalize_substring(bullet)
+        if normalized in normalized_prior:
+            overlaps.append(bullet)
+    return overlaps
+
+
+def significant_changelog_topics(context: dict[str, Any]) -> list[dict[str, Any]]:
+    changed_file_stats = context.get("changed_file_stats", {})
+    if not isinstance(changed_file_stats, dict):
+        changed_file_stats = {}
+    normalized_subjects = [normalize_substring(subject) for subject in context.get("commit_subjects", [])]
+
+    signals: list[dict[str, Any]] = []
+    for rule in CHANGELOG_TOPIC_RULES:
+        matching_files: list[dict[str, Any]] = []
+        churn_sum = 0
+        for raw_path, raw_stats in changed_file_stats.items():
+            path = normalize_substring(str(raw_path))
+            if not any(keyword in path for keyword in rule["file_keywords"]):
+                continue
+            stats = raw_stats if isinstance(raw_stats, dict) else {}
+            file_churn = int(stats.get("churn", 0) or 0)
+            churn_sum += file_churn
+            matching_files.append(
+                {
+                    "path": str(raw_path),
+                    "churn": file_churn,
+                }
+            )
+
+        subject_matches = [
+            subject
+            for subject in normalized_subjects
+            if any(keyword in subject for keyword in rule["subject_keywords"])
+        ]
+
+        has_significant_file_signal = churn_sum >= rule["min_churn"]
+        has_significant_subject_signal = len(subject_matches) >= rule["min_subject_matches"]
+        significant = (has_significant_file_signal and matching_files) or (
+            rule["allow_subject_only"] and has_significant_subject_signal
+        ) or (has_significant_file_signal and has_significant_subject_signal)
+        if not significant:
+            continue
+
+        signals.append(
+            {
+                "id": rule["id"],
+                "label": rule["label"],
+                "bullet_keywords": rule["bullet_keywords"],
+                "matching_files": matching_files,
+                "matching_file_count": len(matching_files),
+                "churn_sum": churn_sum,
+                "matching_subject_count": len(subject_matches),
+            }
+        )
+    return signals
+
+
+def bullet_supported(bullet: str, context: dict[str, Any]) -> bool:
+    if not bullet:
+        return True
+    corpus_parts = list(context.get("commit_subjects", [])) + list(context.get("changed_files", []))
+    corpus = normalize_text(" ".join(corpus_parts))
+    tokens = [
+        token
+        for token in re.findall(r"[A-Za-z][A-Za-z0-9-]{3,}", bullet.lower())
+        if token not in STOPWORDS
+    ]
+    if not tokens:
+        return True
+    if any(token in corpus for token in tokens):
+        return True
+
+    keyword_hints = {
+        "diagnostic": ("diagnostic", "log", "setting.cs", "readme.md"),
+        "telemetry": ("telemetry", "perf", "setting.cs", "perf_reporting"),
+        "seller": ("seller", "outsideconnectionvirtualseller", "outside connection"),
+        "buyer": ("buyer", "virtualofficeresourcebuyer", "resourcebuyer"),
+        "signature": ("signature", "propertymarket", "phantom"),
+        "publish": ("publishconfiguration", "readme", "maintaining"),
+        "readme": ("readme",),
+    }
+    lowered = bullet.lower()
+    for keyword, hints in keyword_hints.items():
+        if keyword in lowered and any(hint in corpus for hint in hints):
+            return True
+    return False
+
+
+def expected_default_literal(value: str) -> str:
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "false"}:
+        return normalized
+    try:
+        number_text = normalized.removesuffix("f").removesuffix("d").removesuffix("m")
+        number = float(number_text)
+        if number.is_integer():
+            return str(int(number))
+        return format(number, "g")
+    except ValueError:
+        return normalized
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint release-facing copy against tracked release sources and helper status."
+    )
+    parser.add_argument("--context", required=True, help="Path to JSON from collect_release_copy_context.py")
+    parser.add_argument("--output", required=True, help="Output JSON path")
+    args = parser.parse_args()
+
+    context = load_json(Path(args.context))
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    errors: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+    info: list[dict[str, str]] = []
+
+    publish = context.get("publish_configuration", {})
+    readme = context.get("readme", {})
+    readme_sections = readme.get("sections", {})
+    readme_release_text = "\n".join(
+        [
+            str(readme.get("intro_text") or ""),
+            str(readme_sections.get("Current Release") or ""),
+            str(readme_sections.get("Current Status") or ""),
+        ]
+    )
+    publish_release_text = "\n".join(
+        [
+            str(publish.get("short_description") or ""),
+            str(publish.get("long_description") or ""),
+            str(publish.get("change_log") or ""),
+        ]
+    )
+    local_helper = context.get("local_release_helper", {})
+    target_version = str(context.get("target_version") or "").strip()
+    configured_version = str(publish.get("mod_version") or "").strip()
+
+    if configured_version != target_version:
+        add_finding(
+            errors,
+            "target_version_mismatch",
+            "publish",
+            f"Target version `{target_version}` does not match PublishConfiguration ModVersion `{configured_version}`.",
+        )
+
+    if local_helper.get("status") == "missing_local_release_script":
+        add_finding(
+            info,
+            "missing_local_release_script",
+            "helper",
+            "The repo-relative local release helper is missing. Release-copy preparation may continue, but no helper handoff command should be generated.",
+        )
+
+    evidence = context.get("evidence")
+    tracks = applicable_validation_tracks(context)
+    evidence_is_complete = evidence_complete(evidence if isinstance(evidence, dict) else None, tracks)
+    if not evidence_is_complete:
+        add_finding(
+            warnings,
+            "release_gate_validation_incomplete",
+            "evidence",
+            "Applicable release-gate evidence or validation is missing or incomplete. Keep conservative wording and leave unresolved checklist placeholders in the issue draft.",
+        )
+
+    readme_experimental = has_experimental_language(readme_release_text)
+    publish_experimental = has_experimental_language(publish_release_text)
+    if readme_experimental != publish_experimental:
+        add_finding(
+            warnings,
+            "experimental_language_mismatch",
+            "copy",
+            "README and PublishConfiguration disagree on whether the software path is still experimental or under investigation.",
+        )
+
+    if tracks.get("software_gate") and not evidence_is_complete and has_strong_software_claim(
+        readme_release_text + "\n" + publish_release_text
+    ):
+        add_finding(
+            errors,
+            "unsupported_strong_software_claim",
+            "copy",
+            "Release-facing copy makes strong software-track claims without complete applicable software-gate evidence.",
+        )
+
+    readme_defaults = readme.get("settings_defaults", {})
+    setting_defaults = context.get("setting_defaults", {})
+    for setting_name, readme_entry in readme_defaults.items():
+        readme_default = expected_default_literal(readme_entry.get("default", ""))
+        setting_default = expected_default_literal(setting_defaults.get(setting_name, ""))
+        if not setting_default:
+            continue
+        if readme_default != setting_default:
+            add_finding(
+                warnings,
+                "setting_default_mismatch",
+                "readme",
+                f"`{setting_name}` default is `{readme_default}` in README but `{setting_default}` in Setting.cs.",
+            )
+
+    for bullet in change_log_bullets(str(publish.get("change_log") or "")):
+        if not bullet_supported(bullet, context):
+            add_finding(
+                warnings,
+                "unsupported_changelog_bullet",
+                "publish",
+                f"ChangeLog bullet is not clearly supported by the diff since {context.get('base_tag')}: `{bullet}`.",
+            )
+
+    change_log = str(publish.get("change_log") or "")
+    bullets = change_log_bullets(change_log)
+    prior_publish = context.get("base_tag_publish_configuration") or {}
+    prior_bullets = change_log_bullets(str(prior_publish.get("change_log") or ""))
+    repeated_bullets = overlapping_prior_release_bullets(bullets, prior_bullets)
+    if repeated_bullets:
+        repeated_text = "; ".join(f"`{bullet}`" for bullet in repeated_bullets)
+        add_finding(
+            warnings,
+            "changelog_carries_forward_prior_release_bullets",
+            "publish",
+            "ChangeLog should be rewritten for the current release only, but it still carries forward "
+            f"bullet(s) from {context.get('base_tag')}: {repeated_text}.",
+        )
+
+    for signal in significant_changelog_topics(context):
+        if bullet_matches_keywords(bullets, signal["bullet_keywords"]):
+            continue
+        add_finding(
+            warnings,
+            "missing_changelog_topic",
+            "publish",
+            "ChangeLog may be missing a significant shipped topic for "
+            f"`{signal['label']}` since {context.get('base_tag')} "
+            f"({signal['matching_file_count']} file(s), {signal['churn_sum']} churn, "
+            f"{signal['matching_subject_count']} matching commit subject(s)).",
+        )
+
+    if not evidence_is_complete:
+        add_finding(
+            warnings,
+            "checklist_field_unresolved",
+            "checklist",
+            "The release checklist `Release-gate evidence / validation` field cannot be fully filled from the current artifacts.",
+        )
+
+    handoff_allowed = (
+        local_helper.get("status") == "present"
+        and configured_version == target_version
+    )
+
+    result = {
+        "findings": {
+            "errors": errors,
+            "warnings": warnings,
+            "info": info,
+        },
+        "checks": {
+            "target_version_matches_publish": configured_version == target_version,
+            "evidence_complete": evidence_is_complete,
+            "applicable_validation_tracks": tracks,
+            "helper_status": local_helper.get("status"),
+            "helper_handoff_allowed": handoff_allowed,
+            "readme_has_experimental_language": readme_experimental,
+            "publish_has_experimental_language": publish_experimental,
+            "rewrite_publish_recommended": bool(errors or any(item["area"] == "publish" for item in warnings)),
+            "rewrite_readme_recommended": bool(
+                any(item["area"] in {"readme", "copy"} for item in errors + warnings)
+            ),
+        },
+    }
+    output_path.write_text(json.dumps(result, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"lint_release_copy.py: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/release_copy_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/release_copy_plan_contract.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Shared contract helpers for draft-release-copy packet/build/validate/apply flows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import collect_release_copy_context as collect_tools
+
+WORKFLOW_FAMILY = "release-copy"
+ARCHETYPE = "audit-and-apply"
+ORCHESTRATOR_PROFILE = "packet-heavy-orchestrator"
+WORKER_RETURN_CONTRACT = "generic"
+WORKER_OUTPUT_SHAPE = "flat"
+
+SHARED_PACKET = "global_packet.json"
+SHARED_LOCAL_PACKET = "synthesis_packet.json"
+FOCUSED_PACKETS = [
+    "publish_packet.json",
+    "readme_packet.json",
+    "changes_packet.json",
+    "checklist_packet.json",
+    "evidence_packet.json",
+]
+CANONICAL_RUNTIME_ARTIFACTS = [
+    "orchestrator.json",
+    SHARED_PACKET,
+    "publish_packet.json",
+    "readme_packet.json",
+    "changes_packet.json",
+    "checklist_packet.json",
+    SHARED_LOCAL_PACKET,
+]
+CANONICAL_OPTIONAL_RUNTIME_ARTIFACTS = ["evidence_packet.json"]
+CANONICAL_EVAL_ARTIFACTS = ["packet_metrics.json", "eval-log.json"]
+
+AUTHORITY_ORDER = [
+    "tracked release rules and metadata",
+    "tracked runtime defaults",
+    "tracked release diff since the base tag",
+    "optional evidence input",
+    "optional repo-relative local helper",
+]
+
+ROUTING_AUTHORITY = "packet_worker_map"
+PREFERRED_WORKER_FAMILIES_ROLE = "registry_metadata_only"
+DERIVED_WORKER_FIELDS = ["recommended_workers", "optional_workers"]
+EXPLANATORY_WORKER_FIELDS = ["worker_selection_guidance"]
+
+SMOKE_OUTPUT_FIELDS = [
+    "status",
+    "reason",
+    "repo_root",
+    "next_action",
+]
+
+
+CORE_STOP_CATEGORIES = [
+    "stale_context",
+    "ambiguous_routing",
+    "missing_required_evidence",
+    "validator_mismatch",
+    "missing_auth",
+    "unresolved_stop_reason",
+]
+
+LOCAL_STOP_CATEGORIES = [
+    "unsupported_layout",
+    "stale_issue_snapshot",
+    "release_gate_incomplete",
+    "rewrite_block_unsupported",
+    "project_scope_required",
+    "synthesis_packet_insufficient",
+]
+
+RAW_REREAD_ALLOWED_REASONS = [
+    "unsupported_layout",
+    "evidence_dispute",
+    "issue_snapshot_conflict",
+    "validator_blocker",
+]
+
+COMMON_PATH_MAX_FOCUSED_PACKETS = 1
+
+PLAN_PHASE_FIELDS = {
+    "top_level": {
+        "required": [
+            "context_fingerprint",
+            "freshness_tuple",
+            "overall_confidence",
+            "stop_reasons",
+            "evidence_status",
+            "draft_basis",
+            "publish_update",
+            "readme_update",
+            "issue_action",
+        ],
+        "allowed": [
+            "context_fingerprint",
+            "freshness_tuple",
+            "overall_confidence",
+            "stop_reasons",
+            "evidence_status",
+            "draft_basis",
+            "publish_update",
+            "readme_update",
+            "issue_action",
+        ],
+        "ignored": [],
+    },
+    "draft_basis": {
+        "required": [
+            "common_path_sufficient",
+            "raw_reread_count",
+            "reread_reasons",
+            "focused_packets_used",
+            "compensatory_reread_detected",
+        ],
+        "allowed": [
+            "common_path_sufficient",
+            "raw_reread_count",
+            "reread_reasons",
+            "focused_packets_used",
+            "compensatory_reread_detected",
+            "synthesis_packet_fingerprint",
+        ],
+        "ignored": [],
+    },
+    "publish_update": {
+        "required": ["mode"],
+        "allowed": ["mode", "short_description", "long_description", "change_log", "mod_version"],
+        "ignored": [],
+    },
+    "readme_update": {
+        "required": ["mode"],
+        "allowed": ["mode", "intro_text", "sections"],
+        "ignored": [],
+    },
+    "issue_action": {
+        "required": ["mode"],
+        "allowed": ["mode", "title", "body_markdown", "project_mode", "project_title"],
+        "ignored": [],
+    },
+}
+
+VALIDATION_ERROR_CODES = {
+    "missing_field": "E_RELEASE_PLAN_MISSING_FIELD",
+    "invalid_mode": "E_RELEASE_PLAN_INVALID_MODE",
+    "invalid_reread_reason": "E_RELEASE_PLAN_INVALID_REREAD_REASON",
+    "validator_mismatch": "E_RELEASE_PLAN_VALIDATOR_MISMATCH",
+    "context_fingerprint": "E_RELEASE_PLAN_CONTEXT_FINGERPRINT",
+    "freshness_tuple": "E_RELEASE_PLAN_FRESHNESS_TUPLE",
+    "stale_context": "E_RELEASE_PLAN_STALE_CONTEXT",
+    "missing_auth": "E_RELEASE_PLAN_MISSING_AUTH",
+    "stale_issue_snapshot": "E_RELEASE_PLAN_STALE_ISSUE_SNAPSHOT",
+    "release_gate_incomplete": "E_RELEASE_PLAN_RELEASE_GATE_INCOMPLETE",
+    "unsupported_layout": "E_RELEASE_PLAN_UNSUPPORTED_LAYOUT",
+    "project_scope_required": "E_RELEASE_PLAN_PROJECT_SCOPE_REQUIRED",
+    "packet_insufficient": "E_RELEASE_PLAN_PACKET_INSUFFICIENT",
+}
+
+VALIDATION_WARNING_CODES = {
+    "ignored_field": "W_RELEASE_PLAN_IGNORED_FIELD",
+}
+
+SMALL_FILE_LIMIT = 8
+MEDIUM_FILE_LIMIT = 20
+SMALL_GROUP_LIMIT = 2
+LARGE_GROUP_LIMIT = 4
+CHURN_OVERRIDE_LIMIT = 400
+
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["repo_mapper", "docs_verifier"],
+    "candidate_producers": ["evidence_summarizer", "large_diff_auditor", "log_triager"],
+    "verifiers": ["docs_verifier"],
+}
+
+PACKET_WORKER_MAP = {
+    "checklist_packet": ["docs_verifier", "repo_mapper"],
+    "publish_packet": ["large_diff_auditor"],
+    "readme_packet": ["docs_verifier"],
+    "changes_packet": ["large_diff_auditor"],
+    "evidence_packet": ["evidence_summarizer"],
+}
+
+WORKER_SELECTION_GUIDANCE = {
+    "routing_authority": "packet_worker_map",
+    "notes": "worker_selection_guidance is explanatory only; packet_worker_map is the concrete routing source.",
+    "agent_type_guidance": {
+        "repo_mapper": "Use for authority order questions, packet membership, and scope mapping.",
+        "docs_verifier": "Use for checklist policy, README wording, and release-policy verification.",
+        "evidence_summarizer": "Use for optional evidence or validation input that needs narrow compression.",
+        "large_diff_auditor": "Use for release-copy drift, changelog coverage, and broad diff review.",
+        "log_triager": "Use for blocker, incident, or validation triage when the release scope touches execution evidence.",
+    },
+}
+
+LOCAL_ONLY_PACKETS = {SHARED_LOCAL_PACKET, "orchestrator.json"}
+SHARED_WORKER_PACKETS = {SHARED_PACKET}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def json_fingerprint(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def normalize_release_version(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return text if text.startswith("v") else f"v{text}"
+
+
+def expected_context_fingerprint(context: dict[str, Any]) -> str:
+    payload = {key: value for key, value in context.items() if key != "context_fingerprint"}
+    return json_fingerprint(payload)
+
+
+def expected_freshness_tuple(context: dict[str, Any]) -> dict[str, Any]:
+    return collect_tools.freshness_tuple(context)
+
+
+def packet_size_bytes(payload: dict[str, Any]) -> int:
+    return len((json.dumps(payload, indent=2, ensure_ascii=True) + "\n").encode("utf-8"))
+
+
+def estimate_token_proxy(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return int(math.ceil(byte_count / 4.0))
+
+
+def packet_size_summary(packet_payloads: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    by_packet = {name: packet_size_bytes(payload) for name, payload in packet_payloads.items()}
+    total = sum(by_packet.values())
+    worker_facing_names = [
+        name
+        for name in packet_payloads
+        if name not in LOCAL_ONLY_PACKETS and name != "orchestrator.json"
+    ]
+    worker_facing_total = sum(by_packet[name] for name in worker_facing_names)
+    local_only_total = sum(by_packet[name] for name in packet_payloads if name in LOCAL_ONLY_PACKETS)
+    largest = max(by_packet.values(), default=0)
+    largest_two = sum(sorted(by_packet.values(), reverse=True)[:2])
+    return {
+        "by_packet": by_packet,
+        "worker_facing_packets": worker_facing_names,
+        "worker_facing_total": worker_facing_total,
+        "local_only_total": local_only_total,
+        "total": total,
+        "largest_packet_bytes": largest,
+        "largest_two_packets_bytes": largest_two,
+        "packet_count": len(packet_payloads),
+        "estimated_packet_tokens": estimate_token_proxy(worker_facing_total),
+        "estimated_local_only_tokens": estimate_token_proxy(total),
+        "estimated_delegation_savings": max(0, estimate_token_proxy(total) - estimate_token_proxy(worker_facing_total)),
+    }
+
+
+def packet_worker_map() -> dict[str, list[str]]:
+    return {packet_name: list(agent_types) for packet_name, agent_types in PACKET_WORKER_MAP.items()}
+
+
+def runtime_artifact_names(*, include_optional: bool = True) -> list[str]:
+    names = list(CANONICAL_RUNTIME_ARTIFACTS)
+    if include_optional:
+        names.extend(CANONICAL_OPTIONAL_RUNTIME_ARTIFACTS)
+    return names
+
+
+def runtime_field_roles() -> dict[str, Any]:
+    return {
+        "routing_authority": ROUTING_AUTHORITY,
+        "preferred_worker_families_role": PREFERRED_WORKER_FAMILIES_ROLE,
+        "derived_worker_fields": list(DERIVED_WORKER_FIELDS),
+        "explanatory_worker_fields": list(EXPLANATORY_WORKER_FIELDS),
+    }

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/release_copy_plan_tools.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/release_copy_plan_tools.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Shared helpers for release-copy validate/apply flows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import xml.sax.saxutils as xml_utils
+from pathlib import Path
+from typing import Any
+
+import collect_release_copy_context as collect_tools
+import release_copy_plan_contract as contract
+
+
+ATTRIBUTE_FIELD_TAGS = {
+    "short_description": "ShortDescription",
+    "mod_version": "ModVersion",
+}
+
+BLOCK_FIELD_TAGS = {
+    "long_description": "LongDescription",
+    "change_log": "ChangeLog",
+}
+
+README_ALLOWED_SECTIONS = {"Current Release", "Current Status"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def json_fingerprint(payload: Any) -> str:
+    return contract.json_fingerprint(payload)
+
+
+def expected_context_fingerprint(context: dict[str, Any]) -> str:
+    return contract.expected_context_fingerprint(context)
+
+
+def expected_freshness_tuple(context: dict[str, Any]) -> dict[str, Any]:
+    return contract.expected_freshness_tuple(context)
+
+
+def normalize_release_version(value: str) -> str:
+    return contract.normalize_release_version(value)
+
+
+def current_head_commit(repo_root: Path) -> str:
+    return collect_tools.git_head_commit(repo_root)
+
+
+def existing_issue_snapshot(issue: dict[str, Any] | None) -> dict[str, Any] | None:
+    return collect_tools.existing_issue_snapshot(issue)
+
+
+def fetch_issue_snapshot(repo_root: Path, repo_slug: str | None, issue_number: int) -> dict[str, Any] | None:
+    return collect_tools.release_issue_by_number(repo_root, repo_slug, issue_number)
+
+
+def replace_publish_fields(text: str, fields: dict[str, str]) -> str:
+    updated = text
+    for field_name, tag_name in ATTRIBUTE_FIELD_TAGS.items():
+        if field_name not in fields:
+            continue
+        value = str(fields[field_name])
+        escaped = xml_utils.escape(value, {'"': "&quot;"})
+        pattern = re.compile(rf"(<{tag_name}\s+Value=\")([^\"]*)(\"\s*/>)")
+        updated, count = pattern.subn(rf"\1{escaped}\3", updated, count=1)
+        if count != 1:
+            raise RuntimeError(f"unsupported layout: missing <{tag_name} Value=\"...\" /> field")
+
+    for field_name, tag_name in BLOCK_FIELD_TAGS.items():
+        if field_name not in fields:
+            continue
+        value = xml_utils.escape(str(fields[field_name]))
+        pattern = re.compile(rf"(<{tag_name}>)(.*?)(</{tag_name}>)", re.DOTALL)
+        updated, count = pattern.subn(lambda match: match.group(1) + value + match.group(3), updated, count=1)
+        if count != 1:
+            raise RuntimeError(f"unsupported layout: missing <{tag_name}>...</{tag_name}> block")
+
+    return updated
+
+
+def split_markdown_document(text: str) -> tuple[str, list[tuple[str, str]]]:
+    lines = text.splitlines()
+    intro_lines: list[str] = []
+    sections: list[tuple[str, str]] = []
+    current_heading: str | None = None
+    current_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith("## "):
+            if current_heading is None:
+                intro = "\n".join(intro_lines).strip()
+            else:
+                sections.append((current_heading, "\n".join(current_lines).strip()))
+            current_heading = line[3:].strip()
+            current_lines = []
+            if len(sections) == 0 and current_heading is not None and not intro_lines:
+                intro_lines = []
+            continue
+        if current_heading is None:
+            intro_lines.append(line)
+        else:
+            current_lines.append(line)
+
+    if current_heading is not None:
+        sections.append((current_heading, "\n".join(current_lines).strip()))
+
+    intro_text = "\n".join(intro_lines).strip()
+    return intro_text, sections
+
+
+def render_markdown_document(intro_text: str, sections: list[tuple[str, str]]) -> str:
+    parts: list[str] = []
+    if intro_text.strip():
+        parts.append(intro_text.strip())
+    for heading, body in sections:
+        section_text = f"## {heading}".rstrip()
+        if body.strip():
+            section_text += "\n" + body.strip()
+        parts.append(section_text)
+    return "\n\n".join(parts).rstrip() + "\n"
+
+
+def replace_readme_blocks(text: str, intro_text: str | None, sections: dict[str, str]) -> str:
+    current_intro, current_sections = split_markdown_document(text)
+    updated_intro = current_intro if intro_text is None else intro_text.strip()
+
+    section_map = {heading: body for heading, body in current_sections}
+    for heading in sections:
+        if heading not in README_ALLOWED_SECTIONS:
+            raise RuntimeError(f"unsupported layout: section `{heading}` is outside the deterministic allowlist")
+        if heading not in section_map:
+            raise RuntimeError(f"unsupported layout: missing README section `{heading}`")
+    updated_sections = [
+        (heading, sections.get(heading, body).strip())
+        for heading, body in current_sections
+    ]
+    return render_markdown_document(updated_intro, updated_sections)
+
+
+def apply_publish_update(path: Path, fields: dict[str, str], dry_run: bool) -> dict[str, Any]:
+    original = path.read_text(encoding="utf-8")
+    updated = replace_publish_fields(original, fields)
+    changed = updated != original
+    if changed and not dry_run:
+        path.write_text(updated, encoding="utf-8")
+    return {
+        "kind": "publish_configuration",
+        "path": str(path),
+        "changed": changed,
+        "fields": sorted(fields.keys()),
+    }
+
+
+def apply_readme_update(path: Path, intro_text: str | None, sections: dict[str, str], dry_run: bool) -> dict[str, Any]:
+    original = path.read_text(encoding="utf-8")
+    updated = replace_readme_blocks(original, intro_text, sections)
+    changed = updated != original
+    if changed and not dry_run:
+        path.write_text(updated, encoding="utf-8")
+    return {
+        "kind": "readme",
+        "path": str(path),
+        "changed": changed,
+        "intro_updated": intro_text is not None,
+        "sections": sorted(sections.keys()),
+    }

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/smoke_prepare_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/smoke_prepare_release_copy.py
@@ -1,0 +1,422 @@
+﻿#!/usr/bin/env python3
+"""Run an end-to-end smoke test for draft-release-copy on a synthetic temp repo."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import release_copy_plan_contract as contract
+
+
+EXPECTED_PACKET_FILES = (
+    "orchestrator.json",
+    "global_packet.json",
+    "publish_packet.json",
+    "readme_packet.json",
+    "changes_packet.json",
+    "checklist_packet.json",
+    "synthesis_packet.json",
+)
+
+README_BASE = """# ExampleProduct
+
+Intro text.
+
+## Current Release
+Experimental path remains under investigation.
+
+## Current Status
+Current status block.
+
+## Settings
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `SoftCap` | `5000` | Runtime cap. |
+"""
+
+
+README_HEAD = """# ExampleProduct
+
+Intro text.
+
+## Current Release
+Experimental path remains under investigation.
+
+## Current Status
+Current status block.
+
+## Settings
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `SoftCap` | `5000` | Runtime cap. |
+"""
+
+
+PUBLISH_BASE = """<Configuration>
+  <ShortDescription Value="Current short description" />
+  <LongDescription>Current long description.</LongDescription>
+  <ModVersion Value="1.0.0" />
+  <ChangeLog>- Prior release note.</ChangeLog>
+</Configuration>
+"""
+
+
+PUBLISH_HEAD = """<Configuration>
+  <ShortDescription Value="Current short description" />
+  <LongDescription>Current long description.</LongDescription>
+  <ModVersion Value="1.1.0" />
+  <ChangeLog>- Diagnostics note for this release.</ChangeLog>
+</Configuration>
+"""
+
+
+SETTING_BASE = """namespace ExampleProduct;
+
+public sealed class Setting
+{
+    public int SoftCap { get; set; }
+
+    public override void SetDefaults()
+    {
+        SoftCap = 5000;
+    }
+}
+"""
+
+
+SETTING_HEAD = """namespace ExampleProduct;
+
+public sealed class Setting
+{
+    public int SoftCap { get; set; }
+
+    public override void SetDefaults()
+    {
+        SoftCap = 5000;
+    }
+}
+"""
+
+
+DIAGNOSTICS_HEAD = """namespace ExampleProduct.Systems;
+
+public sealed class OfficeDemandDiagnosticsSystem
+{
+    public string Describe()
+    {
+        return "Diagnostics cleanup";
+    }
+}
+"""
+
+
+MAINTAINING_MD = """# Maintaining
+
+## Release Operations
+Keep release copy aligned with shipped behavior.
+"""
+
+
+RELEASE_TEMPLATE = """name: Release checklist
+description: Prepare the release checklist.
+title: "[Release] "
+labels: [release]
+body:
+  - type: input
+    id: target_version
+    attributes:
+      label: Target version
+  - type: textarea
+    id: included_changes
+    attributes:
+      label: Included changes
+  - type: textarea
+    id: release_gate
+    attributes:
+      label: Release-gate evidence / validation
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: PublishConfiguration wording reviewed against shipped behavior
+        - label: Release notes reviewed
+"""
+
+
+RELEASE_WORKFLOW = """name: release
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+"""
+
+
+def script_path(name: str) -> Path:
+    return Path(__file__).resolve().with_name(name)
+
+
+def run_command(args: list[str], *, cwd: Path) -> str:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    command = [sys.executable, "-B", *args] if args[0].endswith(".py") else args
+    result = subprocess.run(
+        command,
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if result.returncode != 0:
+        details = "\n".join(part for part in ((result.stderr or "").strip(), (result.stdout or "").strip()) if part)
+        detail_suffix = f"\n{details}" if details else ""
+        raise RuntimeError(f"Command failed: {' '.join(command)}{detail_suffix}")
+    return result.stdout
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def git(args: list[str], *, cwd: Path) -> str:
+    return run_command(["git", *args], cwd=cwd)
+
+
+def init_repo(repo_root: Path) -> None:
+    git(["init"], cwd=repo_root)
+    git(["config", "user.name", "Codex Smoke"], cwd=repo_root)
+    git(["config", "user.email", "codex-smoke@example.invalid"], cwd=repo_root)
+
+    write_text(repo_root / "README.md", README_BASE)
+    write_text(repo_root / "MAINTAINING.md", MAINTAINING_MD)
+    write_text(repo_root / ".github/ISSUE_TEMPLATE/release_checklist.yml", RELEASE_TEMPLATE)
+    write_text(repo_root / ".github/workflows/release.yml", RELEASE_WORKFLOW)
+    write_text(
+        repo_root / ".codex/project/profiles/draft-release-copy/profile.json",
+        json.dumps(
+            {
+                "name": "draft-release-copy",
+                "summary": "smoke profile",
+                "bindings": {
+                    "primary_readme_path": "README.md",
+                    "settings_source_path": "ExampleProduct/Setting.cs",
+                    "publish_config_path": "ExampleProduct/Properties/PublishConfiguration.xml",
+                },
+                "extra": {
+                    "release_copy": {
+                        "maintaining_path": "MAINTAINING.md",
+                        "release_checklist_template_path": ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                        "release_workflow_path": ".github/workflows/release.yml",
+                    }
+                },
+            },
+            indent=2,
+        ) + "\n",
+    )
+    write_text(repo_root / "ExampleProduct/Properties/PublishConfiguration.xml", PUBLISH_BASE)
+    write_text(repo_root / "ExampleProduct/Setting.cs", SETTING_BASE)
+    write_text(repo_root / "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs", "namespace ExampleProduct.Systems;\n")
+    git(["add", "."], cwd=repo_root)
+    git(["commit", "-m", "Initial release baseline"], cwd=repo_root)
+    git(["tag", "v1.0.0"], cwd=repo_root)
+
+    write_text(repo_root / "README.md", README_HEAD)
+    write_text(repo_root / "ExampleProduct/Properties/PublishConfiguration.xml", PUBLISH_HEAD)
+    write_text(repo_root / "ExampleProduct/Setting.cs", SETTING_HEAD)
+    write_text(repo_root / "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs", DIAGNOSTICS_HEAD)
+    git(["add", "."], cwd=repo_root)
+    git(["commit", "-m", "Refresh diagnostics release copy"], cwd=repo_root)
+
+
+def build_smoke_plan(context: dict[str, Any], synthesis_packet: dict[str, Any]) -> dict[str, Any]:
+    defaults = synthesis_packet.get("plan_defaults") or {}
+    draft_basis = defaults.get("draft_basis") or {}
+    return {
+        "context_fingerprint": defaults.get("context_fingerprint") or context.get("context_fingerprint"),
+        "freshness_tuple": defaults.get("freshness_tuple") or context.get("freshness_tuple"),
+        "overall_confidence": defaults.get("overall_confidence") or "medium",
+        "stop_reasons": [],
+        "evidence_status": defaults.get("evidence_status") or "not-applicable",
+        "draft_basis": {
+            "common_path_sufficient": True,
+            "raw_reread_count": 0,
+            "reread_reasons": [],
+            "focused_packets_used": [],
+            "compensatory_reread_detected": False,
+            "synthesis_packet_fingerprint": draft_basis.get("synthesis_packet_fingerprint"),
+        },
+        "publish_update": {"mode": "noop"},
+        "readme_update": {"mode": "noop"},
+        "issue_action": {"mode": "noop"},
+    }
+
+
+def build_smoke_summary(status: str, reason: str | None, repo_root: Path, next_action: str, **extra: Any) -> dict[str, Any]:
+    payload = {
+        "status": status,
+        "reason": reason,
+        "repo_root": str(repo_root),
+        "next_action": next_action,
+    }
+    payload.update(extra)
+    return payload
+
+
+def main() -> int:
+    smoke_output: dict[str, Any]
+
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "draft-release-copy"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        repo_root = temp_dir / "repo"
+        repo_root.mkdir()
+        init_repo(repo_root)
+
+        context_path = temp_dir / "context.json"
+        lint_path = temp_dir / "lint.json"
+        packet_dir = temp_dir / "packets"
+        plan_path = temp_dir / "release-copy-plan.json"
+        validation_path = temp_dir / "validation.json"
+        apply_path = temp_dir / "apply.json"
+
+        publish_path = repo_root / "ExampleProduct/Properties/PublishConfiguration.xml"
+        readme_path = repo_root / "README.md"
+        publish_before = publish_path.read_text(encoding="utf-8")
+        readme_before = readme_path.read_text(encoding="utf-8")
+
+        run_command(
+            [
+                str(script_path("collect_release_copy_context.py")),
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(context_path),
+            ],
+            cwd=repo_root,
+        )
+        context = read_json(context_path)
+
+        run_command(
+            [
+                str(script_path("lint_release_copy.py")),
+                "--context",
+                str(context_path),
+                "--output",
+                str(lint_path),
+            ],
+            cwd=repo_root,
+        )
+        lint = read_json(lint_path)
+
+        run_command(
+            [
+                str(script_path("build_release_copy_packets.py")),
+                "--context",
+                str(context_path),
+                "--lint",
+                str(lint_path),
+                "--output-dir",
+                str(packet_dir),
+            ],
+            cwd=repo_root,
+        )
+
+        packet_files = sorted(path.name for path in packet_dir.iterdir() if path.is_file())
+        missing_packets = [name for name in EXPECTED_PACKET_FILES if name not in packet_files]
+        if missing_packets:
+            raise RuntimeError(f"Missing packet files: {', '.join(missing_packets)}")
+        if "packet_metrics.json" not in packet_files:
+            raise RuntimeError("packet_metrics.json was not written")
+
+        synthesis_packet = read_json(packet_dir / "synthesis_packet.json")
+        orchestrator = read_json(packet_dir / "orchestrator.json")
+        packet_metrics = read_json(packet_dir / "packet_metrics.json")
+        if synthesis_packet.get("common_path_contract", {}).get("sufficient_for_local_final_drafting") is not True:
+            raise RuntimeError("synthesis_packet.json is not marked sufficient for common-path local drafting")
+
+        plan = build_smoke_plan(context, synthesis_packet)
+        plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+        run_command(
+            [
+                str(script_path("validate_release_copy.py")),
+                "--context",
+                str(context_path),
+                "--lint",
+                str(lint_path),
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(validation_path),
+            ],
+            cwd=repo_root,
+        )
+        validation = read_json(validation_path)
+        if validation.get("valid") is not True:
+            raise RuntimeError("validate_release_copy.py did not accept the smoke plan")
+
+        run_command(
+            [
+                str(script_path("apply_release_copy.py")),
+                "--validation",
+                str(validation_path),
+                "--dry-run",
+                "--result-output",
+                str(apply_path),
+            ],
+            cwd=repo_root,
+        )
+        apply_result = read_json(apply_path)
+        if apply_result.get("apply_succeeded") is not True:
+            raise RuntimeError("apply_release_copy.py did not report success")
+        if apply_result.get("raw_reread_count") != 0:
+            raise RuntimeError("common-path smoke expected raw_reread_count == 0")
+        if apply_result.get("compensatory_reread_detected") is not False:
+            raise RuntimeError("common-path smoke expected compensatory_reread_detected == false")
+        if publish_path.read_text(encoding="utf-8") != publish_before:
+            raise RuntimeError("dry-run mutated PublishConfiguration.xml")
+        if readme_path.read_text(encoding="utf-8") != readme_before:
+            raise RuntimeError("dry-run mutated README.md")
+
+        smoke_output = build_smoke_summary(
+            "ok",
+            None,
+            repo_root,
+            "review_smoke_results",
+            base_tag=context.get("base_tag"),
+            target_version=context.get("target_version"),
+            output_files=packet_files,
+            packet_count=packet_metrics.get("packet_count"),
+            largest_packet_bytes=packet_metrics.get("largest_packet_bytes"),
+            largest_two_packets_bytes=packet_metrics.get("largest_two_packets_bytes"),
+            estimated_delegation_savings=packet_metrics.get("estimated_delegation_savings"),
+            raw_reread_count=apply_result.get("raw_reread_count"),
+            compensatory_reread_detected=apply_result.get("compensatory_reread_detected"),
+            apply_succeeded=apply_result.get("apply_succeeded"),
+            smoke_output_fields=contract.SMOKE_OUTPUT_FIELDS,
+        )
+
+    print(json.dumps(smoke_output, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/validate_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/validate_release_copy.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Validate a local release-copy plan before deterministic apply."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import create_release_issue as issue_tools
+import release_copy_plan_contract as contract
+import release_copy_plan_tools as plan_tools
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Path to collect_release_copy_context.py JSON")
+    parser.add_argument("--lint", required=True, help="Path to lint_release_copy.py JSON")
+    parser.add_argument("--plan", required=True, help="Path to local release-copy plan JSON")
+    parser.add_argument("--output", help="Optional output path for validation JSON")
+    return parser.parse_args()
+
+
+def push_issue(
+    bucket: list[str],
+    details: list[dict[str, Any]],
+    *,
+    code: str,
+    message: str,
+    field: str | None = None,
+    stop_category: str | None = None,
+) -> None:
+    bucket.append(message)
+    detail = {"code": code, "message": message}
+    if field is not None:
+        detail["field"] = field
+    if stop_category is not None:
+        detail["stop_category"] = stop_category
+    details.append(detail)
+
+
+def normalize_mapping(
+    name: str,
+    payload: dict[str, Any],
+    *,
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+) -> dict[str, Any]:
+    fields = contract.PLAN_PHASE_FIELDS[name]
+    normalized: dict[str, Any] = {}
+    allowed = set(fields["allowed"])
+    for key, value in payload.items():
+        if key in allowed:
+            normalized[key] = value
+            continue
+        push_issue(
+            warnings,
+            warning_details,
+            code=contract.VALIDATION_WARNING_CODES["ignored_field"],
+            message=f"Ignored unexpected `{name}` field `{key}`.",
+            field=f"{name}.{key}",
+        )
+    return normalized
+
+
+def normalize_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def unique_strings(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    ordered: list[str] = []
+    for value in values:
+        text = normalize_string(value)
+        if text and text not in ordered:
+            ordered.append(text)
+    return ordered
+
+
+def normalize_bool(value: Any) -> bool:
+    return bool(value)
+
+
+def normalize_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def normalized_reread_reason(reason: str) -> str:
+    return normalize_string(reason).lower().replace("-", "_").replace(" ", "_")
+
+
+def expected_issue_title(context: dict[str, Any]) -> str:
+    return f"[Release] {plan_tools.normalize_release_version(str(context.get('target_version') or ''))}"
+
+
+def apply_gate_status(issue_action_mode: str, lint: dict[str, Any]) -> dict[str, Any]:
+    applicable = ["stale_context", "validator_mismatch", "unresolved_stop_reason"]
+    not_applicable = ["ambiguous_routing"]
+    tracks = ((lint.get("checks") or {}).get("applicable_validation_tracks") or {})
+    if any(bool(value) for value in tracks.values()):
+        applicable.append("missing_required_evidence")
+    else:
+        not_applicable.append("missing_required_evidence")
+
+    if issue_action_mode != "noop":
+        applicable.append("missing_auth")
+    else:
+        not_applicable.append("missing_auth")
+
+    return {
+        "status": "pass",
+        "applicable_stop_categories": applicable,
+        "covered_stop_categories": applicable.copy(),
+        "uncovered_stop_categories": [],
+        "not_applicable_stop_categories": not_applicable,
+        "local_stop_categories": contract.LOCAL_STOP_CATEGORIES.copy(),
+    }
+
+
+def validate_plan_contract(
+    context: dict[str, Any],
+    lint: dict[str, Any],
+    raw_plan: dict[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[dict[str, Any]] = []
+    warning_details: list[dict[str, Any]] = []
+    stop_reasons: list[str] = []
+    validation_commands: list[str] = [
+        "git rev-parse --short HEAD",
+        "source fingerprint check",
+        "synthesis packet sufficiency check",
+    ]
+
+    normalized_plan = normalize_mapping(
+        "top_level",
+        raw_plan,
+        warnings=warnings,
+        warning_details=warning_details,
+    )
+
+    for field in contract.PLAN_PHASE_FIELDS["top_level"]["required"]:
+        if field not in normalized_plan:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["missing_field"],
+                message=f"Release-copy plan is missing `{field}`.",
+                field=field,
+                stop_category="validator_mismatch",
+            )
+
+    if errors:
+        gate = apply_gate_status("noop", lint)
+        gate["status"] = "fail"
+        return {
+            "valid": False,
+            "can_apply": False,
+            "errors": errors,
+            "warnings": warnings,
+            "error_details": error_details,
+            "warning_details": warning_details,
+            "stop_reasons": ["validator_mismatch"],
+            "validation_commands": validation_commands,
+            "normalized_plan": {},
+            "normalized_plan_fingerprint": "",
+            "apply_gate_status": gate,
+        }
+
+    expected_context_fingerprint = plan_tools.expected_context_fingerprint(context)
+    if normalize_string(normalized_plan.get("context_fingerprint")) != expected_context_fingerprint:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["context_fingerprint"],
+            message="Plan context fingerprint does not match the collected context.",
+            field="context_fingerprint",
+            stop_category="validator_mismatch",
+        )
+
+    expected_freshness = plan_tools.expected_freshness_tuple(context)
+    if normalized_plan.get("freshness_tuple") != expected_freshness:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["freshness_tuple"],
+            message="Plan freshness tuple does not match the collected context.",
+            field="freshness_tuple",
+            stop_category="validator_mismatch",
+        )
+
+    draft_basis = normalized_plan.get("draft_basis")
+    if not isinstance(draft_basis, dict):
+        draft_basis = {}
+    draft_basis = normalize_mapping("draft_basis", draft_basis, warnings=warnings, warning_details=warning_details)
+    for field in contract.PLAN_PHASE_FIELDS["draft_basis"]["required"]:
+        if field not in draft_basis:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["missing_field"],
+                message=f"draft_basis is missing `{field}`.",
+                field=f"draft_basis.{field}",
+                stop_category="validator_mismatch",
+            )
+
+    common_path_sufficient = normalize_bool(draft_basis.get("common_path_sufficient"))
+    raw_reread_count = normalize_int(draft_basis.get("raw_reread_count"))
+    reread_reasons = unique_strings(draft_basis.get("reread_reasons"))
+    focused_packets_used = unique_strings(draft_basis.get("focused_packets_used"))
+    compensatory_reread_detected = normalize_bool(draft_basis.get("compensatory_reread_detected"))
+    normalized_reasons = [normalized_reread_reason(reason) for reason in reread_reasons]
+
+    invalid_reread_reasons = [
+        reason
+        for reason in normalized_reasons
+        if reason not in contract.RAW_REREAD_ALLOWED_REASONS
+    ]
+    if invalid_reread_reasons:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["invalid_reread_reason"],
+            message="draft_basis contains unsupported reread reason(s): " + ", ".join(invalid_reread_reasons),
+            field="draft_basis.reread_reasons",
+            stop_category="validator_mismatch",
+        )
+
+    if any(reason in {"packet_insufficiency", "packet_insufficient"} for reason in normalized_reasons):
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["packet_insufficient"],
+            message="draft_basis recorded packet insufficiency as a reread reason; treat this as a hard stop instead of compensating with rereads.",
+            field="draft_basis.reread_reasons",
+            stop_category="synthesis_packet_insufficient",
+        )
+
+    if not common_path_sufficient:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["packet_insufficient"],
+            message="synthesis_packet was not sufficient for local final drafting in the common path.",
+            field="draft_basis.common_path_sufficient",
+            stop_category="synthesis_packet_insufficient",
+        )
+
+    if compensatory_reread_detected:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["packet_insufficient"],
+            message="draft_basis marked the reread path as compensatory; this run should stop instead of relying on packet insufficiency.",
+            field="draft_basis.compensatory_reread_detected",
+            stop_category="synthesis_packet_insufficient",
+        )
+
+    if raw_reread_count == 0 and reread_reasons:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["validator_mismatch"],
+            message="draft_basis lists reread reasons even though raw_reread_count is 0.",
+            field="draft_basis.reread_reasons",
+            stop_category="validator_mismatch",
+        )
+
+    if raw_reread_count > 0 and not reread_reasons:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["missing_field"],
+            message="draft_basis.raw_reread_count > 0 requires explicit reread_reasons.",
+            field="draft_basis.reread_reasons",
+            stop_category="validator_mismatch",
+        )
+
+    if raw_reread_count == 0 and len(focused_packets_used) > contract.COMMON_PATH_MAX_FOCUSED_PACKETS:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["packet_insufficient"],
+            message="common-path drafting used more than one focused packet without an allowed reread reason.",
+            field="draft_basis.focused_packets_used",
+            stop_category="synthesis_packet_insufficient",
+        )
+
+    publish_update = normalized_plan.get("publish_update")
+    if not isinstance(publish_update, dict):
+        publish_update = {}
+    publish_update = normalize_mapping("publish_update", publish_update, warnings=warnings, warning_details=warning_details)
+    publish_mode = normalize_string(publish_update.get("mode"))
+    if publish_mode not in {"noop", "replace-fields"}:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["invalid_mode"],
+            message="publish_update.mode must be `noop` or `replace-fields`.",
+            field="publish_update.mode",
+            stop_category="validator_mismatch",
+        )
+    publish_fields = {
+        key: normalize_string(publish_update.get(key))
+        for key in ("short_description", "long_description", "change_log", "mod_version")
+        if normalize_string(publish_update.get(key))
+    }
+    if publish_mode == "replace-fields" and not publish_fields:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["missing_field"],
+            message="publish_update.mode `replace-fields` requires at least one replacement field.",
+            field="publish_update",
+            stop_category="validator_mismatch",
+        )
+    if "mod_version" in publish_fields and publish_fields["mod_version"] != normalize_string(context.get("target_version")):
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["validator_mismatch"],
+            message="publish_update.mod_version must match the collected target_version.",
+            field="publish_update.mod_version",
+            stop_category="validator_mismatch",
+        )
+
+    readme_update = normalized_plan.get("readme_update")
+    if not isinstance(readme_update, dict):
+        readme_update = {}
+    readme_update = normalize_mapping("readme_update", readme_update, warnings=warnings, warning_details=warning_details)
+    readme_mode = normalize_string(readme_update.get("mode"))
+    if readme_mode not in {"noop", "replace-sections"}:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["invalid_mode"],
+            message="readme_update.mode must be `noop` or `replace-sections`.",
+            field="readme_update.mode",
+            stop_category="validator_mismatch",
+        )
+    intro_text = readme_update.get("intro_text")
+    if intro_text is not None:
+        intro_text = str(intro_text).strip()
+    raw_sections = readme_update.get("sections")
+    sections = raw_sections if isinstance(raw_sections, dict) else {}
+    normalized_sections: dict[str, str] = {}
+    for key, value in sections.items():
+        heading = normalize_string(key)
+        if heading not in plan_tools.README_ALLOWED_SECTIONS:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["unsupported_layout"],
+                message=f"README section `{heading}` is outside the deterministic allowlist.",
+                field=f"readme_update.sections.{heading}",
+                stop_category="rewrite_block_unsupported",
+            )
+            continue
+        normalized_sections[heading] = str(value or "").strip()
+    if readme_mode == "replace-sections" and intro_text is None and not normalized_sections:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["missing_field"],
+            message="readme_update.mode `replace-sections` requires intro_text or at least one allowed section replacement.",
+            field="readme_update",
+            stop_category="validator_mismatch",
+        )
+    existing_readme_sections = ((context.get("readme") or {}).get("sections") or {})
+    for heading in normalized_sections:
+        if heading not in existing_readme_sections:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["unsupported_layout"],
+                message=f"Collected README snapshot is missing section `{heading}`.",
+                field=f"readme_update.sections.{heading}",
+                stop_category="rewrite_block_unsupported",
+            )
+
+    issue_action = normalized_plan.get("issue_action")
+    if not isinstance(issue_action, dict):
+        issue_action = {}
+    issue_action = normalize_mapping("issue_action", issue_action, warnings=warnings, warning_details=warning_details)
+    issue_mode = normalize_string(issue_action.get("mode"))
+    if issue_mode not in {"noop", "create", "reuse-existing", "sync-existing-body"}:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["invalid_mode"],
+            message="issue_action.mode must be `noop`, `create`, `reuse-existing`, or `sync-existing-body`.",
+            field="issue_action.mode",
+            stop_category="validator_mismatch",
+        )
+    issue_title = normalize_string(issue_action.get("title"))
+    issue_body_markdown = str(issue_action.get("body_markdown") or "")
+    issue_defaults = context.get("issue_defaults") if isinstance(context.get("issue_defaults"), dict) else {}
+    project_mode = normalize_string(
+        issue_action.get("project_mode") or issue_defaults.get("project_mode") or "auto-add-first"
+    ) or "auto-add-first"
+    project_title = normalize_string(
+        issue_action.get("project_title")
+        or context.get("project_title_default")
+        or issue_tools.DEFAULT_PROJECT_TITLE
+    ) or issue_tools.DEFAULT_PROJECT_TITLE
+    if issue_mode != "noop":
+        if not issue_title:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["missing_field"],
+                message="issue_action requires `title` when mode is not `noop`.",
+                field="issue_action.title",
+                stop_category="validator_mismatch",
+            )
+        if issue_mode in {"create", "sync-existing-body"} and not issue_body_markdown.strip():
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["missing_field"],
+                message="issue_action requires `body_markdown` for create/sync modes.",
+                field="issue_action.body_markdown",
+                stop_category="validator_mismatch",
+            )
+        if issue_title and issue_title != expected_issue_title(context):
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["validator_mismatch"],
+                message=f"Issue title must match the target release title `{expected_issue_title(context)}`.",
+                field="issue_action.title",
+                stop_category="validator_mismatch",
+            )
+        if project_mode not in {"auto-add-first", "require-scope", "issue-only"}:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["invalid_mode"],
+                message="issue_action.project_mode must be `auto-add-first`, `require-scope`, or `issue-only`.",
+                field="issue_action.project_mode",
+                stop_category="validator_mismatch",
+            )
+
+    existing_issue = context.get("existing_release_issue")
+    validated_issue_snapshot = plan_tools.existing_issue_snapshot(existing_issue)
+    if issue_mode in {"reuse-existing", "sync-existing-body"} and not isinstance(existing_issue, dict):
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["stale_issue_snapshot"],
+            message="issue_action requires a collected existing release issue snapshot, but none is available.",
+            field="issue_action.mode",
+            stop_category="stale_issue_snapshot",
+        )
+
+    evidence_status = normalize_string(normalized_plan.get("evidence_status")).lower()
+    if evidence_status not in {"complete", "incomplete", "not-applicable"}:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["invalid_mode"],
+            message="evidence_status must be `complete`, `incomplete`, or `not-applicable`.",
+            field="evidence_status",
+            stop_category="validator_mismatch",
+        )
+    lint_checks = lint.get("checks") or {}
+    if lint_checks.get("evidence_complete") is False and evidence_status == "complete":
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["release_gate_incomplete"],
+            message="Plan claims complete release-gate evidence, but lint marked evidence as incomplete.",
+            field="evidence_status",
+            stop_category="release_gate_incomplete",
+        )
+
+    repo_root = Path(str(context.get("repo_root") or ".")).resolve()
+    try:
+        current_head = plan_tools.current_head_commit(repo_root)
+    except Exception as exc:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["stale_context"],
+            message=str(exc),
+            field="head_commit",
+            stop_category="stale_context",
+        )
+        current_head = ""
+
+    if current_head and current_head != normalize_string(context.get("head_commit")):
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["stale_context"],
+            message="HEAD changed after collection; rerun collect -> lint -> packet build before apply.",
+            field="head_commit",
+            stop_category="stale_context",
+        )
+
+    source_fingerprints = context.get("source_fingerprints") or {}
+    rule_files = context.get("rule_files") or {}
+    stale_sources: list[str] = []
+    for key in ("publish_configuration", "readme"):
+        path_text = normalize_string(rule_files.get(key))
+        fingerprint = normalize_string(source_fingerprints.get(key))
+        if not path_text or not fingerprint:
+            continue
+        current_text = Path(path_text).read_text(encoding="utf-8")
+        if plan_tools.json_fingerprint(current_text) != fingerprint:
+            stale_sources.append(key)
+    if stale_sources:
+        push_issue(
+            errors,
+            error_details,
+            code=contract.VALIDATION_ERROR_CODES["stale_context"],
+            message="Collected release source files changed after collection: " + ", ".join(stale_sources),
+            field="source_fingerprints",
+            stop_category="stale_context",
+        )
+
+    if not errors and issue_mode != "noop":
+        validation_commands.append("gh auth status")
+        try:
+            auth_status = issue_tools.run_command(["gh", "auth", "status"], cwd=repo_root)
+        except Exception as exc:
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["missing_auth"],
+                message=str(exc),
+                field="issue_action",
+                stop_category="missing_auth",
+            )
+            auth_status = ""
+
+        if not errors and project_mode == "require-scope" and "project" not in auth_status.lower():
+            push_issue(
+                errors,
+                error_details,
+                code=contract.VALIDATION_ERROR_CODES["project_scope_required"],
+                message="Issue action requires project scope, but current gh auth status does not include it.",
+                field="issue_action.project_mode",
+                stop_category="project_scope_required",
+            )
+
+        if not errors and issue_mode in {"reuse-existing", "sync-existing-body"} and isinstance(existing_issue, dict):
+            issue_number = int(existing_issue.get("number") or 0)
+            validation_commands.append(f"gh issue view {issue_number}")
+            live_issue = plan_tools.fetch_issue_snapshot(repo_root, context.get("repo_slug"), issue_number)
+            live_snapshot = plan_tools.existing_issue_snapshot(live_issue)
+            if live_snapshot != validated_issue_snapshot:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=contract.VALIDATION_ERROR_CODES["stale_issue_snapshot"],
+                    message="The live release issue snapshot changed after collection; refresh before syncing or reusing it.",
+                    field="existing_release_issue",
+                    stop_category="stale_issue_snapshot",
+                )
+            else:
+                validated_issue_snapshot = live_snapshot
+
+    for detail in error_details:
+        category = detail.get("stop_category")
+        if isinstance(category, str) and category not in stop_reasons:
+            stop_reasons.append(category)
+
+    normalized = {
+        "repo_root": str(repo_root),
+        "repo_slug": context.get("repo_slug"),
+        "context_fingerprint": expected_context_fingerprint,
+        "freshness_tuple": expected_freshness,
+        "source_fingerprints": {
+            key: normalize_string(value)
+            for key, value in source_fingerprints.items()
+            if normalize_string(value)
+        },
+        "rule_files": {
+            key: normalize_string(value)
+            for key, value in rule_files.items()
+            if normalize_string(value)
+        },
+        "local_release_helper_status": (context.get("local_release_helper") or {}).get("status"),
+        "overall_confidence": normalize_string(normalized_plan.get("overall_confidence")).lower() or "medium",
+        "stop_reasons": unique_strings(normalized_plan.get("stop_reasons")),
+        "evidence_status": evidence_status,
+        "draft_basis": {
+            "common_path_sufficient": common_path_sufficient,
+            "raw_reread_count": raw_reread_count,
+            "reread_reasons": normalized_reasons,
+            "focused_packets_used": focused_packets_used,
+            "compensatory_reread_detected": compensatory_reread_detected,
+            "synthesis_packet_fingerprint": normalize_string(draft_basis.get("synthesis_packet_fingerprint")),
+        },
+        "publish_update": {
+            "mode": publish_mode,
+            "fields": publish_fields,
+        },
+        "readme_update": {
+            "mode": readme_mode,
+            "intro_text": intro_text,
+            "sections": normalized_sections,
+        },
+        "issue_action": {
+            "mode": issue_mode,
+            "title": issue_title,
+            "body_markdown": issue_body_markdown,
+            "project_mode": project_mode,
+            "project_title": project_title,
+        },
+        "validated_existing_issue_snapshot": validated_issue_snapshot,
+        "validation_commands": validation_commands,
+    }
+
+    gate = apply_gate_status(issue_mode, lint)
+    can_apply = not errors and not gate["uncovered_stop_categories"]
+    gate["status"] = "pass" if can_apply else "fail"
+    return {
+        "valid": not errors,
+        "can_apply": can_apply,
+        "errors": errors,
+        "warnings": warnings,
+        "error_details": error_details,
+        "warning_details": warning_details,
+        "stop_reasons": stop_reasons,
+        "validation_commands": validation_commands,
+        "normalized_plan": normalized,
+        "normalized_plan_fingerprint": plan_tools.json_fingerprint(normalized),
+        "apply_gate_status": gate,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    context = plan_tools.load_json(Path(args.context).resolve())
+    lint = plan_tools.load_json(Path(args.lint).resolve())
+    plan = plan_tools.load_json(Path(args.plan).resolve())
+    payload = validate_plan_contract(context, lint, plan)
+    if args.output:
+        plan_tools.write_json(Path(args.output).resolve(), payload)
+    else:
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if payload.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/write_evaluation_log.py
@@ -1,0 +1,1070 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "draft-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        publish_configuration = context.get("publish_configuration", {})
+        change_log = publish_configuration.get("change_log")
+        if isinstance(change_log, list):
+            changelog_lines = len(change_log)
+        elif isinstance(change_log, str):
+            changelog_lines = len([line for line in change_log.splitlines() if line.strip()])
+        else:
+            changelog_lines = safe_int(context.get("changelog_lines")) or 0
+        existing_issue = context.get("existing_release_issue") or {}
+        selected_packets = [
+            name
+            for name in packet_files(orchestrator)
+            if name not in {"global_packet.json", "orchestrator.json"}
+        ]
+        return {
+            "release_tag": context.get("target_version") or context.get("release_tag"),
+            "branch": context.get("branch"),
+            "review_mode": orchestrator.get("review_mode"),
+            "selected_packets": selected_packets,
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_mix": worker_roles(orchestrator),
+            "base_tag": context.get("base_tag"),
+            "changelog_lines": changelog_lines,
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_url": existing_issue.get("url"),
+            "issue_creation_status": "existing" if existing_issue.get("url") else None,
+            "project_mode": context.get("project_mode") or context.get("project_mode_default"),
+            "project_scope_available": context.get("project_scope_available"),
+            "project_flag_used": context.get("project_flag_used"),
+            "local_release_helper_status": (context.get("local_release_helper") or {}).get("status"),
+            "local_release_helper_handoff_available": bool(checks.get("helper_handoff_allowed")),
+            "stop_reasons": list_of_strings(context.get("stop_reasons")),
+            "release_issue_created": None,
+            "packet_count": None,
+            "largest_packet_bytes": None,
+            "largest_two_packets_bytes": None,
+            "estimated_local_only_tokens": None,
+            "estimated_packet_tokens": None,
+            "estimated_delegation_savings": None,
+            "raw_reread_count": None,
+            "compensatory_reread_detected": None,
+            "deterministic_file_edit_count": None,
+            "issue_action_attempted": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        skill_name = ((log.get("skill") or {}).get("name") or "").strip()
+        if skill_name == "draft-release-copy":
+            skill_data = ((log.setdefault("skill_specific", {}).setdefault("data", {})))
+            packet_count = safe_int(result.get("packet_count"))
+            largest_packet = safe_int(result.get("largest_packet_bytes"))
+            largest_two_packets = safe_int(result.get("largest_two_packets_bytes"))
+            estimated_local_only = safe_int(result.get("estimated_local_only_tokens"))
+            estimated_packet_tokens = safe_int(result.get("estimated_packet_tokens"))
+            estimated_savings = safe_int(result.get("estimated_delegation_savings"))
+            packet_size_bytes = result.get("packet_size_bytes") if isinstance(result.get("packet_size_bytes"), dict) else {}
+
+            if packet_count is not None:
+                skill_data["packet_count"] = packet_count
+            if largest_packet is not None:
+                skill_data["largest_packet_bytes"] = largest_packet
+            if largest_two_packets is not None:
+                skill_data["largest_two_packets_bytes"] = largest_two_packets
+            if estimated_local_only is not None:
+                skill_data["estimated_local_only_tokens"] = estimated_local_only
+            if estimated_packet_tokens is not None:
+                skill_data["estimated_packet_tokens"] = estimated_packet_tokens
+            if estimated_savings is not None:
+                skill_data["estimated_delegation_savings"] = estimated_savings
+
+            baseline = log.setdefault("baseline", {})
+            if estimated_local_only is not None:
+                baseline["estimated_local_only_tokens"] = estimated_local_only
+            if estimated_savings is not None:
+                baseline["estimated_token_savings"] = estimated_savings
+                baseline["estimated_delegation_savings"] = estimated_savings
+            if estimated_local_only is not None or estimated_savings is not None:
+                baseline["method"] = "packet-byte-proxy"
+                baseline["confidence"] = "estimated"
+
+            measurement = log.setdefault("measurement", {})
+            if packet_size_bytes:
+                measurement["token_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_name = ((log.get("skill") or {}).get("name") or "").strip()
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        if skill_name == "draft-release-copy":
+            skill_data = ((log.setdefault("skill_specific", {}).setdefault("data", {})))
+            raw_reread_count = safe_int(result.get("raw_reread_count"))
+            compensatory = to_bool(result.get("compensatory_reread_detected"))
+            deterministic_count = safe_int(result.get("deterministic_file_edit_count"))
+            issue_action_attempted = to_bool(result.get("issue_action_attempted"))
+            if raw_reread_count is not None:
+                skill_data["raw_reread_count"] = raw_reread_count
+                orchestration["raw_reread_required"] = raw_reread_count > 0
+            if compensatory is not None:
+                skill_data["compensatory_reread_detected"] = compensatory
+            if deterministic_count is not None:
+                skill_data["deterministic_file_edit_count"] = deterministic_count
+            if issue_action_attempted is not None:
+                skill_data["issue_action_attempted"] = issue_action_attempted
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_apply_release_copy_plan.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_apply_release_copy_plan.py
@@ -1,0 +1,269 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import apply_release_copy as apply_release_copy_plan
+import release_copy_plan_tools as plan_tools
+
+
+PUBLISH_XML = """<Configuration>
+  <ShortDescription Value="Current short description" />
+  <LongDescription>Current long description.</LongDescription>
+  <ModVersion Value="1.2.3" />
+  <ChangeLog>- Current release note.</ChangeLog>
+</Configuration>
+"""
+
+README_MD = """# ExampleProduct
+
+Intro text.
+
+## Current Release
+Current release block.
+
+## Current Status
+Current status block.
+"""
+
+
+class ApplyReleaseCopyPlanTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+    def build_normalized_plan(self, tmp: Path, *, issue_action: dict | None = None) -> tuple[dict, Path, Path]:
+        repo_root = tmp / "repo"
+        publish_path = repo_root / "ExampleProduct" / "Properties" / "PublishConfiguration.xml"
+        readme_path = repo_root / "README.md"
+        publish_path.parent.mkdir(parents=True, exist_ok=True)
+        publish_path.write_text(PUBLISH_XML, encoding="utf-8")
+        readme_path.write_text(README_MD, encoding="utf-8")
+
+        normalized_plan = {
+            "repo_root": str(repo_root),
+            "repo_slug": "owner/repo",
+            "context_fingerprint": "sha256:context",
+            "freshness_tuple": {
+                "head_commit": "abc1234",
+                "base_tag": "v1.2.2",
+                "target_version": "1.2.3",
+                "evidence_fingerprint": plan_tools.json_fingerprint({}),
+                "existing_release_issue": None,
+            },
+            "source_fingerprints": {
+                "publish_configuration": plan_tools.json_fingerprint(PUBLISH_XML),
+                "readme": plan_tools.json_fingerprint(README_MD),
+            },
+            "rule_files": {
+                "publish_configuration": str(publish_path),
+                "readme": str(readme_path),
+            },
+            "local_release_helper_status": "present",
+            "overall_confidence": "high",
+            "stop_reasons": [],
+            "evidence_status": "not-applicable",
+            "draft_basis": {
+                "common_path_sufficient": True,
+                "raw_reread_count": 0,
+                "reread_reasons": [],
+                "focused_packets_used": [],
+                "compensatory_reread_detected": False,
+                "synthesis_packet_fingerprint": "sha256:synthesis",
+            },
+            "publish_update": {
+                "mode": "replace-fields",
+                "fields": {
+                    "short_description": "Updated short description",
+                    "change_log": "- Fresh release note.",
+                },
+            },
+            "readme_update": {
+                "mode": "replace-sections",
+                "intro_text": "# ExampleProduct\n\nUpdated intro text.",
+                "sections": {
+                    "Current Release": "Updated release block.",
+                    "Current Status": "Updated status block.",
+                },
+            },
+            "issue_action": issue_action or {"mode": "noop", "title": "", "body_markdown": "", "project_mode": "auto-add-first", "project_title": "ExampleProduct Tracker"},
+            "validated_existing_issue_snapshot": None,
+            "validation_commands": ["git rev-parse --short HEAD"],
+        }
+        return normalized_plan, publish_path, readme_path
+
+    def validation_payload(self, normalized_plan: dict) -> dict:
+        return {
+            "valid": True,
+            "can_apply": True,
+            "errors": [],
+            "warnings": [],
+            "stop_reasons": [],
+            "normalized_plan": normalized_plan,
+            "normalized_plan_fingerprint": plan_tools.json_fingerprint(normalized_plan),
+            "apply_gate_status": {
+                "status": "pass",
+                "applicable_stop_categories": ["stale_context", "validator_mismatch", "unresolved_stop_reason"],
+                "covered_stop_categories": ["stale_context", "validator_mismatch", "unresolved_stop_reason"],
+                "uncovered_stop_categories": [],
+                "not_applicable_stop_categories": ["ambiguous_routing", "missing_auth", "missing_required_evidence"],
+                "local_stop_categories": [],
+            },
+        }
+
+    def run_apply(self, validation: dict, *, dry_run: bool = False, current_head: str = "abc1234") -> tuple[int, str, dict]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "apply.json"
+            self.write_json(validation_path, validation)
+
+            argv = [
+                "apply_release_copy_plan.py",
+                "--validation",
+                str(validation_path),
+                "--result-output",
+                str(result_path),
+            ]
+            if dry_run:
+                argv.append("--dry-run")
+
+            stdout = io.StringIO()
+            with mock.patch.object(
+                apply_release_copy_plan.plan_tools,
+                "current_head_commit",
+                return_value=current_head,
+            ), mock.patch.object(
+                sys,
+                "argv",
+                argv,
+            ), redirect_stdout(stdout):
+                exit_code = apply_release_copy_plan.main()
+
+            return exit_code, stdout.getvalue(), json.loads(result_path.read_text(encoding="utf-8"))
+
+    def test_apply_dry_run_uses_validator_output_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            normalized_plan, publish_path, readme_path = self.build_normalized_plan(tmp)
+            validation = self.validation_payload(normalized_plan)
+
+            exit_code, _stdout, payload = self.run_apply(validation, dry_run=True)
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["validation_source"], "validator_normalized_plan")
+            self.assertEqual(payload["raw_reread_count"], 0)
+            self.assertFalse(payload["compensatory_reread_detected"])
+            self.assertEqual(payload["deterministic_file_edit_count"], 2)
+            self.assertFalse(payload["issue_action_attempted"])
+            self.assertEqual(publish_path.read_text(encoding="utf-8"), PUBLISH_XML)
+            self.assertEqual(readme_path.read_text(encoding="utf-8"), README_MD)
+            mutation_kinds = [item["kind"] for item in payload["mutations"]]
+            self.assertEqual(mutation_kinds, ["publish_configuration", "readme"])
+
+    def test_apply_rejects_tampered_validator_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            normalized_plan, _publish_path, _readme_path = self.build_normalized_plan(tmp)
+            validation = self.validation_payload(normalized_plan)
+            validation["normalized_plan"]["publish_update"]["fields"]["short_description"] = "Tampered"
+
+            exit_code, _stdout, payload = self.run_apply(validation)
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(payload["stop_reason"], "validator_mismatch")
+
+    def test_apply_rolls_back_files_when_issue_action_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            issue_action = {
+                "mode": "create",
+                "title": "[Release] v1.2.3",
+                "body_markdown": "Checklist body",
+                "project_mode": "auto-add-first",
+                "project_title": "ExampleProduct Tracker",
+            }
+            normalized_plan, publish_path, readme_path = self.build_normalized_plan(tmp, issue_action=issue_action)
+            validation = self.validation_payload(normalized_plan)
+            validation["apply_gate_status"]["applicable_stop_categories"].append("missing_auth")
+            validation["apply_gate_status"]["covered_stop_categories"].append("missing_auth")
+            validation["apply_gate_status"]["not_applicable_stop_categories"] = ["ambiguous_routing", "missing_required_evidence"]
+
+            with mock.patch.object(
+                apply_release_copy_plan.issue_tools,
+                "run_command",
+                return_value="Logged in with project scope.",
+            ), mock.patch.object(
+                apply_release_copy_plan.issue_tools,
+                "execute_issue_action",
+                side_effect=RuntimeError("gh issue create failed"),
+            ):
+                exit_code, _stdout, payload = self.run_apply(validation)
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(payload["stop_reason"], "apply_failed")
+            self.assertTrue(payload["rollback_needed"])
+            self.assertTrue(payload["issue_action_attempted"])
+            self.assertEqual(payload["deterministic_file_edit_count"], 2)
+            self.assertEqual(sorted(payload["rolled_back_files"]), sorted([str(publish_path), str(readme_path)]))
+            self.assertEqual(publish_path.read_text(encoding="utf-8"), PUBLISH_XML)
+            self.assertEqual(readme_path.read_text(encoding="utf-8"), README_MD)
+
+    def test_apply_stops_on_stale_issue_snapshot_before_file_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            issue_action = {
+                "mode": "sync-existing-body",
+                "title": "[Release] v1.2.3",
+                "body_markdown": "Checklist body",
+                "project_mode": "auto-add-first",
+                "project_title": "ExampleProduct Tracker",
+            }
+            normalized_plan, publish_path, readme_path = self.build_normalized_plan(tmp, issue_action=issue_action)
+            normalized_plan["validated_existing_issue_snapshot"] = {
+                "number": 42,
+                "title": "[Release] v1.2.3",
+                "state": "OPEN",
+                "url": "https://example.invalid/issues/42",
+                "body_fingerprint": plan_tools.json_fingerprint("Original body"),
+            }
+            normalized_plan["freshness_tuple"]["existing_release_issue"] = normalized_plan["validated_existing_issue_snapshot"]
+            validation = self.validation_payload(normalized_plan)
+            validation["apply_gate_status"]["applicable_stop_categories"].append("missing_auth")
+            validation["apply_gate_status"]["covered_stop_categories"].append("missing_auth")
+            validation["apply_gate_status"]["not_applicable_stop_categories"] = ["ambiguous_routing", "missing_required_evidence"]
+
+            with mock.patch.object(
+                apply_release_copy_plan.issue_tools,
+                "run_command",
+                return_value="Logged in with project scope.",
+            ), mock.patch.object(
+                apply_release_copy_plan.plan_tools,
+                "fetch_issue_snapshot",
+                return_value={
+                    "number": 42,
+                    "title": "[Release] v1.2.3",
+                    "url": "https://example.invalid/issues/42",
+                    "state": "OPEN",
+                    "body": "Changed body",
+                },
+            ):
+                exit_code, _stdout, payload = self.run_apply(validation)
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(payload["stop_reason"], "stale_issue_snapshot")
+            self.assertFalse(payload["issue_action_attempted"])
+            self.assertEqual(publish_path.read_text(encoding="utf-8"), PUBLISH_XML)
+            self.assertEqual(readme_path.read_text(encoding="utf-8"), README_MD)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_build_release_copy_packets_contract.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_build_release_copy_packets_contract.py
@@ -1,0 +1,399 @@
+import io
+import json
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import build_release_copy_packets as packets
+import release_copy_plan_contract as contract
+
+
+BASELINE_WORKER_FACING_BYTES = 8832
+TARGET_WORKER_FACING_BYTES = int(BASELINE_WORKER_FACING_BYTES * 0.75)
+
+
+class BuildReleaseCopyPacketsContractTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+    def read_json(self, path: Path) -> dict:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def build_context(self) -> dict:
+        return {
+            "repo_slug": "owner/repo",
+            "branch": "main",
+            "head_commit": "abc1234",
+            "base_tag": "v1.2.2",
+            "target_version": "1.2.3",
+            "revision_range": "v1.2.2..HEAD",
+            "context_fingerprint": "sha256:context",
+            "freshness_tuple": {
+                "head_commit": "abc1234",
+                "base_tag": "v1.2.2",
+                "target_version": "1.2.3",
+                "evidence_fingerprint": "sha256:evidence",
+                "existing_release_issue": {
+                    "number": 42,
+                    "title": "[Release] v1.2.3",
+                    "state": "OPEN",
+                    "url": "https://example.invalid/issues/42",
+                    "body_fingerprint": "sha256:issue",
+                },
+            },
+            "existing_release_issue": {
+                "number": 42,
+                "title": "[Release] v1.2.3",
+                "url": "https://example.invalid/issues/42",
+                "state": "OPEN",
+                "body": "Existing checklist body",
+                "evidence": {
+                    "software_track_status": "pending",
+                },
+                "checked_labels": ["PublishConfiguration wording reviewed against shipped behavior"],
+            },
+            "project_title_default": "ExampleProduct Tracker",
+            "diff_stat": " 6 files changed, 180 insertions(+), 25 deletions(-)",
+            "changed_files": [
+                "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+                "ExampleProduct/Setting.cs",
+                "README.md",
+                "ExampleProduct/Properties/PublishConfiguration.xml",
+                ".github/workflows/release.yml",
+                "MAINTAINING.md",
+            ],
+            "changed_file_groups": {
+                "runtime": {
+                    "count": 2,
+                    "sample_files": [
+                        "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+                        "ExampleProduct/Setting.cs",
+                    ],
+                },
+                "docs": {
+                    "count": 2,
+                    "sample_files": ["README.md", "MAINTAINING.md"],
+                },
+                "config": {
+                    "count": 2,
+                    "sample_files": [
+                        "ExampleProduct/Properties/PublishConfiguration.xml",
+                        ".github/workflows/release.yml",
+                    ],
+                },
+                "automation": {"count": 0, "sample_files": []},
+                "tests": {"count": 0, "sample_files": []},
+                "other": {"count": 0, "sample_files": []},
+            },
+            "changed_file_stats": {
+                "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs": {
+                    "insertions": 120,
+                    "deletions": 40,
+                    "churn": 160,
+                },
+                "ExampleProduct/Setting.cs": {
+                    "insertions": 40,
+                    "deletions": 20,
+                    "churn": 60,
+                },
+                "README.md": {"insertions": 10, "deletions": 4, "churn": 14},
+                "ExampleProduct/Properties/PublishConfiguration.xml": {
+                    "insertions": 6,
+                    "deletions": 2,
+                    "churn": 8,
+                },
+                ".github/workflows/release.yml": {
+                    "insertions": 3,
+                    "deletions": 1,
+                    "churn": 4,
+                },
+                "MAINTAINING.md": {"insertions": 1, "deletions": 0, "churn": 1},
+            },
+            "commit_subjects": [
+                "Tighten diagnostics wording for release",
+                "Refresh release checklist guidance",
+            ],
+            "publish_configuration": {
+                "short_description": "Current short description",
+                "long_description": "Current long description.",
+                "change_log": "- Current release note.",
+                "mod_version": "1.2.3",
+            },
+            "base_tag_publish_configuration": {
+                "change_log": "- Prior release note.",
+            },
+            "readme": {
+                "intro_text": "# ExampleProduct\n\nIntro text.",
+                "sections": {
+                    "Current Release": "Current release block.",
+                    "Current Status": "Current status block.",
+                },
+            },
+            "release_checklist": {
+                "title_prefix": "[Release] ",
+                "fields": [
+                    {"id": "target_version", "label": "Target version"},
+                    {"id": "included_changes", "label": "Included changes"},
+                ],
+                "checkbox_labels": [
+                    "PublishConfiguration wording reviewed against shipped behavior",
+                    "Release notes reviewed",
+                ],
+            },
+            "local_release_helper": {
+                "status": "present",
+                "repo_relative_path": "scripts/release.ps1",
+            },
+            "evidence": {
+                "software_track_status": "pending",
+                "comparable_evidence": "",
+                "anchor_comparison": "",
+                "release_pr_validation_note": "",
+            },
+        }
+
+    def build_lint(self) -> dict:
+        return {
+            "checks": {
+                "evidence_complete": False,
+                "applicable_validation_tracks": {
+                    "software_gate": True,
+                    "telemetry_validation": False,
+                },
+                "helper_handoff_allowed": True,
+                "rewrite_publish_recommended": True,
+                "rewrite_readme_recommended": True,
+            },
+            "findings": {
+                "errors": [
+                    {
+                        "area": "publish",
+                        "code": "unsupported_strong_software_claim",
+                        "message": "Release-facing copy makes strong software-track claims without complete evidence.",
+                    }
+                ],
+                "warnings": [
+                    {
+                        "area": "readme",
+                        "code": "setting_default_mismatch",
+                        "message": "`SoftCap` default is `4000` in README but `5000` in Setting.cs.",
+                    },
+                    {
+                        "area": "checklist",
+                        "code": "checklist_field_unresolved",
+                        "message": "Release-gate evidence field remains unresolved.",
+                    },
+                ],
+                "info": [
+                    {
+                        "area": "helper",
+                        "code": "missing_local_release_script",
+                        "message": "Helper handoff remains local-only.",
+                    }
+                ],
+            },
+        }
+
+    def run_builder(self, context: dict, lint: dict) -> tuple[int, str, dict[str, dict]]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context_path = tmp / "context.json"
+            lint_path = tmp / "lint.json"
+            output_dir = tmp / "packets"
+            self.write_json(context_path, context)
+            self.write_json(lint_path, lint)
+
+            stdout = io.StringIO()
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "build_release_copy_packets.py",
+                    "--context",
+                    str(context_path),
+                    "--lint",
+                    str(lint_path),
+                    "--output-dir",
+                    str(output_dir),
+                ],
+            ), redirect_stdout(stdout):
+                exit_code = packets.main()
+
+            payloads = {
+                path.name: self.read_json(path)
+                for path in output_dir.iterdir()
+            }
+            return exit_code, stdout.getvalue(), payloads
+
+    def test_contract_metadata_and_routing_helpers(self) -> None:
+        self.assertEqual(contract.WORKFLOW_FAMILY, "release-copy")
+        self.assertEqual(contract.ARCHETYPE, "audit-and-apply")
+        self.assertEqual(contract.ORCHESTRATOR_PROFILE, "packet-heavy-orchestrator")
+        self.assertEqual(contract.SHARED_PACKET, "global_packet.json")
+        self.assertEqual(contract.SHARED_LOCAL_PACKET, "synthesis_packet.json")
+        self.assertEqual(
+            contract.runtime_artifact_names(include_optional=False),
+            [
+                "orchestrator.json",
+                "global_packet.json",
+                "publish_packet.json",
+                "readme_packet.json",
+                "changes_packet.json",
+                "checklist_packet.json",
+                "synthesis_packet.json",
+            ],
+        )
+        self.assertEqual(contract.runtime_field_roles()["routing_authority"], "packet_worker_map")
+        self.assertEqual(
+            contract.runtime_field_roles()["preferred_worker_families_role"],
+            "registry_metadata_only",
+        )
+        self.assertEqual(
+            contract.runtime_field_roles()["derived_worker_fields"],
+            ["recommended_workers", "optional_workers"],
+        )
+        self.assertEqual(packets.packet_worker_map()["publish_packet"], ["large_diff_auditor"])
+        self.assertEqual(packets.packet_worker_map()["checklist_packet"], ["docs_verifier", "repo_mapper"])
+        self.assertEqual(packets.review_mode(5, 2, []), ("local-only", 0))
+        self.assertEqual(packets.review_mode(9, 2, []), ("targeted-delegation", 2))
+        self.assertEqual(packets.review_mode(21, 4, []), ("broad-delegation", 3))
+        self.assertEqual(
+            packets.review_mode(4, 1, [{"reason": "override", "detail": "x"}]),
+            ("targeted-delegation", 2),
+        )
+        self.assertEqual(
+            packets.review_mode(12, 2, [{"reason": "override", "detail": "x"}]),
+            ("broad-delegation", 3),
+        )
+        self.assertEqual(
+            packets.handoff_command(
+                {
+                    "target_version": "1.2.3",
+                    "local_release_helper": {"status": "present", "repo_relative_path": "helpers/run.ps1"},
+                },
+                {"checks": {"helper_handoff_allowed": True}},
+            ),
+            r"powershell -File .\helpers\run.ps1 -Version v1.2.3",
+        )
+        self.assertIsNone(
+            packets.handoff_command(
+                {
+                    "target_version": "1.2.3",
+                    "local_release_helper": {"status": "missing", "repo_relative_path": "helpers/run.ps1"},
+                },
+                {"checks": {"helper_handoff_allowed": True}},
+            )
+        )
+
+    def test_packet_emission_and_common_path_sufficiency(self) -> None:
+        context = self.build_context()
+        lint = self.build_lint()
+
+        exit_code, stdout, payloads = self.run_builder(context, lint)
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn('"review_mode": "targeted-delegation"', stdout)
+
+        expected_files = {
+            "global_packet.json",
+            "publish_packet.json",
+            "readme_packet.json",
+            "changes_packet.json",
+            "checklist_packet.json",
+            "evidence_packet.json",
+            "synthesis_packet.json",
+            "orchestrator.json",
+            "packet_metrics.json",
+        }
+        emitted_files = set(payloads)
+        self.assertEqual(emitted_files, expected_files)
+
+        global_packet = payloads["global_packet.json"]
+        publish_packet = payloads["publish_packet.json"]
+        readme_packet = payloads["readme_packet.json"]
+        changes_packet = payloads["changes_packet.json"]
+        checklist_packet = payloads["checklist_packet.json"]
+        evidence_packet = payloads["evidence_packet.json"]
+        synthesis_packet = payloads["synthesis_packet.json"]
+        orchestrator = payloads["orchestrator.json"]
+        packet_metrics = payloads["packet_metrics.json"]
+
+        self.assertTrue(packets.synthesis_packet_common_path_ready(synthesis_packet))
+        self.assertTrue(packets.SYNTHESIS_REQUIRED_KEYS.issubset(synthesis_packet))
+        self.assertTrue(synthesis_packet["common_path_contract"]["sufficient_for_local_final_drafting"])
+        self.assertTrue(synthesis_packet["common_path_contract"]["packet_insufficiency_is_failure"])
+        self.assertEqual(
+            synthesis_packet["common_path_contract"]["raw_reread_allowed_reasons"],
+            contract.RAW_REREAD_ALLOWED_REASONS,
+        )
+        self.assertEqual(
+            synthesis_packet["plan_defaults"]["draft_basis"]["raw_reread_count"],
+            0,
+        )
+        self.assertFalse(
+            synthesis_packet["plan_defaults"]["draft_basis"]["compensatory_reread_detected"]
+        )
+
+        self.assertEqual(global_packet["worker_return_contract"], contract.WORKER_RETURN_CONTRACT)
+        self.assertEqual(global_packet["worker_output_shape"], contract.WORKER_OUTPUT_SHAPE)
+        self.assertEqual(global_packet["workflow_family"], contract.WORKFLOW_FAMILY)
+        self.assertEqual(global_packet["authority_order"], contract.AUTHORITY_ORDER)
+        self.assertEqual(global_packet["gate_summary"]["helper_status"], "present")
+        self.assertNotIn("packet_worker_map", global_packet)
+        self.assertNotIn("changed_files", changes_packet)
+        self.assertTrue(changes_packet["topic_signals"])
+        self.assertTrue(changes_packet["representative_files"])
+        self.assertTrue(changes_packet["condensed_commit_subjects"])
+        self.assertTrue(synthesis_packet["shipped_change_summary"]["topic_signals"])
+        self.assertNotIn("packet_worker_map", publish_packet)
+        self.assertNotIn("packet_worker_map", readme_packet)
+        self.assertNotIn("packet_worker_map", changes_packet)
+        self.assertNotIn("packet_worker_map", checklist_packet)
+        self.assertNotIn("packet_worker_map", evidence_packet)
+
+        self.assertEqual(orchestrator["workflow_family"], contract.WORKFLOW_FAMILY)
+        self.assertEqual(orchestrator["archetype"], contract.ARCHETYPE)
+        self.assertEqual(orchestrator["orchestrator_profile"], contract.ORCHESTRATOR_PROFILE)
+        self.assertEqual(orchestrator["shared_packet"], "global_packet.json")
+        self.assertEqual(orchestrator["shared_local_packet"], "synthesis_packet.json")
+        self.assertEqual(orchestrator["routing_contract"], contract.runtime_field_roles())
+        self.assertEqual(
+            orchestrator["common_path_contract"]["required_packets"],
+            ["global_packet.json", "synthesis_packet.json"],
+        )
+        self.assertEqual(
+            orchestrator["common_path_contract"]["max_additional_focused_packets"],
+            contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+        )
+        self.assertEqual(orchestrator["raw_reread_allowed_reasons"], contract.RAW_REREAD_ALLOWED_REASONS)
+        self.assertNotIn("estimated_packet_tokens", orchestrator)
+        self.assertNotIn("estimated_delegation_savings", orchestrator)
+
+        self.assertEqual(packet_metrics["packet_count"], len(orchestrator["packet_files"]))
+        self.assertEqual(packet_metrics["packet_count"], len(expected_files) - 1)
+        packet_sizes = packet_metrics["packet_size_bytes"]
+        self.assertEqual(
+            packet_sizes["worker_facing_total"],
+            sum(
+                packet_sizes["by_packet"][name]
+                for name in expected_files
+                if name not in {"synthesis_packet.json", "orchestrator.json", "packet_metrics.json"}
+            ),
+        )
+        self.assertLessEqual(packet_sizes["worker_facing_total"], TARGET_WORKER_FACING_BYTES)
+        self.assertGreater(packet_sizes["raw_local_source_bytes"], 0)
+        self.assertGreater(packet_metrics["estimated_delegation_savings"], 0)
+        self.assertGreaterEqual(packet_metrics["largest_packet_bytes"], 1)
+        self.assertGreaterEqual(packet_metrics["largest_two_packets_bytes"], packet_metrics["largest_packet_bytes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_collect_release_copy_context.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_collect_release_copy_context.py
@@ -1,0 +1,72 @@
+import tempfile
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import collect_release_copy_context as collector
+
+
+class CollectReleaseCopyContextProfileResolutionTests(unittest.TestCase):
+    def test_default_repo_profile_path_prefers_project_local_skill_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            project_profile = (
+                repo_root / ".codex" / "project" / "profiles" / "draft-release-copy" / "profile.json"
+            )
+            project_profile.parent.mkdir(parents=True, exist_ok=True)
+            project_profile.write_text("{}", encoding="utf-8")
+
+            resolved = collector.default_repo_profile_path(repo_root)
+
+            self.assertEqual(resolved, project_profile.resolve())
+
+    def test_default_repo_profile_path_falls_back_to_project_default_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            default_profile = repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json"
+            default_profile.parent.mkdir(parents=True, exist_ok=True)
+            default_profile.write_text("{}", encoding="utf-8")
+
+            resolved = collector.default_repo_profile_path(repo_root)
+
+            self.assertEqual(resolved, default_profile.resolve())
+
+    def test_default_repo_profile_path_falls_back_to_retained_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+
+            resolved = collector.default_repo_profile_path(repo_root)
+
+            self.assertEqual(resolved, collector.retained_default_repo_profile_path())
+
+    def test_resolve_profile_path_prefers_repo_relative_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            project_profile = (
+                repo_root / ".codex" / "project" / "profiles" / "draft-release-copy" / "profile.json"
+            )
+            project_profile.parent.mkdir(parents=True, exist_ok=True)
+            project_profile.write_text("{}", encoding="utf-8")
+
+            resolved = collector.resolve_profile_path(
+                ".codex/project/profiles/draft-release-copy/profile.json",
+                repo_root,
+            )
+
+            self.assertEqual(resolved, project_profile.resolve())
+
+    def test_resolve_profile_path_accepts_skill_relative_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+
+            resolved = collector.resolve_profile_path("profiles/default/profile.json", repo_root)
+
+            self.assertEqual(resolved, collector.retained_default_repo_profile_path())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_collect_release_copy_context_missing_bound_files.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_collect_release_copy_context_missing_bound_files.py
@@ -1,0 +1,104 @@
+﻿import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import collect_release_copy_context as collector
+
+
+class CollectReleaseCopyContextMainTests(unittest.TestCase):
+    def test_main_reports_missing_required_binding_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            (repo_root / "README.md").write_text("# Repo\n", encoding="utf-8")
+
+            stderr = io.StringIO()
+            output_path = repo_root / "out" / "context.json"
+            argv = [
+                "collect_release_copy_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--profile",
+                str(collector.retained_default_repo_profile_path()),
+                "--output",
+                str(output_path),
+            ]
+
+            with mock.patch.object(sys, "argv", argv), contextlib.redirect_stderr(stderr):
+                exit_code = collector.main()
+
+            self.assertEqual(exit_code, 1)
+            error_text = stderr.getvalue()
+            self.assertIn("collect_release_copy_context.py:", error_text)
+            self.assertIn("bindings.publish_config_path", error_text)
+            self.assertIn("missing required repo profile binding", error_text)
+            self.assertNotIn("Traceback", error_text)
+
+    def test_main_reports_missing_required_bound_file_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            profile_path = repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json"
+            profile_path.parent.mkdir(parents=True, exist_ok=True)
+            profile_path.write_text(
+                json.dumps(
+                    {
+                        "bindings": {
+                            "primary_readme_path": "README.md",
+                            "publish_config_path": "release/PublishConfiguration.xml",
+                            "settings_source_path": "src/Setting.cs",
+                        },
+                        "extra": {
+                            "release_copy": {
+                                "maintaining_path": "MAINTAINING.md",
+                                "release_checklist_template_path": ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                "release_workflow_path": ".github/workflows/release.yml",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (repo_root / "README.md").write_text("# Repo\n", encoding="utf-8")
+            (repo_root / "MAINTAINING.md").write_text("## Release Operations\n\n- step\n", encoding="utf-8")
+            checklist_path = repo_root / ".github" / "ISSUE_TEMPLATE" / "release_checklist.yml"
+            checklist_path.parent.mkdir(parents=True, exist_ok=True)
+            checklist_path.write_text("name: Release checklist\n", encoding="utf-8")
+            workflow_path = repo_root / ".github" / "workflows" / "release.yml"
+            workflow_path.parent.mkdir(parents=True, exist_ok=True)
+            workflow_path.write_text("name: release\n", encoding="utf-8")
+            settings_path = repo_root / "src" / "Setting.cs"
+            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            settings_path.write_text("namespace Example {}\n", encoding="utf-8")
+
+            stderr = io.StringIO()
+            output_path = repo_root / "out" / "context.json"
+            argv = [
+                "collect_release_copy_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(output_path),
+            ]
+
+            with mock.patch.object(sys, "argv", argv), contextlib.redirect_stderr(stderr):
+                exit_code = collector.main()
+
+            self.assertEqual(exit_code, 1)
+            error_text = stderr.getvalue()
+            self.assertIn("collect_release_copy_context.py:", error_text)
+            self.assertIn("bindings.publish_config_path", error_text)
+            self.assertIn("missing file", error_text)
+            self.assertNotIn("Traceback", error_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_create_release_issue.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_create_release_issue.py
@@ -1,0 +1,216 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import create_release_issue as create_release_issue
+
+
+class CreateReleaseIssueTests(unittest.TestCase):
+    def read_json(self, path: Path) -> dict:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_dry_run_reuses_existing_issue_and_plans_edit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            body_path = tmp / "body.md"
+            result_path = tmp / "issue-result.json"
+            body_path.write_text("# Body\n", encoding="utf-8")
+
+            def fake_run_command(args: list[str], cwd: Path, check: bool = True) -> str:
+                if args[:4] == ["gh", "repo", "view", "--json"]:
+                    return json.dumps({"nameWithOwner": "owner/repo"})
+                if args[:3] == ["gh", "auth", "status"]:
+                    return "Logged in with project scope."
+                if args[:3] == ["gh", "issue", "list"]:
+                    return json.dumps(
+                        [
+                            {
+                                "number": 12,
+                                "title": "[Release] v1.2.3",
+                                "url": "https://example.invalid/issues/12",
+                                "state": "OPEN",
+                            }
+                        ]
+                    )
+                self.fail(f"Unexpected command: {args}")
+
+            stdout = io.StringIO()
+            with mock.patch.object(create_release_issue, "run_command", side_effect=fake_run_command), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "create_release_issue.py",
+                    "--title",
+                    "[Release] v1.2.3",
+                    "--body-file",
+                    str(body_path),
+                    "--repo-root",
+                    str(repo_root),
+                    "--reuse-existing",
+                    "--sync-existing-body",
+                    "--project-mode",
+                    "auto-add-first",
+                    "--result-output",
+                    str(result_path),
+                    "--dry-run",
+                ],
+            ), redirect_stdout(stdout):
+                exit_code = create_release_issue.main()
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(payload["mutation_type"], "gh_issue_edit_existing")
+            self.assertEqual(payload["existing_issue_number"], 12)
+            self.assertTrue(payload["project_scope_available"])
+            self.assertTrue(payload["project_flag_used"])
+            self.assertEqual(
+                payload["command"][:5],
+                ["gh", "issue", "edit", "12", "--title"],
+            )
+            self.assertIn("--add-project", payload["command"])
+            self.assertEqual(self.read_json(result_path)["mutation_type"], "gh_issue_edit_existing")
+
+    def test_sync_existing_body_requires_reuse_existing_before_any_gh_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            body_path = tmp / "body.md"
+            body_path.write_text("# Body\n", encoding="utf-8")
+
+            stderr = io.StringIO()
+            with mock.patch.object(
+                create_release_issue,
+                "run_command",
+                side_effect=AssertionError("gh command should not run for invalid local input contract"),
+            ), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "create_release_issue.py",
+                    "--title",
+                    "[Release] v1.2.3",
+                    "--body-file",
+                    str(body_path),
+                    "--repo-root",
+                    str(repo_root),
+                    "--sync-existing-body",
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = create_release_issue.main()
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn("--sync-existing-body requires --reuse-existing", stderr.getvalue())
+
+    def test_missing_body_file_stops_before_any_gh_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            missing_body_path = tmp / "missing.md"
+
+            stderr = io.StringIO()
+            with mock.patch.object(
+                create_release_issue,
+                "run_command",
+                side_effect=AssertionError("gh command should not run when body file is missing"),
+            ), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "create_release_issue.py",
+                    "--title",
+                    "[Release] v1.2.3",
+                    "--body-file",
+                    str(missing_body_path),
+                    "--repo-root",
+                    str(repo_root),
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = create_release_issue.main()
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn("body file not found", stderr.getvalue())
+
+    def test_require_scope_stops_without_project_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            body_path = tmp / "body.md"
+            body_path.write_text("# Body\n", encoding="utf-8")
+            recorded_calls: list[list[str]] = []
+
+            def fake_run_command(args: list[str], cwd: Path, check: bool = True) -> str:
+                recorded_calls.append(args)
+                if args[:3] == ["gh", "auth", "status"]:
+                    return "Logged in."
+                self.fail(f"Unexpected command: {args}")
+
+            stderr = io.StringIO()
+            with mock.patch.object(create_release_issue, "run_command", side_effect=fake_run_command), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "create_release_issue.py",
+                    "--title",
+                    "[Release] v1.2.3",
+                    "--body-file",
+                    str(body_path),
+                    "--repo-root",
+                    str(repo_root),
+                    "--project-mode",
+                    "require-scope",
+                    "--reuse-existing",
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = create_release_issue.main()
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn("project scope is required but not available", stderr.getvalue())
+            self.assertEqual(recorded_calls, [["gh", "auth", "status"]])
+
+    def test_require_scope_stops_cleanly_when_gh_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            body_path = tmp / "body.md"
+            body_path.write_text("# Body\n", encoding="utf-8")
+
+            stderr = io.StringIO()
+            with mock.patch.object(create_release_issue.subprocess, "run", side_effect=FileNotFoundError("gh")), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "create_release_issue.py",
+                    "--title",
+                    "[Release] v1.2.3",
+                    "--body-file",
+                    str(body_path),
+                    "--repo-root",
+                    str(repo_root),
+                    "--project-mode",
+                    "require-scope",
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = create_release_issue.main()
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn("project scope is required but not available", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_lint_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_lint_release_copy.py
@@ -1,0 +1,151 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import lint_release_copy as lint_release_copy
+
+
+class LintReleaseCopyTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def read_json(self, path: Path) -> dict:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def run_lint(self, context: dict) -> dict:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context_path = tmp / "context.json"
+            output_path = tmp / "lint.json"
+            self.write_json(context_path, context)
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "lint_release_copy.py",
+                    "--context",
+                    str(context_path),
+                    "--output",
+                    str(output_path),
+                ],
+            ):
+                exit_code = lint_release_copy.main()
+
+            self.assertEqual(exit_code, 0)
+            return self.read_json(output_path)
+
+    def test_lint_flags_software_gate_claims_and_missing_topics(self) -> None:
+        context = {
+            "target_version": "1.2.3",
+            "base_tag": "v1.2.2",
+            "publish_configuration": {
+                "mod_version": "1.2.3",
+                "short_description": "Software path fixed for office demand buyers.",
+                "long_description": "Diagnostics are stable now.",
+                "change_log": "- Publish metadata updated for this release.",
+            },
+            "base_tag_publish_configuration": {
+                "change_log": "- Prior release telemetry note.",
+            },
+            "readme": {
+                "intro_text": "This release confirms the software fix.",
+                "sections": {
+                    "Current Release": "Software fix confirmed for diagnostics and buyer fallback.",
+                    "Current Status": "No experimental disclaimer remains.",
+                },
+                "settings_defaults": {},
+            },
+            "setting_defaults": {},
+            "local_release_helper": {
+                "status": "present",
+            },
+            "changed_files": [
+                "ExampleProduct/Setting.cs",
+                "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+                "ExampleProduct/Systems/VirtualOfficeResourceBuyerFixSystem.cs",
+            ],
+            "changed_file_stats": {
+                "ExampleProduct/Setting.cs": {"churn": 140},
+                "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs": {"churn": 160},
+                "ExampleProduct/Systems/VirtualOfficeResourceBuyerFixSystem.cs": {"churn": 150},
+            },
+            "commit_subjects": [
+                "Tighten diagnostic flow for buyers",
+                "Buyer fallback cleanup",
+            ],
+            "evidence": {
+                "software_track_status": "pending",
+                "comparable_evidence": "",
+                "anchor_comparison": "",
+                "release_pr_validation_note": "",
+            },
+        }
+
+        result = self.run_lint(context)
+
+        error_codes = {item["code"] for item in result["findings"]["errors"]}
+        warning_codes = {item["code"] for item in result["findings"]["warnings"]}
+
+        self.assertIn("unsupported_strong_software_claim", error_codes)
+        self.assertIn("release_gate_validation_incomplete", warning_codes)
+        self.assertIn("missing_changelog_topic", warning_codes)
+        self.assertIn("checklist_field_unresolved", warning_codes)
+        self.assertTrue(result["checks"]["target_version_matches_publish"])
+        self.assertFalse(result["checks"]["evidence_complete"])
+        self.assertTrue(result["checks"]["helper_handoff_allowed"])
+        self.assertTrue(result["checks"]["rewrite_publish_recommended"])
+        self.assertTrue(result["checks"]["rewrite_readme_recommended"])
+
+    def test_lint_reports_missing_helper_and_version_mismatch(self) -> None:
+        context = {
+            "target_version": "2.0.0",
+            "base_tag": "v1.9.9",
+            "publish_configuration": {
+                "mod_version": "1.9.9",
+                "short_description": "Experimental path remains under investigation.",
+                "long_description": "",
+                "change_log": "- Diagnostics logging cleanup.",
+            },
+            "base_tag_publish_configuration": {
+                "change_log": "- Previous release note.",
+            },
+            "readme": {
+                "intro_text": "Experimental path remains under investigation.",
+                "sections": {
+                    "Current Release": "",
+                    "Current Status": "",
+                },
+                "settings_defaults": {},
+            },
+            "setting_defaults": {},
+            "local_release_helper": {
+                "status": "missing_local_release_script",
+            },
+            "changed_files": [],
+            "changed_file_stats": {},
+            "commit_subjects": [],
+            "evidence": None,
+        }
+
+        result = self.run_lint(context)
+
+        error_codes = {item["code"] for item in result["findings"]["errors"]}
+        info_codes = {item["code"] for item in result["findings"]["info"]}
+
+        self.assertIn("target_version_mismatch", error_codes)
+        self.assertIn("missing_local_release_script", info_codes)
+        self.assertFalse(result["checks"]["target_version_matches_publish"])
+        self.assertFalse(result["checks"]["helper_handoff_allowed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_smoke_prepare_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_smoke_prepare_release_copy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import release_copy_plan_contract as contract  # noqa: E402
+import smoke_prepare_release_copy as smoke  # noqa: E402
+
+
+class SmokePrepareReleaseCopyTests(unittest.TestCase):
+    def test_success_output_uses_reference_schema(self) -> None:
+        with patch.object(sys, "argv", ["smoke_prepare_release_copy.py"]):
+            buffer = io.StringIO()
+            with patch("sys.stdout", buffer):
+                self.assertEqual(smoke.main(), 0)
+
+        payload = json.loads(buffer.getvalue())
+        for key in contract.SMOKE_OUTPUT_FIELDS:
+            self.assertIn(key, payload)
+        self.assertEqual(payload["status"], "ok")
+        self.assertIsNone(payload["reason"])
+        self.assertEqual(payload["next_action"], "review_smoke_results")
+        self.assertGreater(payload["estimated_delegation_savings"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_validate_release_copy_plan.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_validate_release_copy_plan.py
@@ -1,0 +1,320 @@
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import release_copy_plan_tools as plan_tools
+import validate_release_copy as validate_release_copy_plan
+
+
+PUBLISH_XML = """<Configuration>
+  <ShortDescription Value="Current short description" />
+  <LongDescription>Current long description.</LongDescription>
+  <ModVersion Value="1.2.3" />
+  <ChangeLog>- Current release note.</ChangeLog>
+</Configuration>
+"""
+
+README_MD = """# ExampleProduct
+
+Intro text.
+
+## Current Release
+Current release block.
+
+## Current Status
+Current status block.
+"""
+
+
+class ValidateReleaseCopyPlanTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+    def build_context(self, tmp: Path, *, existing_issue: dict | None = None) -> dict:
+        repo_root = tmp / "repo"
+        publish_path = repo_root / "ExampleProduct" / "Properties" / "PublishConfiguration.xml"
+        readme_path = repo_root / "README.md"
+        publish_path.parent.mkdir(parents=True, exist_ok=True)
+        readme_path.parent.mkdir(parents=True, exist_ok=True)
+        publish_path.write_text(PUBLISH_XML, encoding="utf-8")
+        readme_path.write_text(README_MD, encoding="utf-8")
+
+        context = {
+            "repo_root": str(repo_root),
+            "repo_slug": "owner/repo",
+            "head_commit": "abc1234",
+            "base_tag": "v1.2.2",
+            "target_version": "1.2.3",
+            "rule_files": {
+                "publish_configuration": str(publish_path),
+                "readme": str(readme_path),
+            },
+            "publish_configuration": {
+                "path": str(publish_path),
+                "mod_version": "1.2.3",
+                "short_description": "Current short description",
+                "long_description": "Current long description.",
+                "change_log": "- Current release note.",
+            },
+            "readme": {
+                "path": str(readme_path),
+                "intro_text": "# ExampleProduct\n\nIntro text.",
+                "sections": {
+                    "Current Release": "Current release block.",
+                    "Current Status": "Current status block.",
+                },
+            },
+            "source_fingerprints": {
+                "publish_configuration": plan_tools.json_fingerprint(PUBLISH_XML),
+                "readme": plan_tools.json_fingerprint(README_MD),
+            },
+            "existing_release_issue": existing_issue,
+            "evidence": None,
+            "local_release_helper": {"status": "present"},
+            "project_title_default": "ExampleProduct Tracker",
+        }
+        context["freshness_tuple"] = plan_tools.expected_freshness_tuple(context)
+        context["context_fingerprint"] = plan_tools.expected_context_fingerprint(context)
+        return context
+
+    def base_lint(self, *, evidence_complete: bool, tracks: dict[str, bool] | None = None) -> dict:
+        return {
+            "findings": {"errors": [], "warnings": [], "info": []},
+            "checks": {
+                "evidence_complete": evidence_complete,
+                "applicable_validation_tracks": tracks or {"software_gate": False, "telemetry_validation": False},
+            },
+        }
+
+    def base_plan(self, context: dict, *, evidence_status: str = "not-applicable", issue_action: dict | None = None) -> dict:
+        return {
+            "context_fingerprint": context["context_fingerprint"],
+            "freshness_tuple": context["freshness_tuple"],
+            "overall_confidence": "high",
+            "stop_reasons": [],
+            "evidence_status": evidence_status,
+            "draft_basis": {
+                "common_path_sufficient": True,
+                "raw_reread_count": 0,
+                "reread_reasons": [],
+                "focused_packets_used": [],
+                "compensatory_reread_detected": False,
+                "synthesis_packet_fingerprint": "sha256:synthesis",
+            },
+            "publish_update": {"mode": "noop"},
+            "readme_update": {"mode": "noop"},
+            "issue_action": issue_action or {"mode": "noop"},
+        }
+
+    def run_validator(self, context: dict, lint: dict, plan: dict, **patches: object) -> dict:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context_path = tmp / "context.json"
+            lint_path = tmp / "lint.json"
+            plan_path = tmp / "plan.json"
+            output_path = tmp / "validation.json"
+            self.write_json(context_path, context)
+            self.write_json(lint_path, lint)
+            self.write_json(plan_path, plan)
+
+            patchers = [
+                mock.patch.object(validate_release_copy_plan.plan_tools, "current_head_commit", return_value=context["head_commit"]),
+            ]
+            for name, value in patches.items():
+                patchers.append(mock.patch(name, value))
+
+            with ExitStack() as stack:
+                for patcher in patchers:
+                    stack.enter_context(patcher)
+                stack.enter_context(
+                    mock.patch.object(
+                        sys,
+                        "argv",
+                        [
+                            "validate_release_copy_plan.py",
+                            "--context",
+                            str(context_path),
+                            "--lint",
+                            str(lint_path),
+                            "--plan",
+                            str(plan_path),
+                            "--output",
+                            str(output_path),
+                        ],
+                    )
+                )
+                validate_release_copy_plan.main()
+
+            return json.loads(output_path.read_text(encoding="utf-8"))
+
+    def test_validator_stops_on_release_gate_before_any_gh_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context = self.build_context(tmp)
+            lint = self.base_lint(
+                evidence_complete=False,
+                tracks={"software_gate": True, "telemetry_validation": False},
+            )
+            plan = self.base_plan(
+                context,
+                evidence_status="complete",
+                issue_action={
+                    "mode": "create",
+                    "title": "[Release] v1.2.3",
+                    "body_markdown": "Checklist body",
+                    "project_mode": "auto-add-first",
+                },
+            )
+
+            payload = self.run_validator(
+                context,
+                lint,
+                plan,
+                **{
+                    "validate_release_copy.issue_tools.run_command": mock.Mock(
+                        side_effect=AssertionError("gh auth should not run before local release-gate failure")
+                    )
+                },
+            )
+
+            self.assertFalse(payload["valid"])
+            self.assertIn("release_gate_incomplete", payload["stop_reasons"])
+            self.assertEqual(payload["apply_gate_status"]["status"], "fail")
+
+    def test_validator_warns_and_strips_unknown_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context = self.build_context(tmp)
+            lint = self.base_lint(evidence_complete=True)
+            plan = self.base_plan(context)
+            plan["extra_top_level"] = "ignore me"
+            plan["publish_update"] = {
+                "mode": "replace-fields",
+                "short_description": "Updated short description",
+                "extra_publish_field": "ignore me too",
+            }
+
+            payload = self.run_validator(context, lint, plan)
+
+            self.assertTrue(payload["valid"])
+            warning_codes = {item["code"] for item in payload["warning_details"]}
+            self.assertIn("W_RELEASE_PLAN_IGNORED_FIELD", warning_codes)
+            self.assertNotIn("extra_top_level", payload["normalized_plan"])
+            self.assertNotIn("extra_publish_field", payload["normalized_plan"]["publish_update"]["fields"])
+
+    def test_validator_stops_on_compensatory_reread(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context = self.build_context(tmp)
+            lint = self.base_lint(evidence_complete=True)
+            plan = self.base_plan(context)
+            plan["draft_basis"]["raw_reread_count"] = 1
+            plan["draft_basis"]["reread_reasons"] = ["unsupported_layout"]
+            plan["draft_basis"]["compensatory_reread_detected"] = True
+
+            payload = self.run_validator(context, lint, plan)
+
+            self.assertFalse(payload["valid"])
+            self.assertIn("synthesis_packet_insufficient", payload["stop_reasons"])
+
+    def test_validator_stops_on_packet_insufficiency_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context = self.build_context(tmp)
+            lint = self.base_lint(evidence_complete=True)
+            plan = self.base_plan(context)
+            plan["draft_basis"]["raw_reread_count"] = 1
+            plan["draft_basis"]["reread_reasons"] = ["packet_insufficiency"]
+
+            payload = self.run_validator(context, lint, plan)
+
+            self.assertFalse(payload["valid"])
+            self.assertIn("synthesis_packet_insufficient", payload["stop_reasons"])
+
+    def test_validator_detects_stale_existing_issue_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context = self.build_context(
+                tmp,
+                existing_issue={
+                    "number": 42,
+                    "title": "[Release] v1.2.3",
+                    "url": "https://example.invalid/issues/42",
+                    "state": "OPEN",
+                    "body": "Original body",
+                },
+            )
+            lint = self.base_lint(evidence_complete=True)
+            plan = self.base_plan(
+                context,
+                issue_action={
+                    "mode": "sync-existing-body",
+                    "title": "[Release] v1.2.3",
+                    "body_markdown": "Updated body",
+                    "project_mode": "auto-add-first",
+                },
+            )
+
+            with mock.patch.object(
+                validate_release_copy_plan.issue_tools,
+                "run_command",
+                return_value="Logged in with project scope.",
+            ), mock.patch.object(
+                validate_release_copy_plan.plan_tools,
+                "fetch_issue_snapshot",
+                return_value={
+                    "number": 42,
+                    "title": "[Release] v1.2.3",
+                    "url": "https://example.invalid/issues/42",
+                    "state": "OPEN",
+                    "body": "Changed body",
+                },
+            ), mock.patch.object(
+                validate_release_copy_plan.plan_tools,
+                "current_head_commit",
+                return_value=context["head_commit"],
+            ):
+                payload = validate_release_copy_plan.validate_plan_contract(context, lint, plan)
+
+            self.assertFalse(payload["valid"])
+            self.assertIn("stale_issue_snapshot", payload["stop_reasons"])
+
+    def test_validator_emits_apply_safe_normalized_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context = self.build_context(tmp)
+            lint = self.base_lint(evidence_complete=True)
+            plan = self.base_plan(context)
+            plan["publish_update"] = {
+                "mode": "replace-fields",
+                "short_description": "Updated short description",
+                "change_log": "- Fresh release note.",
+            }
+            plan["readme_update"] = {
+                "mode": "replace-sections",
+                "sections": {
+                    "Current Release": "Updated release block.",
+                    "Current Status": "Updated status block.",
+                },
+            }
+
+            payload = self.run_validator(context, lint, plan)
+
+            self.assertTrue(payload["valid"])
+            self.assertTrue(payload["can_apply"])
+            self.assertEqual(payload["apply_gate_status"]["status"], "pass")
+            self.assertEqual(payload["normalized_plan"]["publish_update"]["fields"]["short_description"], "Updated short description")
+            self.assertEqual(payload["normalized_plan"]["readme_update"]["sections"]["Current Release"], "Updated release block.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_write_evaluation_log_release_copy.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/tests/test_write_evaluation_log_release_copy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # noqa: E402
+
+
+class WriteEvaluationLogReleaseCopyTests(unittest.TestCase):
+    def test_build_phase_merges_packet_metrics_as_eval_only(self) -> None:
+        log = {
+            "skill": {"name": "draft-release-copy"},
+            "quality": {},
+            "safety": {},
+            "outputs": {},
+            "orchestration": {},
+            "baseline": {},
+            "measurement": {"token_source": "unavailable"},
+            "skill_specific": {"data": {}},
+        }
+        result = {
+            "review_mode": "targeted-delegation",
+            "recommended_worker_count": 2,
+            "packet_count": 8,
+            "largest_packet_bytes": 1200,
+            "largest_two_packets_bytes": 2100,
+            "estimated_local_only_tokens": 1800,
+            "estimated_packet_tokens": 950,
+            "estimated_delegation_savings": 850,
+            "packet_size_bytes": {"worker_facing_total": 3800, "raw_local_source_bytes": 7200},
+        }
+
+        eval_log.apply_phase_update(log, "build", result, duration=0.5)
+
+        self.assertEqual(log["orchestration"]["review_mode"], "targeted-delegation")
+        self.assertEqual(log["orchestration"]["worker_count"], 2)
+        self.assertEqual(log["skill_specific"]["data"]["packet_count"], 8)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_packet_tokens"], 950)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_delegation_savings"], 850)
+        self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 1800)
+        self.assertEqual(log["baseline"]["estimated_token_savings"], 850)
+        self.assertEqual(log["baseline"]["estimated_delegation_savings"], 850)
+        self.assertEqual(log["measurement"]["token_source"], "estimated")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/SKILL.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: gh-address-review-threads
+description: Inspect unresolved GitHub PR review threads on the open pull request for the current branch, decide whether to accept, reject, defer, or defer outdated threads, post acknowledgement and completion replies with gh CLI, apply accepted fixes, and resolve completed threads. Use when Codex needs to read open PR review threads, summarize the planned direction or rejection, perform the work, then post a completion reply and resolve the finished threads.
+---
+
+# Address Review Threads
+
+Use this skill to handle unresolved GitHub PR review threads on the current branch, then post the matching acknowledgement and completion replies and resolve the accepted threads.
+
+This is a packet-driven repo workflow skill:
+- keep GitHub auth, context collection, per-thread adjudication, final reply wording, GitHub mutations, and broad fixes local
+- use deterministic scripts to compress thread history into `global`, `thread-batch`, and `thread` packets
+- use `gpt-5.4-mini` workers only for narrow packet analysis and only for small fixes that satisfy the delegation guardrails
+- stop on low confidence, stale snapshots, or ambiguous ownership instead of guessing
+
+Boundary:
+- Keep reusable packet-workflow semantics in `references/core-contract.md`.
+- Keep default repo bindings and review-doc ownership in `profiles/default/profile.json`.
+- Keep vendored repo overrides data-only in `.codex/project/profiles/`.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/gh-address-review-threads/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/gh-address-review-threads/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/gh-address-review-threads/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Collect structured context.
+- Run `gh auth status`.
+- If authentication fails, stop and tell the user to run `gh auth login`.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_review_threads.py --repo <repo-root> --output <context-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_review_packets.py --context <context-json> --repo-root <repo-root> --output-dir <packet-dir> --result-output <packet-dir>/build-result.json`.
+- Draft a raw thread-actions plan locally.
+- Run `<python-bin> -B <skill-dir>/scripts/validate_thread_action_plan.py --context <context-json> --plan <raw-plan-json> --phase <ack|complete> --output <validated-plan-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase build --result <packet-dir>/build-result.json`.
+- Read `<packet-dir>/orchestrator.json` first.
+- Keep `<packet-dir>/global_packet.json` in view before reading any thread packet.
+- Before deciding a thread, read that packet's `discussion`, `existing_self_reply`, `reply_candidates`, `validation_candidates`, and `ownership_summary` or `shared_fix_surface`.
+
+2. Follow the review mode.
+- `local-only`: keep thread analysis and code changes local.
+- `targeted-delegation`: use 1-2 `gpt-5.4-mini` workers on thread-batch or singleton packets.
+- `broad-delegation`: use 3-4 `gpt-5.4-mini` workers and add QA only when findings conflict or the fix surface is broad.
+- Respect `review_mode_overrides` when churn, cross-group core files, or meaningful generated-file slices warrant widening the mode.
+- Treat `packet_worker_map` as the routing authority for delegated thread packets.
+- Treat `preferred_worker_families` as registry metadata only.
+- Treat `recommended_workers` and `optional_workers` as derived convenience fields only.
+- Read `references/review-threads-contract.md` before broad delegation or reply planning on a noisy PR.
+
+3. Keep adjudication local.
+- Decide `accept`, `reject`, `defer`, or `defer-outdated` per unresolved thread locally.
+- Default outdated threads to `defer-outdated`.
+- Upgrade an outdated thread to `accept` only after confirming against current `HEAD` that the issue still applies.
+- Draft acknowledgement replies locally, apply accepted fixes, validate them, then draft completion replies.
+- Commit and push accepted work before posting a completion reply or resolving the thread.
+- Do not use a top-level PR comment unless the user asks for one.
+
+4. Respect reply and resolution rules.
+- Start acknowledgement replies with the exact ack marker on line 1.
+- Start completion replies with the exact complete marker on line 1.
+- Apply actions only from the normalized validator output; do not feed raw `thread_actions` JSON into `apply_thread_action_plan.py`.
+- Resolve only accepted threads after the pushed fix and validation are complete.
+- Preserve still-accurate text when updating an existing reply.
+- During `ack`, you may adopt one recent unmarked self-authored reply after the latest reviewer comment.
+- During `complete`, never adopt an unmarked reply.
+
+## Packet Contract
+
+- `orchestrator_profile=standard`
+- `decision_ready_packets=false`
+- `worker_return_contract=generic`
+- `worker_output_shape=flat`
+- `xhigh_reread_policy=packet-first local adjudication with raw rereads only for explicit exception reasons`
+- `packet_worker_map` routes delegated `thread-batch-*` and eligible singleton `thread-*` packets to `packet_explorer`.
+- `common_path_contract` means the default local path is `global_packet.json + one thread-batch packet` or `global_packet.json + one thread packet`.
+- `quality_escape_hints` is advisory only; explicit reread or escape decisions must still use the allowed reason enum or an explicit stop.
+- `large_diff_auditor` remains an explicit optional QA worker, not a routed packet default.
+- `context_fingerprint` must stay stable across collect, build, validate, and apply for one workflow run.
+
+## Delegation Rules
+
+- Never ask workers to rediscover the whole PR or raw review history from scratch.
+- Pass `global_packet.json` plus one `thread-batch-*.json` or one `thread-*.json` packet.
+- Require this output contract from each analysis worker:
+  - `thread ids`
+  - `problem summary`
+  - `fix direction`
+  - `risk`
+  - `files to edit`
+  - `tests to run`
+- Delegate actual code edits only when all of these are true:
+  - one batch or one thread
+  - two files or fewer
+  - one subsystem
+  - no schema, public interface, config, or workflow changes
+  - validation path is clear
+- Otherwise keep the code change local and use workers only for analysis.
+- Read `references/delegation-playbook.md` when `review_mode` is not `local-only`.
+- Read `references/comment-contract.md` before drafting acknowledgement or completion replies.
+- Read `references/review-threads-contract.md` for packet and routing rules.
+- Read `references/thread-action-contract.md` before validating or applying `thread_actions`.
+- Read `references/architecture-note.md` before changing the packet shape or reconsidering a hierarchical worker/result model.
+
+## Scripts
+
+- `scripts/collect_review_threads.py`
+  - Collect PR metadata, changed files, diff stat, top-level comments, review submissions, unresolved and outdated review threads, and reply-update candidates.
+- `scripts/build_review_packets.py`
+  - Split the collected context into `orchestrator.json`, `global_packet.json`, per-thread packets, clustered batch packets, `packet_metrics.json`, and an eval-side build result.
+- `scripts/validate_thread_action_plan.py`
+  - Validate raw `thread_actions`, normalize them into deterministic order, enforce fallback and marker-conflict rules, and emit the canonical apply envelope.
+- `scripts/apply_thread_action_plan.py`
+  - Consume only the normalized validator output, add or update acknowledgement and completion replies, and resolve accepted threads after completion.
+- `scripts/write_evaluation_log.py`
+  - Record the shared evaluation log for efficiency, quality, and safety tracking.
+- `scripts/review_thread_packet_contract.py`
+  - Shared contract for packet naming, routing authority, reread reasons, common-path sufficiency, and eval-side packet metrics.
+- `scripts/smoke_gh_address_review_threads.py`
+  - Operator-facing dry-run smoke path that emits a short `status/reason/thread_counts/next_action` summary.
+  - Default mode targets the current-branch PR and blocks cleanly on missing auth, missing `gh`, no open PR, or no unresolved threads.
+  - `--synthetic` runs a self-contained temp-fixture smoke so maintainers can verify the full packet/build/validate/apply dry-run path without a live PR.
+- `scripts/thread_action_contract.py`
+  - Shared contract for `reply_candidates`, `marker_conflicts`, `thread_actions`, context fingerprints, and validator/apply normalization rules.
+
+## Evaluation
+
+- Use the packet directory for machine-readable action results such as `<packet-dir>/ack-result.json` and `<packet-dir>/complete-result.json`.
+- Treat `<packet-dir>/packet_metrics.json` as evaluation-only. Do not use token-efficiency counters as runtime routing input.
+- After drafting a raw phase plan, prefer `<python-bin> -B <skill-dir>/scripts/validate_thread_action_plan.py ... --output <packet-dir>/ack-validated.json` or `... --output <packet-dir>/complete-validated.json`, then merge with `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase validate --result <validated-json>`.
+- After `ack` or `complete`, prefer `<python-bin> -B <skill-dir>/scripts/apply_thread_action_plan.py ... --plan <validated-json> --result-output <packet-dir>/ack-result.json` or `... --plan <validated-json> --result-output <packet-dir>/complete-result.json`, then merge each result with `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase apply --result <result-json>`.
+- After the overall run, write `<packet-dir>/final-eval.json` with worker usage, token data when available, final usability, outputs, and notes, then run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py finalize --log <eval-log-json> --final <packet-dir>/final-eval.json`.
+- Prefer the contract-default `<eval-log-json>` outside the repo. Keep packets and helper temp files under the fixed gitignored runtime root from `## Execution Roots`.
+- Read `references/evaluation-log-contract.md` for the shared envelope and `references/gh-address-review-threads-evaluation-contract.md` for thread-specific fields.
+- Read `references/architecture-note.md` for the rationale behind the current flat/generic contract and the criteria for revisiting hierarchy.
+- Use `<python-bin> -B <skill-dir>/scripts/smoke_gh_address_review_threads.py --repo-root <repo-root>` for an operator-facing dry-run smoke on the current branch PR.
+- Use `<python-bin> -B <skill-dir>/scripts/smoke_gh_address_review_threads.py --synthetic` for a self-contained reference smoke that does not require a live PR or `gh` auth.
+
+## Output
+
+- Tell the user which threads were accepted, rejected, deferred, or left outdated.
+- Mention what code changed and which validations you ran.
+- Include the PR URL.
+- If blocked, name the blocker precisely: missing `gh` auth, no open PR for the branch, missing reply target, or unresolved implementation risk.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/SKILL.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/SKILL.md
@@ -36,12 +36,13 @@ Boundary:
 1. Collect structured context.
 - Run `gh auth status`.
 - If authentication fails, stop and tell the user to run `gh auth login`.
-- Run `<python-bin> -B <skill-dir>/scripts/collect_review_threads.py --repo <repo-root> --output <context-json>`.
-- Run `<python-bin> -B <skill-dir>/scripts/build_review_packets.py --context <context-json> --repo-root <repo-root> --output-dir <packet-dir> --result-output <packet-dir>/build-result.json`.
+- Before pushing accepted work, collect the pre-push snapshot with `<python-bin> -B <skill-dir>/scripts/collect_review_threads.py --repo <repo-root> --output <context-json>`.
+- Build the initial packets with `<python-bin> -B <skill-dir>/scripts/build_review_packets.py --context <context-json> --repo-root <repo-root> --output-dir <packet-dir> --result-output <packet-dir>/build-result.json`.
 - Draft a raw thread-actions plan locally.
 - Run `<python-bin> -B <skill-dir>/scripts/validate_thread_action_plan.py --context <context-json> --plan <raw-plan-json> --phase <ack|complete> --output <validated-plan-json>`.
 - Run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>`.
 - Run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase build --result <packet-dir>/build-result.json`.
+- After accepted work is pushed, recollect a post-push snapshot, rebuild packets with `--previous-context <pre-push-context-json>` and `--reconciliation-input <reconciliation-json>`, then use `<python-bin> -B <skill-dir>/scripts/reconcile_outdated_threads.py --context <post-push-context-json> --packet-dir <packet-dir> --output <raw-complete-plan-json>` to seed the complete-phase plan.
 - Read `<packet-dir>/orchestrator.json` first.
 - Keep `<packet-dir>/global_packet.json` in view before reading any thread packet.
 - Before deciding a thread, read that packet's `discussion`, `existing_self_reply`, `reply_candidates`, `validation_candidates`, and `ownership_summary` or `shared_fix_surface`.
@@ -59,10 +60,14 @@ Boundary:
 3. Keep adjudication local.
 - Decide `accept`, `reject`, `defer`, or `defer-outdated` per unresolved thread locally.
 - Default outdated threads to `defer-outdated`.
-- Upgrade an outdated thread to `accept` only after confirming against current `HEAD` that the issue still applies.
-- Draft acknowledgement replies locally, apply accepted fixes, validate them, then draft completion replies.
+- Same-run outdated transitions may auto-resolve only when the thread was non-outdated before this run's push, became outdated after the push, and current `HEAD` plus real validation evidence prove the accepted fix already covers the request.
+- If a transitioned outdated thread still applies against current `HEAD`, return it to the normal unresolved queue for another implementation pass in the same run.
+- If the same-run recheck is ambiguous, keep the thread `defer-outdated` and unresolved.
+- Draft acknowledgement replies locally, then post the normalized `ack` reply for every `accept`, `reject`, `defer`, or `defer-outdated` thread before starting implementation, validation, commits, or pushes for that thread.
+- Do not begin code edits for an accepted thread until its `ack` reply is posted unless GitHub mutation is temporarily blocked; if mutation is blocked, stop and report that blocker instead of silently proceeding.
+- After the `ack` reply is posted, apply accepted fixes, validate them, then draft completion replies.
 - Commit and push accepted work before posting a completion reply or resolving the thread.
-- Do not use a top-level PR comment unless the user asks for one.
+- If collected review feedback includes actionable review-body or top-level PR comments that do not have a replyable review thread, call out that they are non-thread findings and use a top-level PR comment only when needed to preserve the same ack-before-work / complete-after-push workflow.
 
 4. Respect reply and resolution rules.
 - Start acknowledgement replies with the exact ack marker on line 1.
@@ -72,6 +77,7 @@ Boundary:
 - Preserve still-accurate text when updating an existing reply.
 - During `ack`, you may adopt one recent unmarked self-authored reply after the latest reviewer comment.
 - During `complete`, never adopt an unmarked reply.
+- Do not treat a thread as handled if the code change landed but the `ack` reply was skipped; missing `ack` is a workflow failure that must be corrected explicitly.
 
 ## Packet Contract
 
@@ -116,6 +122,10 @@ Boundary:
   - Collect PR metadata, changed files, diff stat, top-level comments, review submissions, unresolved and outdated review threads, and reply-update candidates.
 - `scripts/build_review_packets.py`
   - Split the collected context into `orchestrator.json`, `global_packet.json`, per-thread packets, clustered batch packets, `packet_metrics.json`, and an eval-side build result.
+  - When given `--previous-context` and `--reconciliation-input`, mark same-run non-outdated -> outdated transitions and attach conservative `outdated_recheck` evidence.
+- `scripts/reconcile_outdated_threads.py`
+  - Build a conservative complete-phase raw plan from post-push packets.
+  - Auto-upgrade only same-run outdated transitions with `resolution_verdict=auto-accept`; leave ambiguous transitions unresolved.
 - `scripts/validate_thread_action_plan.py`
   - Validate raw `thread_actions`, normalize them into deterministic order, enforce fallback and marker-conflict rules, and emit the canonical apply envelope.
 - `scripts/apply_thread_action_plan.py`
@@ -127,7 +137,7 @@ Boundary:
 - `scripts/smoke_gh_address_review_threads.py`
   - Operator-facing dry-run smoke path that emits a short `status/reason/thread_counts/next_action` summary.
   - Default mode targets the current-branch PR and blocks cleanly on missing auth, missing `gh`, no open PR, or no unresolved threads.
-  - `--synthetic` runs a self-contained temp-fixture smoke so maintainers can verify the full packet/build/validate/apply dry-run path without a live PR.
+  - `--synthetic` runs a self-contained temp-fixture smoke so maintainers can verify the full packet/build/reconcile/validate/apply dry-run path without a live PR.
 - `scripts/thread_action_contract.py`
   - Shared contract for `reply_candidates`, `marker_conflicts`, `thread_actions`, context fingerprints, and validator/apply normalization rules.
 

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: "Address Review Threads"
+  short_description: "Inspect and resolve open GitHub PR review threads"
+  default_prompt: >-
+    Use $gh-address-review-threads to handle unresolved PR review threads on
+    this branch. Collect structured thread packets, keep
+    global_packet.json in view, decide accept/reject/defer/defer-outdated
+    locally, and post acknowledgement and completion replies only after the
+    accepted fix is validated and pushed.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/agents/openai.yaml
@@ -6,4 +6,6 @@ interface:
     this branch. Collect structured thread packets, keep
     global_packet.json in view, decide accept/reject/defer/defer-outdated
     locally, and post acknowledgement and completion replies only after the
-    accepted fix is validated and pushed.
+    accepted fix is validated and pushed. After a push, allow same-run
+    non-outdated -> outdated transitions to auto-resolve only when current
+    HEAD already proves the request is satisfied.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/builder-spec.json
@@ -1,0 +1,83 @@
+{
+  "skill_name": "gh-address-review-threads",
+  "description": "Inspect unresolved GitHub PR review threads on the open pull request for the current branch, decide whether to accept, reject, defer, or defer outdated threads, post acknowledgement and completion replies with gh CLI, apply accepted fixes, and resolve completed threads. Use when Codex needs to read open PR review threads, summarize the planned direction or rejection, perform the work, then post a completion reply and resolve the finished threads.",
+  "domain_slug": "review_threads",
+  "workflow_family": "github-review",
+  "archetype": "audit-and-apply",
+  "primary_goal": "handle unresolved GitHub PR review threads with packetized analysis, guarded replies, and validator-normalized apply actions",
+  "trigger_phrases": [
+    "address review threads",
+    "handle unresolved PR review comments",
+    "reply to unresolved review threads",
+    "resolve accepted review threads"
+  ],
+  "task_packet_names": [
+    "thread"
+  ],
+  "uses_batch_packets": true,
+  "orchestrator_profile": "standard",
+  "needs_validate": true,
+  "needs_apply": true,
+  "decision_ready_packets": false,
+  "worker_return_contract": "generic",
+  "worker_output_shape": "flat",
+  "packet_worker_map": {
+    "batch-packet-01": [
+      "packet_explorer"
+    ],
+    "thread": [
+      "packet_explorer"
+    ]
+  },
+  "repo_profile": {
+    "name": "default",
+    "summary": "Default reusable profile scaffold for GitHub review-thread workflows. Replace with project-local review-docs, path bindings, and ownership hints when vendored.",
+    "repo_match": {
+      "root_markers": [
+        ".git",
+        "README.md"
+      ],
+      "remote_patterns": []
+    },
+    "bindings": {
+      "primary_readme_path": "README.md",
+      "settings_source_path": null,
+      "publish_config_path": null
+    },
+    "packet_defaults": {
+      "review_docs": {
+        "batch-packet-01": [
+          ".github/pull_request_template.md",
+          "CONTRIBUTING.md"
+        ],
+        "thread": [
+          ".github/pull_request_template.md",
+          "CONTRIBUTING.md"
+        ]
+      },
+      "source_path_globs": {
+        "batch-packet-01": [
+          "**/*"
+        ],
+        "thread": [
+          "**/*"
+        ]
+      }
+    },
+    "lint_rules": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "notes": [
+      "Keep repo-specific PR guidance and review-doc ownership in project-local profiles when vendored.",
+      "Do not encode reply policy, packet routing authority, or validator/apply behavior in this profile."
+    ]
+  },
+  "builder_versioning": {
+    "builder_family": "packet-workflow",
+    "builder_semver": "0.1.0",
+    "compatibility_epoch": 1,
+    "builder_spec_schema_version": 1,
+    "repo_profile_schema_version": 1
+  }
+}

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/migration-worksheet.md
@@ -1,0 +1,59 @@
+# Migration Worksheet: gh-address-review-threads
+
+## Workflow Snapshot
+- `workflow_family`: `github-review`
+- Current runtime shape: `standard`, `generic`, `flat`, validator/apply split
+- Primary packets: `global_packet`, per-thread packets, thread batch packets
+- Current authoritative files:
+  - references: `review-threads-contract.md`, `thread-action-contract.md`, `comment-contract.md`
+  - scripts: `collect_review_threads.py`, `build_review_packets.py`, `validate_thread_action_plan.py`, `apply_thread_action_plan.py`
+  - tests: collect/build/validate/apply/smoke coverage exists
+
+## Repo-Specific Inputs Seen In Legacy Skill
+- PR template and repo guidance file discovery
+- Changed-file grouping heuristics and core-area hints
+- Optional repo guidance paths surfaced in packets
+
+## Migration Classification
+- `core`
+  - validator/apply separation
+  - reply-plan normalization boundary
+  - review-mode semantics
+  - worker-family semantics and packet-routing authority rules
+- `profiles/default/profile.json`
+  - review-doc paths for thread packets
+  - repo markers and primary README binding
+  - source-path globs for packet ownership hints
+- Skill-local
+  - review-thread packet schema
+  - acknowledgement/completion marker policy
+  - GitHub thread action validation and apply logic
+
+## Legacy Inventory Mapping
+- references kept as domain-local: `comment-contract.md`, `review-threads-contract.md`, `thread-action-contract.md`
+- new retained interface additions: `builder-spec.json`, `references/core-contract.md`, `profiles/default/profile.json`
+- scripts to update for profile metadata wiring: `collect_review_threads.py`, `build_review_packets.py`
+
+## Retained vs Consumer-Local 판정
+- Data-only profile로 표현 가능한 repo-specific 차이:
+  - PR guidance file locations
+  - review-doc ownership lists
+  - source-path glob hints
+- 실행 의미/정책/행동 계약까지 건드리는 차이:
+  - 없음. reply marker policy, thread action validation, and apply semantics are reusable skill-local contracts.
+- Decision: `retained`
+
+## Core 승격 기준
+- 반복 shared gap 여부:
+  - active profile loading and profile metadata propagation repeat across multiple retained skills
+  - generic core-area path heuristics also repeat across multiple retained skills
+- 일회성 우회 여부:
+  - thread marker adoption and completion-reply semantics are skill-specific and stay local
+- Decision:
+  - shared profile-loading boundary belongs in foundry core/builder guidance
+  - marker-policy logic stays skill-local
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/profiles/default/profile.json
@@ -1,0 +1,53 @@
+{
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "publish_config_path": null,
+    "settings_source_path": null
+  },
+  "lint_rules": {
+    "missing_review_docs_are_errors": false,
+    "require_readme_settings_table": false
+  },
+  "name": "default",
+  "notes": [
+    "Keep repo-specific PR guidance and review-doc ownership in project-local profiles when vendored.",
+    "Do not encode reply policy, packet routing authority, or validator/apply behavior in this profile."
+  ],
+  "packet_defaults": {
+    "review_docs": {
+      "batch-packet-01": [
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md"
+      ],
+      "thread": [
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md"
+      ]
+    },
+    "source_path_globs": {
+      "batch-packet-01": [
+        "**/*"
+      ],
+      "thread": [
+        "**/*"
+      ]
+    }
+  },
+  "profile_path": "profiles/default/profile.json",
+  "repo_match": {
+    "remote_patterns": [],
+    "root_markers": [
+      ".git",
+      "README.md"
+    ]
+  },
+  "summary": "Default reusable profile scaffold for GitHub review-thread workflows. Replace with project-local review-docs, path bindings, and ownership hints when vendored.",
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/architecture-note.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/architecture-note.md
@@ -1,0 +1,30 @@
+# Address Review Threads Architecture Note
+
+This note records why `gh-address-review-threads` currently keeps a flat/generic packet workflow and when that decision should be revisited.
+
+## Why Flat Stays
+
+- The core output is a local `thread_actions` execution plan, not a reusable cross-packet candidate inventory.
+- Final adjudication stays local because each unresolved thread still needs local ownership checks, reply wording, fix application, and mutation gating.
+- Workers analyze one `thread-batch` or one singleton `thread` packet at a time and return proposal-grade findings; they do not emit decision-ready candidates.
+- The deterministic boundary that matters most here is `collect -> build -> validate -> apply`, so the workflow gains more from a strong flat contract than from an extra hierarchical synthesis layer.
+
+## What The Flat Contract Means
+
+- `decision_ready_packets=false`
+- `worker_return_contract=generic`
+- `worker_output_shape=flat`
+- `packet_worker_map` routes only delegated `thread-batch-*` and eligible singleton `thread-*` packets.
+- The local agent owns final decisions, final reply text, pushes, and thread resolution.
+- Token-efficiency retrofit does not imply hierarchy here; runtime routing stays flat and token metrics stay evaluation-side.
+
+## When To Revisit Hierarchy
+
+Revisit a hierarchical result model if two or more of these become normal workflow patterns:
+
+- local code repeatedly reassembles worker findings into candidate-like intermediate structures
+- per-thread ambiguity or reread control becomes a recurring candidate-management problem
+- one thread decision regularly depends on combining findings from multiple packets
+- apply-time logic starts reconstructing something equivalent to `candidates[] + footer`
+
+Until those conditions appear, a flat/generic contract is the simpler and more stable shape for this skill.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/comment-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/comment-contract.md
@@ -1,0 +1,33 @@
+# Comment Contract
+
+Keep replies short, factual, and thread-local. Do not repeat the whole thread history.
+When updating an existing reply, preserve any still-accurate text and edit only what is required to satisfy the marker, decision, implementation, or validation requirements.
+
+## Acknowledgement Reply
+
+Start with the exact `ack` marker on line 1.
+
+Then include:
+- one short sentence summarizing what the reviewer is asking
+- one short sentence with `accept`, `reject`, `defer`, or `defer-outdated`
+- if accepted, one short sentence describing the implementation direction or immediate validation plan
+- if rejected or deferred, one short sentence with the reason or blocker
+
+## Completion Reply
+
+Start with the exact `complete` marker on line 1.
+
+Then include:
+- one short sentence describing what changed
+- one short sentence listing the validation that actually ran
+- one short sentence for any remaining caveat only if it matters to the reviewer
+
+Use completion replies only for accepted threads that reached implementation, validation, and a push of the relevant change to the PR branch.
+
+## Claims To Avoid
+
+- Do not claim tests ran unless they actually ran.
+- Do not claim behavior changed unless the code change supports it.
+- Do not claim a fix landed until the relevant change is pushed to the PR branch.
+- Do not claim rollout, migration, or compatibility impact unless verified.
+- Do not claim the thread is fully addressed if remaining caveats still block resolution.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/comment-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/comment-contract.md
@@ -6,6 +6,7 @@ When updating an existing reply, preserve any still-accurate text and edit only 
 ## Acknowledgement Reply
 
 Start with the exact `ack` marker on line 1.
+Post the acknowledgement reply before any code edits, validation runs, commits, or pushes for that accepted/rejected/deferred item.
 
 Then include:
 - one short sentence summarizing what the reviewer is asking
@@ -16,6 +17,7 @@ Then include:
 ## Completion Reply
 
 Start with the exact `complete` marker on line 1.
+Post the completion reply only after the relevant fix is pushed to the PR branch.
 
 Then include:
 - one short sentence describing what changed

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/core-contract.md
@@ -108,6 +108,7 @@ Stop conditions:
 
 - Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/core-contract.md
@@ -1,0 +1,117 @@
+# Gh Address Review Threads Core Contract
+
+This file captures the reusable packet-workflow core for the generated `gh-address-review-threads` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+
+## Core Metadata
+
+- `workflow_family`: `github-review`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `thread.json`
+- No additional orchestrator-profile-specific runtime packet is required.
+
+Review mode overrides inherited by default:
+- diff churn exceeds a configured threshold
+- core runtime, config, or process files span multiple groups
+- generated files are present but are not the majority of the change
+
+Authority order:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+## Generic Worker Contract
+
+## Generic Adjudication Structure
+
+- This scaffold uses the `generic` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Generic flat mode does not require hierarchical `candidates[]` plus `footer` worker output.
+
+## Worker Families
+
+- The builder keeps worker-family structure generic and reusable across packet-driven workflows.
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+
+- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:
+- `repo_mapper`
+- `packet_explorer`
+- `docs_verifier`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `batch-packet-01`
+  - `packet_explorer`
+- `thread`
+  - `packet_explorer`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Summary: Default reusable profile scaffold for GitHub review-thread workflows. Replace with project-local review-docs, path bindings, and ownership hints when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `batch-packet-01`
+    - `.github/pull_request_template.md`
+    - `CONTRIBUTING.md`
+  - `thread`
+    - `.github/pull_request_template.md`
+    - `CONTRIBUTING.md`
+- source path globs:
+  - `batch-packet-01`
+    - `**/*`
+  - `thread`
+    - `**/*`
+- Default lint rules:
+- `require_readme_settings_table`: false
+- `missing_review_docs_are_errors`: false
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes
+
+- Optional local helpers remain non-authoritative even when collected.
+- Final plan confidence is recomputed locally even when worker confidence signals are present.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/delegation-playbook.md
@@ -1,0 +1,112 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`
+  - no workers
+- `targeted-delegation`
+  - 1-2 analysis workers
+- `broad-delegation`
+  - 3-4 analysis workers
+- Optional QA worker
+  - only when worker findings conflict or a broad fix needs a second coverage pass
+
+## Packet Order
+
+- Every worker reads `global_packet.json` first.
+- Prefer `thread-batch-*.json` when it exists.
+- Read singleton `thread-*.json` only for threads not covered by a batch.
+- Keep each worker on exactly one routed packet.
+- Treat `packet_worker_map` as the routing authority for delegated thread analysis.
+
+## Shared Context
+
+`global_packet.json` keeps all workers aligned on:
+- PR intent
+- user-visible impact
+- reply-marker rules
+- outdated-thread policy
+- context fingerprint
+- local reply contract
+- code-change delegation guardrails
+- review mode overrides
+- worker selection guidance
+- worker return contract
+- worker output shape
+- xHigh reread policy
+
+Thread packets may also include existing self-authored replies. Keep that context in view and surface any mismatch between the existing reply and the current reviewer request in `problem summary` or `risk` so the main agent can reconcile it before choosing a decision.
+
+## Analysis Worker Contract
+
+Prefer `packet_explorer`.
+
+Return exactly:
+- `thread ids`
+- `problem summary`
+- `fix direction`
+- `risk`
+- `files to edit`
+- `tests to run`
+
+Do not draft the final acknowledgement or completion reply in the worker output. The main agent owns final wording.
+
+## Local Validation Gate
+
+- draft raw `thread_actions` locally
+- run `validate_thread_action_plan.py` before any apply step
+- keep apply on the normalized validator output only
+- if `context_fingerprint` changed, rebuild packets and revalidate instead of forcing apply
+
+## Code-Change Delegation Guardrails
+
+Use a worker for code edits only when all of these are true:
+- one batch or one thread
+- two files or fewer
+- one subsystem
+- no schema, public interface, config, or workflow changes
+- validation path is clear
+
+If any guardrail fails, keep the implementation local and use mini workers only for analysis.
+
+## QA Pass
+
+Prefer `large_diff_auditor` or explicit `gpt-5.4-mini`.
+
+Provide:
+- `global_packet.json`
+- the relevant `thread-batch-*.json` or `thread-*.json`
+- the proposed completion reply
+- the changed files or diff slice being resolved
+
+Require:
+- `thread ids`
+- `resolution verdict`
+- `coverage gaps`
+- `unsupported claims`
+- `remaining risk`
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $gh-address-review-threads at <skill-path> to analyze PR review-thread packets.
+
+Read only:
+- <global-packet>
+- <thread-batch-or-thread-packets>
+- <specific file slice if needed>
+
+Return exactly:
+- thread ids
+- problem summary
+- fix direction
+- risk
+- files to edit
+- tests to run
+```
+
+Keep each worker narrow. Do not ask a worker to reread the whole PR conversation or whole diff.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as build, lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/gh-address-review-threads-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/gh-address-review-threads-evaluation-contract.md
@@ -1,0 +1,85 @@
+# Address Review Threads Evaluation Contract
+
+Use the shared envelope in [`evaluation-log-contract.md`](evaluation-log-contract.md) and keep workflow-specific metrics under `skill_specific.data`.
+
+## Recommended Domain Fields
+
+Record only workflow-specific counters and boundary signals that do not fit cleanly in the shared envelope.
+
+Recommended fields:
+- `pr_number`
+- `review_mode`
+- `packet_count`
+- `worker_count`
+- `thread_batch_count`
+- `singleton_thread_packet_count`
+- `common_path_sufficient`
+- `threads_seen`
+- `threads_accepted`
+- `threads_rejected`
+- `threads_deferred`
+- `threads_defer_outdated`
+- `threads_resolved`
+- `outdated_threads_seen`
+- `marker_conflicts`
+- `marker_conflicts_warning`
+- `marker_conflicts_adoption_blocking`
+- `marker_conflicts_hard_stop`
+- `adopted_unmarked_reply_count`
+- `skipped_outdated_count`
+- `invalid_complete_count`
+- `resolve_after_complete_count`
+- `validation_commands`
+- `final_pr_url`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+
+## Thread Decision Metrics
+
+Track the per-run decision counts separately from the raw thread total.
+
+- `threads_seen`
+  - total unresolved threads seen at collection time
+- `threads_accepted`
+  - threads that reached implementation and completion
+- `threads_rejected`
+  - threads the main agent explicitly rejected
+- `threads_deferred`
+  - threads intentionally left unresolved for now
+- `threads_defer_outdated`
+  - threads deferred because the reviewer comment is stale against current `HEAD`
+- `threads_resolved`
+  - threads actually resolved after completion
+
+## Boundary Signals
+
+- `outdated_threads_seen`
+  - count unresolved outdated threads surfaced by collection
+- `marker_conflicts`
+  - count threads with existing managed-reply marker conflicts
+- `marker_conflicts_warning`
+  - count warning-only conflict records
+- `marker_conflicts_adoption_blocking`
+  - count adoption-blocking conflict records
+- `marker_conflicts_hard_stop`
+  - count hard-stop conflict records
+
+## Validator And Apply Counters
+
+- `adopted_unmarked_reply_count`
+  - count updates that safely reused the validator fallback from an unmarked self-authored reply
+- `skipped_outdated_count`
+  - count actions normalized to `decision=defer-outdated`
+- `invalid_complete_count`
+  - count invalid complete-phase attempts rejected by validation
+- `resolve_after_complete_count`
+  - count accepted complete actions that requested thread resolution
+
+## Expected Behavior
+
+- Keep full thread discussion bodies out of the evaluation log unless a debugging path explicitly requires them.
+- Prefer counts, booleans, enums, and short reason lists over free-form summaries.
+- Keep the contract aligned with the local reply markers, per-thread decision model, and push-before-complete rule.
+- Build-phase review mode, worker derivation, packet/thread counts, and `common_path_sufficient` come from the build result JSON.
+- Size and token-proxy metrics come only from `packet_metrics.json`.
+- `packet_metrics.json` is evaluation-only and must not be treated as a runtime routing source.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/gh-address-review-threads-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/gh-address-review-threads-evaluation-contract.md
@@ -21,6 +21,9 @@ Recommended fields:
 - `threads_defer_outdated`
 - `threads_resolved`
 - `outdated_threads_seen`
+- `outdated_transition_candidates`
+- `outdated_auto_resolved`
+- `outdated_recheck_ambiguous`
 - `marker_conflicts`
 - `marker_conflicts_warning`
 - `marker_conflicts_adoption_blocking`
@@ -55,6 +58,12 @@ Track the per-run decision counts separately from the raw thread total.
 
 - `outdated_threads_seen`
   - count unresolved outdated threads surfaced by collection
+- `outdated_transition_candidates`
+  - count unresolved threads that were non-outdated before this run's push and outdated after the push
+- `outdated_auto_resolved`
+  - count transitioned outdated threads that reused the normal accepted completion-and-resolve path
+- `outdated_recheck_ambiguous`
+  - count transitioned outdated threads that stayed unresolved because current-`HEAD` proof was missing or unclear
 - `marker_conflicts`
   - count threads with existing managed-reply marker conflicts
 - `marker_conflicts_warning`
@@ -81,5 +90,7 @@ Track the per-run decision counts separately from the raw thread total.
 - Prefer counts, booleans, enums, and short reason lists over free-form summaries.
 - Keep the contract aligned with the local reply markers, per-thread decision model, and push-before-complete rule.
 - Build-phase review mode, worker derivation, packet/thread counts, and `common_path_sufficient` come from the build result JSON.
+- Same-run outdated-transition candidate and ambiguous-recheck counts may come from the build result JSON.
+- Final same-run outdated auto-resolve counts come from the apply result `reconciliation_summary`.
 - Size and token-proxy metrics come only from `packet_metrics.json`.
 - `packet_metrics.json` is evaluation-only and must not be treated as a runtime routing source.

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/review-threads-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/review-threads-contract.md
@@ -118,6 +118,10 @@ Keep shared workflow facts here:
 - PR identity and URL
 - reply marker policy
 - outdated-thread policy
+- `same_run_reconciliation`
+  - whether post-push same-run reconciliation is enabled
+  - transitioned thread ids
+  - counts for transitioned candidates, auto-resolve candidates, and ambiguous rechecks
 - code-change delegation guardrails
 - disallowed claims
 - diff summary and review overrides
@@ -140,6 +144,16 @@ Each `thread-*.json` packet keeps:
 - `ownership_summary`
 - `reply_update_basis`
 - `quality_escape_hints`
+- `transitioned_to_outdated` when the thread was unresolved and non-outdated before this run's push, then unresolved and outdated after the push
+- `outdated_recheck` for same-run transitioned outdated threads:
+  - `previous_snapshot`
+  - `original_request`
+  - `same_run_acceptance`
+  - `validation_provenance`
+  - `current_head_evidence`
+  - `resolution_verdict`
+  - `verdict_reason`
+  - `auto_resolution_candidate`
 
 Each `thread-batch-*.json` packet keeps:
 - batch identity and clustering reason
@@ -158,7 +172,7 @@ Each `thread-batch-*.json` packet keeps:
   - `thread-batch-*.json`
   - `thread-*.json`
 - eval-side artifacts:
-  - build result JSON for review mode, worker derivation, packet/thread counts, override signals, and `common_path_sufficient`
+  - build result JSON for review mode, worker derivation, packet/thread counts, override signals, `common_path_sufficient`, and same-run outdated-transition counters
   - `packet_metrics.json` for size and token-proxy metrics only
 - do not duplicate token-efficiency counters into runtime packets
 
@@ -184,6 +198,7 @@ Each `thread-batch-*.json` packet keeps:
   - note the remaining caveat only if it matters
 
 Resolve only accepted threads after the relevant change is pushed and validation is complete.
+Same-run outdated transitions may reuse the normal accepted completion-and-resolve path only when `current HEAD` already proves the request is satisfied.
 
 ## Thread Action Validation
 

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/review-threads-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/review-threads-contract.md
@@ -1,0 +1,200 @@
+# Review Threads Contract
+
+This file defines the packet, worker, and reply contract for the `gh-address-review-threads` skill.
+
+For the workflow-shape rationale and the criteria for revisiting hierarchy, read [`architecture-note.md`](architecture-note.md).
+
+## Builder Metadata
+
+- `workflow_family`: `github-review`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Required Packet Outputs
+
+- `orchestrator.json`
+- `global_packet.json`
+- `thread-batch-*.json` when clustered non-outdated threads share one fix surface
+- `thread-*.json` for every unresolved thread
+
+## Canonical Context Fields
+
+- `context_fingerprint`
+  - top-level collect fingerprint for the current unresolved-thread snapshot
+  - must match across collect, build, validate, and apply in one run
+- `reply_candidates`
+  - canonical shape:
+```json
+{
+  "ack": {
+    "mode": "add|update",
+    "comment_id": "123",
+    "reason": "exact_managed_reply|adopt_latest_unmarked_reply_after_reviewer|no_existing_ack_reply",
+    "managed": true,
+    "adopted_unmarked_reply": false
+  },
+  "complete": {
+    "mode": "add|update",
+    "comment_id": "456",
+    "reason": "exact_managed_reply|complete_never_adopts_unmarked_reply",
+    "managed": true,
+    "adopted_unmarked_reply": false
+  }
+}
+```
+- `marker_conflicts`
+  - canonical shape is a severity-bearing object list
+  - fields:
+    - `phase`
+    - `severity`
+    - `reason`
+    - `comment_ids`
+    - `blocks_adoption`
+    - `blocks_update`
+    - `blocks_apply`
+
+## Authority Order
+
+Use evidence in this order:
+- the current PR thread discussion and latest reviewer request
+- current `HEAD` code and directly inspected diff slices
+- managed reply markers and current self-authored replies
+- repository PR guidance and validation output
+- packet summaries and worker findings
+
+## Worker Routing Metadata
+
+- `packet_worker_map`
+  - each delegated `thread-batch-*` packet routes to `packet_explorer`
+  - each delegated non-outdated singleton `thread-*` packet routes to `packet_explorer`
+- optional QA pass
+  - `large_diff_auditor`
+
+Rules:
+- `packet_worker_map` is the routing authority for delegated thread analysis
+- `preferred_worker_families` is registry metadata only
+- `recommended_workers` and `optional_workers` are derived convenience fields only
+- final per-thread decisions, reply wording, pushes, and resolution stay local
+- runtime logic must never infer routing from `preferred_worker_families` or `optional_workers`
+
+## Common-Path Contract
+
+- default local adjudication basis:
+  - `global_packet.json + one thread-batch packet`
+  - `global_packet.json + one thread packet`
+- allowed reread reasons:
+  - `conflicting_signals`
+  - `missing_required_evidence`
+  - `insufficient_excerpt_quality`
+  - `ownership_ambiguity`
+  - `stale_context`
+- `common_path_sufficient == true` only when all of these hold:
+  - required evidence is present inside the packet set used for the decision
+  - ownership ambiguity stays below the escape threshold
+  - no explicit reread or escape reason is required
+  - a validator-ready recommendation path is closed from packet contents alone
+- `review_mode_overrides` may widen worker recommendation or review mode, but they must not upgrade missing evidence, ownership ambiguity, or reread need into `common_path_sufficient=true`
+- `quality_escape_hints` is advisory only; explicit reread or escape decisions must still use the allowed reason enum or an explicit stop
+
+## Marker Conflict Stop Rules
+
+| Severity | Meaning | Validate | Apply |
+|---|---|---|---|
+| `warning` | latest exact managed target is unique and older duplicates remain | allow, record warning | allow |
+| `adoption-blocking` | unmarked reply adoption path is unsafe | block adoption-based fallback update only | same |
+| `hard-stop` | target ambiguity or marker corruption | block any non-`skip` action for the phase | same |
+
+Notes:
+- `adoption-blocking` does not block `add`.
+- `adoption-blocking` allows `update` only when an explicit comment id targets the current exact managed reply.
+- `hard-stop` allows only `skip` for the affected phase.
+
+## Global Packet Semantics
+
+Keep shared workflow facts here:
+- PR identity and URL
+- reply marker policy
+- outdated-thread policy
+- code-change delegation guardrails
+- disallowed claims
+- diff summary and review overrides
+- `context_fingerprint`
+- `marker_conflict_summary`
+- `preferred_worker_families`
+- `packet_worker_map`
+- `routing_contract`
+
+## Thread Packet Semantics
+
+Each `thread-*.json` packet keeps:
+- thread identity and path
+- reviewer comment summary
+- existing self reply and managed reply candidates
+- canonical `marker_conflicts`
+- file snippet and diff snippet
+- small-fix applicability hints
+- `validation_candidates`
+- `ownership_summary`
+- `reply_update_basis`
+- `quality_escape_hints`
+
+Each `thread-batch-*.json` packet keeps:
+- batch identity and clustering reason
+- shared file context
+- grouped thread ids
+- one narrow fix surface that can be analyzed together
+- `shared_fix_surface`
+- `validation_candidates`
+- `quality_escape_hints`
+
+## Runtime Vs Eval Artifacts
+
+- runtime contract:
+  - `orchestrator.json`
+  - `global_packet.json`
+  - `thread-batch-*.json`
+  - `thread-*.json`
+- eval-side artifacts:
+  - build result JSON for review mode, worker derivation, packet/thread counts, override signals, and `common_path_sufficient`
+  - `packet_metrics.json` for size and token-proxy metrics only
+- do not duplicate token-efficiency counters into runtime packets
+
+## Smoke Modes
+
+- live operator smoke:
+  - uses the current-branch PR
+  - may return `blocked` or `noop` with the fixed `status/reason/thread_counts/next_action` schema
+- synthetic reference smoke:
+  - uses a temp fixture and no live GitHub state
+  - must exercise collect-equivalent context, build, validate, apply `--dry-run`, and evaluation merge end to end
+- both smoke modes keep the short summary schema at the top level
+
+## Reply And Resolution Rules
+
+- `ack`
+  - summarize the reviewer request
+  - state accept, reject, defer, or defer-outdated
+  - state the implementation direction or blocker
+- `complete`
+  - summarize what changed
+  - list validation that actually ran
+  - note the remaining caveat only if it matters
+
+Resolve only accepted threads after the relevant change is pushed and validation is complete.
+
+## Thread Action Validation
+
+- raw `thread_actions` must be normalized before apply
+- normalized actions are sorted by:
+  - `path`
+  - `line or original_line or 0`
+  - `thread_id`
+- `apply_thread_action_plan.py` consumes only the normalized validator output
+- `update` requires:
+  - explicit `*_comment_id`, or
+  - `reply_candidates.<phase>.comment_id` fallback
+- `update` with no explicit or fallback id fails with:
+  - `missing_update_target`

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/references/thread-action-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/references/thread-action-contract.md
@@ -1,0 +1,79 @@
+# Thread Action Contract
+
+This file defines the canonical `thread_actions` contract shared by the validator, apply script, tests, and smoke workflows.
+
+For the rationale behind keeping the workflow flat/generic, read [`architecture-note.md`](architecture-note.md).
+
+## Source Of Truth
+
+- `scripts/thread_action_contract.py`
+  - canonical field policy
+  - canonical validation codes
+  - context fingerprint rules
+  - deterministic action ordering
+
+## Phase Field Policy
+
+`ack`
+- mode field: `ack_mode`
+- body field: `ack_body`
+- comment id field: `ack_comment_id`
+- allowed modes: `add`, `update`, `skip`
+- body required for: `add`, `update`
+- comment id rules:
+  - `add`: ignore explicit id
+  - `update`: use explicit id first, then `reply_candidates.ack.comment_id`
+  - `skip`: ignore explicit id
+
+`complete`
+- mode field: `complete_mode`
+- body field: `complete_body`
+- comment id field: `complete_comment_id`
+- allowed modes: `add`, `update`, `skip`
+- body required for: `add`, `update`
+- comment id rules:
+  - `add`: ignore explicit id
+  - `update`: use explicit id first, then `reply_candidates.complete.comment_id`
+  - `skip`: ignore explicit id
+- extra rules:
+  - `complete` actions are valid only for `decision=accept`
+  - `resolve_after_complete` is valid only when `complete_mode != skip`
+
+## Deterministic Ordering
+
+Normalized actions must always sort by:
+- `path`
+- `line or original_line or 0`
+- `thread_id`
+
+This ordering uses the current context thread metadata, not the input plan order.
+
+## Warning Codes
+
+- `unknown_action_field_ignored`
+- `ignored_comment_id_for_add`
+- `ignored_comment_id_for_skip`
+- `ignored_body_for_skip`
+- `ignored_resolve_after_complete_outside_complete`
+
+## Error Codes
+
+- `invalid_plan_shape`
+- `missing_thread_id`
+- `unknown_thread_id`
+- `invalid_decision`
+- `invalid_mode`
+- `missing_required_body`
+- `missing_update_target`
+- `invalid_complete_for_non_accept`
+- `invalid_resolve_after_complete`
+- `adoption_blocked_update`
+- `hard_stop_marker_conflict`
+- `stale_context_fingerprint`
+
+## Apply Boundary
+
+- `apply_thread_action_plan.py` must consume only the normalized validator output
+- raw `thread_actions` JSON is never a valid apply input
+- `apply --dry-run` follows the same rule and must not bypass normalization
+- apply must stop when the normalized plan `context_fingerprint` does not match the current context

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/apply_thread_action_plan.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/apply_thread_action_plan.py
@@ -257,6 +257,8 @@ def main() -> int:
             ],
             "mutation_type": operations[0]["operation"] if operations else None,
         }
+        if isinstance(validated.get("reconciliation_summary"), dict):
+            payload["reconciliation_summary"] = validated["reconciliation_summary"]
         write_json_output(args.result_output, payload)
         print(json.dumps(payload, indent=2, ensure_ascii=True))
         return 0
@@ -304,6 +306,8 @@ def main() -> int:
         ],
         "mutation_type": results[0]["operation"] if results else None,
     }
+    if isinstance(validated.get("reconciliation_summary"), dict):
+        payload["reconciliation_summary"] = validated["reconciliation_summary"]
     write_json_output(args.result_output, payload)
     print(json.dumps(payload, indent=2, ensure_ascii=True))
     return 0

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/apply_thread_action_plan.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/apply_thread_action_plan.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Apply acknowledgement and completion actions for PR review threads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from thread_action_contract import load_normalized_plan_envelope
+
+
+PHASES = {"ack", "complete"}
+DECISIONS = {"accept", "reject", "defer", "defer-outdated"}
+MARKER_PREFIX = "<!-- codex:review-thread v1 phase={phase} thread={thread_id} -->"
+MANAGED_MARKER_START = "<!-- codex:review-thread v1 "
+
+ADD_REPLY_MUTATION = """\
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(
+    input: {
+      pullRequestReviewThreadId: $threadId
+      body: $body
+    }
+  ) {
+    comment {
+      id
+      url
+    }
+  }
+}
+"""
+
+UPDATE_REPLY_MUTATION = """\
+mutation($commentId: ID!, $body: String!) {
+  updatePullRequestReviewComment(
+    input: {
+      pullRequestReviewCommentId: $commentId
+      body: $body
+    }
+  ) {
+    pullRequestReviewComment {
+      id
+      url
+    }
+  }
+}
+"""
+
+RESOLVE_THREAD_MUTATION = """\
+mutation($threadId: ID!) {
+  resolveReviewThread(
+    input: {
+      threadId: $threadId
+    }
+  ) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}
+"""
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def decode_text(data: bytes) -> str:
+    return data.decode("utf-8", errors="replace")
+
+
+def run_json(args: list[str], cwd: Path, stdin_text: str | None = None) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=str(cwd),
+            input=(stdin_text.encode("utf-8") if stdin_text is not None else None),
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        command_name = args[0] if args else "command"
+        raise RuntimeError(f"{command_name} executable not found") from exc
+    if result.returncode != 0:
+        stderr = decode_text(result.stderr).strip()
+        stdout = decode_text(result.stdout).strip()
+        detail = stderr or stdout or "command failed"
+        raise RuntimeError(f"{' '.join(args)}: {detail}")
+    try:
+        return json.loads(decode_text(result.stdout))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"failed to parse JSON from {' '.join(args)}: {exc}") from exc
+
+
+def ensure_marker(body: str, phase: str, thread_id: str) -> str:
+    body = body.strip()
+    marker = MARKER_PREFIX.format(phase=phase, thread_id=thread_id)
+    if body.startswith(marker):
+        return body
+    if body.startswith(MANAGED_MARKER_START):
+        _first_line, _sep, rest = body.partition("\n")
+        return marker if not rest else marker + "\n" + rest.lstrip("\n")
+    return marker if not body else marker + "\n" + body
+
+
+def thread_lookup(context: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(thread["thread_id"]): thread for thread in context.get("threads", [])}
+
+
+def phase_fields(phase: str) -> tuple[str, str, str]:
+    if phase == "ack":
+        return "ack_mode", "ack_body", "ack_comment_id"
+    return "complete_mode", "complete_body", "complete_comment_id"
+
+
+def fallback_comment_id(thread: dict[str, Any], phase: str) -> str | None:
+    candidates = (thread.get("reply_candidates") or {}).get(phase) or {}
+    comment_id = candidates.get("comment_id")
+    return str(comment_id) if comment_id else None
+
+
+def graphql(repo_root: Path, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    args = ["gh", "api", "graphql", "-F", "query=@-"]
+    for key, value in variables.items():
+        args.extend(["-F", f"{key}={value}"])
+    payload = run_json(args, cwd=repo_root, stdin_text=query)
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"], indent=2, ensure_ascii=True))
+    return payload
+
+
+def write_json_output(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply acknowledgement and completion actions for PR review threads."
+    )
+    parser.add_argument("--context", type=Path, required=True, help="Path to JSON from collect_review_threads.py")
+    parser.add_argument(
+        "--plan",
+        type=Path,
+        required=True,
+        help="Path to normalized validation JSON from validate_thread_action_plan.py",
+    )
+    parser.add_argument("--phase", choices=sorted(PHASES), required=True, help="Action phase to apply")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned mutations without calling GitHub")
+    parser.add_argument(
+        "--result-output",
+        type=Path,
+        help="Optional path to write the JSON result payload.",
+    )
+    args = parser.parse_args()
+
+    context = load_json(args.context)
+    plan = load_json(args.plan)
+    repo_root = Path(str(context.get("repo_root") or ".")).resolve()
+    validated = load_normalized_plan_envelope(context, plan, args.phase)
+    entries = list(validated["normalized_thread_actions"])
+    threads_by_id = thread_lookup(context)
+    mode_field, body_field, comment_id_field = phase_fields(args.phase)
+
+    operations: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+
+    for entry in entries:
+        thread_id = str(entry.get("thread_id") or "")
+        if not thread_id:
+            raise RuntimeError("each plan entry must include thread_id")
+        if thread_id not in threads_by_id:
+            raise RuntimeError(f"thread_id {thread_id} is not present in the context")
+        decision = str(entry.get("decision") or "")
+        if decision not in DECISIONS:
+            raise RuntimeError(f"thread {thread_id}: invalid decision `{decision}`")
+
+        thread = threads_by_id[thread_id]
+        mode = str(entry.get(mode_field) or "skip")
+        if mode not in {"add", "update", "skip"}:
+            raise RuntimeError(f"thread {thread_id}: invalid {mode_field} `{mode}`")
+        if args.phase == "complete" and decision != "accept" and mode != "skip":
+            raise RuntimeError(f"thread {thread_id}: complete actions are only valid for accepted threads")
+
+        body = str(entry.get(body_field) or "")
+        if mode != "skip" and not body.strip():
+            raise RuntimeError(f"thread {thread_id}: {body_field} is required when {mode_field} is {mode}")
+
+        target_comment_id = entry.get(comment_id_field) or fallback_comment_id(thread, args.phase)
+        if mode == "update" and not target_comment_id:
+            raise RuntimeError(f"thread {thread_id}: update requested but no comment id was supplied or inferred")
+
+        if mode != "skip":
+            managed_body = ensure_marker(body, args.phase, thread_id)
+            if mode == "add":
+                operations.append(
+                    {
+                        "thread_id": thread_id,
+                        "phase": args.phase,
+                        "operation": "add_reply",
+                        "variables": {
+                            "threadId": thread_id,
+                            "body": managed_body,
+                        },
+                    }
+                )
+            else:
+                operations.append(
+                    {
+                        "thread_id": thread_id,
+                        "phase": args.phase,
+                        "operation": "update_reply",
+                        "variables": {
+                            "commentId": str(target_comment_id),
+                            "body": managed_body,
+                        },
+                    }
+                )
+
+        if args.phase == "complete" and decision == "accept" and bool(entry.get("resolve_after_complete")):
+            operations.append(
+                {
+                    "thread_id": thread_id,
+                    "phase": args.phase,
+                    "operation": "resolve_thread",
+                    "variables": {
+                        "threadId": thread_id,
+                    },
+                }
+            )
+
+    if args.dry_run:
+        payload = {
+            "dry_run": True,
+            "apply_succeeded": True,
+            "fingerprint_match": bool(validated.get("fingerprint_match")),
+            "context_fingerprint": validated.get("context_fingerprint"),
+            "phase": args.phase,
+            "counters": validated.get("counters", {}),
+            "warnings": validated.get("warnings", []),
+            "normalized_thread_actions": entries,
+            "operations": operations,
+            "mutations": [
+                {
+                    "kind": operation["operation"],
+                    "thread_id": operation["thread_id"],
+                    "phase": operation["phase"],
+                }
+                for operation in operations
+            ],
+            "mutation_type": operations[0]["operation"] if operations else None,
+        }
+        write_json_output(args.result_output, payload)
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+        return 0
+
+    for operation in operations:
+        op_type = operation["operation"]
+        variables = dict(operation["variables"])
+        if op_type == "add_reply":
+            payload = graphql(repo_root, ADD_REPLY_MUTATION, variables)
+            response = payload["data"]["addPullRequestReviewThreadReply"]["comment"]
+        elif op_type == "update_reply":
+            payload = graphql(repo_root, UPDATE_REPLY_MUTATION, variables)
+            response = payload["data"]["updatePullRequestReviewComment"]["pullRequestReviewComment"]
+        elif op_type == "resolve_thread":
+            payload = graphql(repo_root, RESOLVE_THREAD_MUTATION, variables)
+            response = payload["data"]["resolveReviewThread"]["thread"]
+        else:
+            raise RuntimeError(f"unknown operation type {op_type}")
+        results.append(
+            {
+                "thread_id": operation["thread_id"],
+                "phase": operation["phase"],
+                "operation": op_type,
+                "result": response,
+            }
+        )
+
+    payload = {
+        "dry_run": False,
+        "apply_succeeded": True,
+        "fingerprint_match": bool(validated.get("fingerprint_match")),
+        "context_fingerprint": validated.get("context_fingerprint"),
+        "phase": args.phase,
+        "counters": validated.get("counters", {}),
+        "warnings": validated.get("warnings", []),
+        "normalized_thread_actions": entries,
+        "results": results,
+        "mutations": [
+            {
+                "kind": item["operation"],
+                "thread_id": item["thread_id"],
+                "phase": item["phase"],
+            }
+            for item in results
+        ],
+        "mutation_type": results[0]["operation"] if results else None,
+    }
+    write_json_output(args.result_output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"apply_thread_action_plan.py: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/build_review_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/build_review_packets.py
@@ -1,0 +1,1080 @@
+#!/usr/bin/env python3
+"""Build packet artifacts for token-efficient PR review-thread handling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from thread_action_contract import context_fingerprint, marker_conflict_summary, normalize_marker_conflicts
+from review_thread_packet_contract import (
+    ARCHETYPE,
+    BROAD_TARGET_LIMIT,
+    CHURN_OVERRIDE_LIMIT,
+    COMMON_PATH_CONTRACT,
+    DECISION_READY_PACKETS,
+    LOCAL_THREAD_LIMIT,
+    MEANINGFUL_GENERATED_FILE_MIN_COUNT,
+    MEANINGFUL_GENERATED_FILE_MIN_RATIO,
+    ORCHESTRATOR_PROFILE,
+    PREFERRED_WORKER_FAMILIES,
+    TARGETED_THREAD_LIMIT,
+    WORKER_OUTPUT_SHAPE,
+    WORKER_RETURN_CONTRACT,
+    WORKFLOW_FAMILY,
+    XHIGH_REREAD_POLICY,
+    build_result_payload,
+    compute_packet_metrics,
+    derive_optional_workers,
+    derive_packet_worker_map,
+    derive_recommended_workers,
+)
+
+
+SNIPPET_RADIUS = 12
+DIFF_SNIPPET_CHAR_LIMIT = 2200
+GENERATED_FILE_PATTERNS = (
+    re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
+    re.compile(r"\.(g|generated)\.[^.]+$"),
+    re.compile(r"\.designer\.[^.]+$"),
+    re.compile(r"(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|cargo\.lock)$"),
+    re.compile(r"\.min\.(js|css)$"),
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def parse_markdown_headings(markdown_text: str | None) -> list[str]:
+    if not markdown_text:
+        return []
+    return [line[3:].strip() for line in markdown_text.splitlines() if line.startswith("## ")]
+
+
+def section_bodies(markdown_text: str | None) -> dict[str, str]:
+    if not markdown_text:
+        return {}
+    sections: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                sections[current] = "\n".join(buffer).strip()
+            current = line[3:].strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        sections[current] = "\n".join(buffer).strip()
+    return sections
+
+
+def parse_diff_totals(diff_stat: str | None) -> dict[str, int] | None:
+    if not diff_stat:
+        return None
+    last_line = diff_stat.strip().splitlines()[-1]
+    files_match = re.search(r"(?P<files>\d+) files? changed", last_line)
+    insertions_match = re.search(r"(?P<insertions>\d+) insertions?\(\+\)", last_line)
+    deletions_match = re.search(r"(?P<deletions>\d+) deletions?\(-\)", last_line)
+    if not files_match and not insertions_match and not deletions_match:
+        return None
+    files_changed = int(files_match.group("files")) if files_match else 0
+    insertions = int(insertions_match.group("insertions")) if insertions_match else 0
+    deletions = int(deletions_match.group("deletions")) if deletions_match else 0
+    return {
+        "files_changed": files_changed,
+        "insertions": insertions,
+        "deletions": deletions,
+        "churn": insertions + deletions,
+    }
+
+
+def classify_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    lower = normalized.lower()
+    if (
+        "/tests/" in lower
+        or lower.endswith("_test.py")
+        or lower.endswith(".tests.cs")
+        or lower.endswith(".spec.ts")
+        or lower.startswith(".github/scripts/tests/")
+    ):
+        return "tests"
+    if (
+        lower.startswith(".github/workflows/")
+        or lower.startswith(".github/scripts/")
+        or lower.startswith(".github/issue_template/")
+        or lower.startswith(".github/instructions/")
+    ):
+        return "automation"
+    if lower.endswith(".md") or lower.startswith("docs/"):
+        return "docs"
+    if lower.endswith((".yml", ".yaml", ".toml", ".json", ".csproj", ".props", ".targets")):
+        return "config"
+    if lower.endswith((".cs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java")):
+        return "runtime"
+    return "other"
+
+
+def core_area_for_path(path: str) -> str | None:
+    lower = path.replace("\\", "/").lower()
+    runtime_prefixes = (
+        "src/",
+        "lib/",
+        "app/",
+        "server/",
+        "client/",
+    )
+    runtime_files: set[str] = set()
+    process_prefixes = (
+        ".github/workflows/",
+        ".github/scripts/",
+        ".github/issue_template/",
+        ".github/instructions/",
+    )
+    process_files = {
+        ".github/pull_request_template.md",
+        "contributing.md",
+        "maintaining.md",
+    }
+    config_files = {
+        "pyproject.toml",
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "poetry.lock",
+        "cargo.lock",
+    }
+    if lower.startswith(runtime_prefixes) or lower in runtime_files:
+        return "runtime"
+    if lower.startswith(process_prefixes) or lower in process_files:
+        return "process"
+    if lower.endswith((".csproj", ".props", ".targets")) or lower in config_files:
+        return "config"
+    return None
+
+
+def is_generated_file(path: str) -> bool:
+    lowered = path.replace("\\", "/").lower()
+    return any(pattern.search(lowered) for pattern in GENERATED_FILE_PATTERNS)
+
+
+def run_git(repo_root: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    return result.stdout
+
+
+def guidance_paths(repo_root: Path) -> dict[str, str]:
+    candidates = {
+        "pull_request_instructions": ".github/instructions/pull-request.instructions.md",
+        "pull_request_template": ".github/pull_request_template.md",
+        "commit_message_instructions": ".github/instructions/commit-message.instructions.md",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "contributing": "CONTRIBUTING.md",
+        "maintaining": "MAINTAINING.md",
+    }
+    result: dict[str, str] = {}
+    for key, relative_path in candidates.items():
+        path = repo_root / relative_path
+        if path.exists():
+            result[key] = str(path)
+    return result
+
+
+def make_line_snippet(path: Path, line_number: int | None, radius: int = SNIPPET_RADIUS) -> str | None:
+    if not path.is_file():
+        return None
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        return None
+    target = line_number if line_number and line_number > 0 else 1
+    target = min(max(target, 1), len(lines))
+    start = max(target - radius, 1)
+    end = min(target + radius, len(lines))
+    return "\n".join(f"{index:>5}: {lines[index - 1]}" for index in range(start, end + 1))
+
+
+def diff_range_candidates(base_ref: str | None, head_ref: str | None) -> list[str]:
+    if not base_ref or not head_ref:
+        return []
+    return [
+        f"{base_ref}..{head_ref}",
+        f"origin/{base_ref}..{head_ref}",
+        f"{base_ref}..origin/{head_ref}",
+        f"origin/{base_ref}..origin/{head_ref}",
+    ]
+
+
+def diff_snippet_for_path(
+    repo_root: Path,
+    base_ref: str | None,
+    head_ref: str | None,
+    path: str,
+    line_number: int | None,
+    cache: dict[str, str | None],
+) -> str | None:
+    if path in cache:
+        return cache[path]
+    normalized_path = path.replace("\\", "/")
+    full_diff = None
+    for revision_range in diff_range_candidates(base_ref, head_ref):
+        output = run_git(repo_root, ["diff", "-U3", revision_range, "--", normalized_path])
+        if output.strip():
+            full_diff = output
+            break
+    if not full_diff:
+        cache[path] = None
+        return None
+    if line_number is None or len(full_diff) <= DIFF_SNIPPET_CHAR_LIMIT:
+        cache[path] = full_diff[:DIFF_SNIPPET_CHAR_LIMIT].rstrip()
+        return cache[path]
+    hunk_pattern = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@", re.MULTILINE)
+    matches = list(hunk_pattern.finditer(full_diff))
+    selected = None
+    for index, match in enumerate(matches):
+        start = int(match.group("start"))
+        count = int(match.group("count") or "1")
+        end = start + max(count, 1) + 3
+        if start - 3 <= line_number <= end:
+            next_start = matches[index + 1].start() if index + 1 < len(matches) else len(full_diff)
+            selected = full_diff[match.start():next_start].strip()
+            break
+    if selected is None:
+        selected = full_diff[:DIFF_SNIPPET_CHAR_LIMIT].strip()
+    cache[path] = selected[:DIFF_SNIPPET_CHAR_LIMIT].rstrip()
+    return cache[path]
+
+
+def clean_headline_line(line: str) -> str:
+    text = line.strip()
+    if not text:
+        return ""
+    text = re.sub(r"<!--.*?-->", " ", text)
+    text = re.sub(r"`{3,}.*", " ", text)
+    text = re.sub(r"!\[[^\]]*\]\([^)]+\)", " ", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"https?://\S+", " ", text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"^[*\-+>\s]+", "", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"[*_~]+", "", text)
+    text = re.sub(r"\s+", " ", text).strip().lower()
+    if text in {"nit", "nits", "suggestion", "suggestions", "question", "questions", "please address"}:
+        return ""
+    return text
+
+
+def normalized_headline(body: str) -> str:
+    for raw_line in body.splitlines():
+        cleaned = clean_headline_line(raw_line)
+        if cleaned:
+            return cleaned[:160]
+    return clean_headline_line(body)[:160]
+
+
+def reviewer_headline(thread: dict[str, Any]) -> str:
+    reviewer_comment = thread.get("reviewer_comment") or {}
+    return normalized_headline(str(reviewer_comment.get("body") or ""))
+
+
+def safe_excerpt(text: str | None, limit: int = 220) -> str:
+    if not text:
+        return ""
+    compact = re.sub(r"\s+", " ", text).strip()
+    return compact[: limit - 3] + "..." if len(compact) > limit else compact
+
+
+def comment_summary(comment: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not comment:
+        return None
+    return {
+        "id": comment.get("id"),
+        "author_login": comment.get("author_login"),
+        "created_at": comment.get("created_at"),
+        "updated_at": comment.get("updated_at"),
+        "url": comment.get("url"),
+        "body": comment.get("body"),
+    }
+
+
+def packet_name(prefix: str, index: int) -> str:
+    return f"{prefix}-{index:02d}.json"
+
+
+def candidate_decision(thread: dict[str, Any]) -> str:
+    return "defer-outdated" if thread.get("is_outdated") else "accept"
+
+
+def code_change_policy(path: str) -> dict[str, Any]:
+    area = classify_path(path)
+    core_area = core_area_for_path(path)
+    blockers: list[str] = []
+    if core_area in {"config", "process"}:
+        blockers.append("Touches config or maintainer workflow paths.")
+    if area == "automation":
+        blockers.append("Touches automation files.")
+    return {
+        "small_fix_candidate": area in {"runtime", "tests", "docs"} and not blockers,
+        "blockers": blockers,
+    }
+
+
+def validation_candidates_for_path(path: str, area: str, *, is_outdated: bool) -> list[dict[str, Any]]:
+    if is_outdated:
+        return [
+            {
+                "kind": "outdated-default",
+                "path": path,
+                "basis": "Default to defer-outdated unless current HEAD proves the issue still applies.",
+            }
+        ]
+    if area in {"runtime", "tests"}:
+        return [
+            {
+                "kind": "narrow_validation",
+                "path": path,
+                "basis": "Run the narrowest repo-appropriate check covering this fix surface before completion.",
+            }
+        ]
+    if area == "docs":
+        return [
+            {
+                "kind": "docs_scope_check",
+                "path": path,
+                "basis": "Confirm the wording still matches the current diff scope before replying.",
+            }
+        ]
+    return [
+        {
+            "kind": "local_scope_review",
+            "path": path,
+            "basis": "Re-check config, workflow, or ownership impact locally before accepting and resolving.",
+        }
+    ]
+
+
+def reply_update_basis(reply_candidates: dict[str, Any] | None) -> dict[str, Any]:
+    basis: dict[str, Any] = {}
+    for phase in ("ack", "complete"):
+        candidate = (reply_candidates or {}).get(phase) or {}
+        basis[phase] = {
+            "mode": candidate.get("mode"),
+            "comment_id": candidate.get("comment_id"),
+            "reason": candidate.get("reason"),
+            "managed": bool(candidate.get("managed")),
+            "adopted_unmarked_reply": bool(candidate.get("adopted_unmarked_reply")),
+        }
+    return basis
+
+
+def packet_quality_basis(
+    *,
+    reviewer_bodies: list[str],
+    path: str,
+    path_exists: bool,
+    snippet: str | None,
+    diff_snippet: str | None,
+) -> dict[str, Any]:
+    required_evidence_present = bool(
+        reviewer_bodies
+        and all(body.strip() for body in reviewer_bodies)
+        and path.strip()
+        and path_exists
+        and ((snippet or "").strip() or (diff_snippet or "").strip())
+    )
+    ownership_ambiguous = not path.strip() or not path_exists
+    explicit_escape_reasons: list[str] = []
+    if not required_evidence_present:
+        explicit_escape_reasons.append("missing_required_evidence")
+    if ownership_ambiguous:
+        explicit_escape_reasons.append("ownership_ambiguity")
+    if not ((snippet or "").strip() or (diff_snippet or "").strip()):
+        explicit_escape_reasons.append("insufficient_excerpt_quality")
+    explicit_escape_reasons = list(dict.fromkeys(explicit_escape_reasons))
+    return {
+        "required_evidence_present": required_evidence_present,
+        "ownership_ambiguous": ownership_ambiguous,
+        "explicit_reread_reasons": explicit_escape_reasons,
+        "validator_ready_recommendation_path": required_evidence_present and not explicit_escape_reasons,
+        "common_path_sufficient": required_evidence_present and not ownership_ambiguous and not explicit_escape_reasons,
+    }
+
+
+def quality_escape_hints(
+    quality_basis: dict[str, Any],
+    *,
+    path: str,
+    is_outdated: bool,
+    blockers: list[str] | None = None,
+) -> list[str]:
+    hints: list[str] = []
+    if is_outdated:
+        hints.append("Outdated threads stay defer-outdated by default; only reopen the issue after checking current HEAD.")
+    if "missing_required_evidence" in quality_basis.get("explicit_reread_reasons", []):
+        hints.append(f"Treat missing evidence for {path or '<unknown>'} as a reread trigger only if the packet cannot support a local decision.")
+    if "ownership_ambiguity" in quality_basis.get("explicit_reread_reasons", []):
+        hints.append("Ownership ambiguity is advisory here; record an explicit allowed reason before widening scope or rereading raw diff.")
+    if "insufficient_excerpt_quality" in quality_basis.get("explicit_reread_reasons", []):
+        hints.append("Low-quality excerpts are advisory until an explicit reread reason is recorded.")
+    for blocker in blockers or []:
+        hints.append(f"Blocker: {blocker}")
+    return hints
+
+
+def sort_threads(threads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        threads,
+        key=lambda thread: (
+            str(thread.get("path") or ""),
+            int(thread.get("line") or thread.get("original_line") or 0),
+            str(thread.get("thread_id") or ""),
+        ),
+    )
+
+
+def cluster_non_outdated_threads(threads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    eligible = sort_threads(
+        [thread for thread in threads if not thread.get("is_resolved") and not thread.get("is_outdated")]
+    )
+    used: set[str] = set()
+    batches: list[dict[str, Any]] = []
+
+    by_primary_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for thread in eligible:
+        headline = reviewer_headline(thread)
+        if headline:
+            by_primary_key.setdefault((str(thread.get("path") or ""), headline), []).append(thread)
+
+    for (path, headline), group in by_primary_key.items():
+        if len(group) <= 1:
+            continue
+        batches.append(
+            {
+                "cluster_reason": "same_path_and_normalized_headline",
+                "path": path,
+                "normalized_headline": headline,
+                "reviewer_login": group[0].get("reviewer_login"),
+                "threads": sort_threads(group),
+            }
+        )
+        used.update(str(thread["thread_id"]) for thread in group)
+
+    leftovers = [thread for thread in eligible if str(thread["thread_id"]) not in used]
+    by_fallback_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for thread in leftovers:
+        by_fallback_key.setdefault(
+            (str(thread.get("path") or ""), str(thread.get("reviewer_login") or "")),
+            [],
+        ).append(thread)
+
+    for (path, reviewer_login), group in by_fallback_key.items():
+        group = sort_threads(group)
+        if len(group) <= 1:
+            continue
+        current_cluster = [group[0]]
+        for thread in group[1:]:
+            previous = current_cluster[-1]
+            previous_line = int(previous.get("line") or previous.get("original_line") or 0)
+            current_line = int(thread.get("line") or thread.get("original_line") or 0)
+            if abs(current_line - previous_line) <= 20:
+                current_cluster.append(thread)
+                continue
+            if len(current_cluster) > 1:
+                batches.append(
+                    {
+                        "cluster_reason": "same_path_reviewer_and_line_window",
+                        "path": path,
+                        "normalized_headline": reviewer_headline(current_cluster[0]),
+                        "reviewer_login": reviewer_login,
+                        "threads": current_cluster,
+                    }
+                )
+                used.update(str(item["thread_id"]) for item in current_cluster)
+            current_cluster = [thread]
+        if len(current_cluster) > 1:
+            batches.append(
+                {
+                    "cluster_reason": "same_path_reviewer_and_line_window",
+                    "path": path,
+                    "normalized_headline": reviewer_headline(current_cluster[0]),
+                    "reviewer_login": reviewer_login,
+                    "threads": current_cluster,
+                }
+            )
+            used.update(str(item["thread_id"]) for item in current_cluster)
+
+    return sorted(
+        [batch for batch in batches if len(batch["threads"]) > 1],
+        key=lambda batch: (
+            str(batch.get("path") or ""),
+            int(batch["threads"][0].get("line") or batch["threads"][0].get("original_line") or 0),
+        ),
+    )
+
+
+def determine_review_mode(
+    unresolved_non_outdated_count: int,
+    active_path_count: int,
+    active_area_count: int,
+    analysis_target_count: int,
+    override_signals: list[dict[str, str]],
+) -> str:
+    if unresolved_non_outdated_count <= LOCAL_THREAD_LIMIT and active_path_count <= 1 and active_area_count <= 1:
+        review_mode = "local-only"
+    elif unresolved_non_outdated_count > TARGETED_THREAD_LIMIT or analysis_target_count >= BROAD_TARGET_LIMIT:
+        review_mode = "broad-delegation"
+    else:
+        review_mode = "targeted-delegation"
+
+    if override_signals and review_mode == "local-only":
+        review_mode = "targeted-delegation"
+    elif override_signals and review_mode == "targeted-delegation":
+        review_mode = "broad-delegation"
+    return review_mode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build packet artifacts for token-efficient PR review-thread handling."
+    )
+    parser.add_argument("--context", type=Path, required=True, help="Path to JSON from collect_review_threads.py")
+    parser.add_argument("--repo-root", type=Path, required=True, help="Repository root")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory for generated packets")
+    parser.add_argument("--result-output", type=Path, help="Optional path to write the eval-side build result JSON.")
+    args = parser.parse_args()
+
+    context = load_json(args.context)
+    repo_root = args.repo_root.resolve()
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pr = context.get("pr", {})
+    threads = sort_threads(list(context.get("threads", [])))
+    unresolved_threads = [thread for thread in threads if not thread.get("is_resolved")]
+    unresolved_non_outdated = [thread for thread in unresolved_threads if not thread.get("is_outdated")]
+    unresolved_outdated = [thread for thread in unresolved_threads if thread.get("is_outdated")]
+    changed_files = [str(path) for path in context.get("changed_files", [])]
+    diff_totals = parse_diff_totals(context.get("diff_stat"))
+    generated_file_count = sum(1 for path in changed_files if is_generated_file(path))
+    generated_file_ratio = (generated_file_count / len(changed_files)) if changed_files else 0.0
+    core_areas_touched = sorted(
+        {area for path in changed_files if (area := core_area_for_path(path)) is not None}
+    )
+
+    override_signals: list[dict[str, str]] = []
+    if (diff_totals or {}).get("churn", 0) >= CHURN_OVERRIDE_LIMIT:
+        override_signals.append(
+            {
+                "reason": "diff_stat_threshold",
+                "detail": f"PR diff churn reached {(diff_totals or {}).get('churn', 0)} lines (threshold {CHURN_OVERRIDE_LIMIT}).",
+            }
+        )
+    if len(core_areas_touched) >= 2:
+        override_signals.append(
+            {
+                "reason": "core_files_across_groups",
+                "detail": "Core runtime/config/process files were touched across multiple groups: "
+                + ", ".join(core_areas_touched),
+            }
+        )
+    if (
+        generated_file_count >= MEANINGFUL_GENERATED_FILE_MIN_COUNT
+        and MEANINGFUL_GENERATED_FILE_MIN_RATIO <= generated_file_ratio < 0.5
+    ):
+        override_signals.append(
+            {
+                "reason": "generated_files_not_majority",
+                "detail": "Generated files are present but are not the majority of the change "
+                f"({generated_file_count}/{len(changed_files)}).",
+            }
+        )
+
+    sections = section_bodies(str(pr.get("body") or ""))
+    global_packet_name = "global_packet.json"
+    global_packet = {
+        "purpose": "Shared context every worker should keep in view before reading thread packets.",
+        "workflow_family": "github-review",
+        "archetype": "audit-and-apply",
+        "decision_ready_packets": False,
+        "worker_return_contract": "generic",
+        "worker_output_shape": "flat",
+        "xhigh_reread_policy": "packet-first local adjudication with raw rereads only for explicit exception reasons",
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "repo_profile": context.get("repo_profile"),
+        "pr": {
+            "id": pr.get("id"),
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "url": pr.get("url"),
+            "state": pr.get("state"),
+            "head_ref": pr.get("headRefName"),
+            "base_ref": pr.get("baseRefName"),
+        },
+        "viewer_login": context.get("viewer_login"),
+        "pr_intent": sections.get("Why", ""),
+        "user_visible_impact": sections.get("What changed", ""),
+        "rollout_migration_risk": {
+            "how_excerpt": sections.get("How", ""),
+            "risk_excerpt": sections.get("Risk / Rollback", ""),
+        },
+        "linked_issue": pr.get("closingIssuesReferences", []) or [],
+        "required_template_sections": context.get("expected_template_sections")
+        or parse_markdown_headings(read_text_if_exists(repo_root / ".github/pull_request_template.md")),
+        "repo_guidance_paths": context.get("rule_files") or guidance_paths(repo_root),
+        "diff_summary": {
+            "diff_stat": context.get("diff_stat"),
+            "diff_totals": diff_totals,
+            "changed_file_count": len(changed_files),
+            "generated_file_count": generated_file_count,
+            "generated_file_ratio": round(generated_file_ratio, 3),
+            "core_areas_touched": core_areas_touched,
+        },
+        "outdated_policy": {
+            "default_decision": "defer-outdated",
+            "code_change_default": "Do not assign implementation work to outdated threads by default.",
+            "auto_resolve": "Never auto-resolve outdated threads.",
+            "upgrade_rule": "Upgrade an outdated thread to accept only after verifying against the current HEAD that the issue still applies.",
+            "completion_reply_default": "Do not post a completion reply for outdated threads unless they were upgraded to accept and fixed.",
+        },
+        "reject_policy": "Reject or defer with a concise reason and leave the thread unresolved.",
+        "disallowed_actions": [
+            "Do not add a top-level PR comment by default.",
+            "Do not resolve rejected, deferred, or defer-outdated threads.",
+            "Do not modify comments outside the exact managed marker policy.",
+            "Do not claim tests, migrations, rollout safety, or user-visible behavior unless verified.",
+            "Do not delegate broad or cross-cutting code changes to mini workers.",
+        ],
+        "disallowed_claims": [
+            "Do not claim the issue is fixed until code and validation are complete.",
+            "Do not claim a thread is outdated-and-safe unless current HEAD actually proves it.",
+            "Do not claim config, workflow, or public-interface changes are low risk without checking the files.",
+        ],
+        "context_fingerprint": context_fingerprint(context),
+        "review_mode_overrides": override_signals,
+        "managed_reply_markers": {
+            "ack": "<!-- codex:review-thread v1 phase=ack thread=<thread-id> -->",
+            "complete": "<!-- codex:review-thread v1 phase=complete thread=<thread-id> -->",
+            "update_priority": [
+                "update the newest exact managed reply for the same phase and thread",
+                "during ack only, adopt the newest unmarked self-authored reply after the latest reviewer comment and prepend the marker",
+                "otherwise add a new reply",
+                "never adopt an unmarked reply during complete",
+            ],
+        },
+        "comment_contract": {
+            "ack": [
+                "summarize the reviewer request",
+                "state accept, reject, defer, or defer-outdated",
+                "state the implementation direction or blocker",
+            ],
+            "complete": [
+                "summarize what changed",
+                "list validation that actually ran",
+                "note the remaining caveat only if it matters",
+            ],
+        },
+        "code_change_delegation_policy": {
+            "small_fix_only": True,
+            "required_conditions": [
+                "one batch or one thread",
+                "two files or fewer",
+                "one subsystem",
+                "no schema, public interface, config, or workflow changes",
+                "validation path is clear",
+            ],
+        },
+    }
+
+    batches = cluster_non_outdated_threads(unresolved_threads)
+    thread_to_batch: dict[str, str] = {}
+    batch_files: list[str] = []
+    thread_files: list[str] = []
+    marker_conflicts: list[dict[str, Any]] = []
+    diff_cache: dict[str, str | None] = {}
+    packet_quality_records: list[dict[str, Any]] = []
+    runtime_payloads: dict[str, Any] = {}
+
+    for batch_index, batch in enumerate(batches, start=1):
+        batch_id = f"batch-{batch_index:02d}"
+        batch_file = packet_name("thread-batch", batch_index)
+        batch_files.append(batch_file)
+        path = str(batch.get("path") or "")
+        line = batch["threads"][0].get("line") or batch["threads"][0].get("original_line")
+        common_context = {
+            "path": path,
+            "path_exists": (repo_root / path).is_file(),
+            "area": classify_path(path),
+            "core_area": core_area_for_path(path),
+            "generated_file": is_generated_file(path),
+            "snippet": make_line_snippet(repo_root / path, int(line) if line else None),
+            "diff_snippet": diff_snippet_for_path(
+                repo_root,
+                str(pr.get("baseRefName") or ""),
+                str(pr.get("headRefName") or ""),
+                path,
+                int(line) if line else None,
+                diff_cache,
+            ),
+        }
+        batch_quality = packet_quality_basis(
+            reviewer_bodies=[str((thread.get("reviewer_comment") or {}).get("body") or "") for thread in batch["threads"]],
+            path=path,
+            path_exists=bool(common_context["path_exists"]),
+            snippet=common_context["snippet"],
+            diff_snippet=common_context["diff_snippet"],
+        )
+        validation_candidates = validation_candidates_for_path(path, str(common_context["area"]), is_outdated=False)
+        batch_payload = {
+            "purpose": "Analyze a cluster of related unresolved non-outdated review threads together before choosing one fix direction.",
+            "batch": {
+                "batch_id": batch_id,
+                "cluster_reason": batch["cluster_reason"],
+                "path": path,
+                "normalized_headline": batch.get("normalized_headline"),
+                "reviewer_login": batch.get("reviewer_login"),
+                "thread_ids": [thread["thread_id"] for thread in batch["threads"]],
+            },
+            "shared_fix_surface": {
+                "path": path,
+                "area": common_context["area"],
+                "core_area": common_context["core_area"],
+                "thread_count": len(batch["threads"]),
+                "default_decision_candidate": "accept",
+            },
+            "common_file_context": common_context,
+            "validation_candidates": validation_candidates,
+            "quality_escape_hints": quality_escape_hints(batch_quality, path=path, is_outdated=False),
+            "adjudication_basis": batch_quality,
+            "threads": [],
+        }
+        for thread in batch["threads"]:
+            thread_to_batch[str(thread["thread_id"])] = batch_id
+            batch_payload["threads"].append(
+                {
+                    "thread_id": thread["thread_id"],
+                    "line": thread.get("line"),
+                    "original_line": thread.get("original_line"),
+                    "reviewer_login": thread.get("reviewer_login"),
+                    "reviewer_headline": reviewer_headline(thread),
+                    "reviewer_comment_excerpt": safe_excerpt((thread.get("reviewer_comment") or {}).get("body")),
+                    "latest_self_reply_excerpt": safe_excerpt((thread.get("latest_self_reply") or {}).get("body")),
+                    "default_decision_candidate": candidate_decision(thread),
+                }
+            )
+        write_json(output_dir / batch_file, batch_payload)
+        runtime_payloads[batch_file] = batch_payload
+        packet_quality_records.append({"packet": batch_file, **batch_quality})
+
+    for thread_index, thread in enumerate(unresolved_threads, start=1):
+        path = str(thread.get("path") or "")
+        batch_id = thread_to_batch.get(str(thread["thread_id"]))
+        file_policy = code_change_policy(path)
+        thread_file = packet_name("thread", thread_index)
+        thread_files.append(thread_file)
+        line = thread.get("line") or thread.get("original_line")
+        path_exists = (repo_root / path).is_file()
+        area = classify_path(path)
+        file_context = {
+            "path_exists": path_exists,
+            "area": area,
+            "core_area": core_area_for_path(path),
+            "generated_file": is_generated_file(path),
+            "snippet": make_line_snippet(repo_root / path, int(line) if line else None),
+            "diff_snippet": diff_snippet_for_path(
+                repo_root,
+                str(pr.get("baseRefName") or ""),
+                str(pr.get("headRefName") or ""),
+                path,
+                int(line) if line else None,
+                diff_cache,
+            ),
+        }
+        quality_basis = packet_quality_basis(
+            reviewer_bodies=[str((thread.get("reviewer_comment") or {}).get("body") or "")],
+            path=path,
+            path_exists=path_exists,
+            snippet=file_context["snippet"],
+            diff_snippet=file_context["diff_snippet"],
+        )
+        validation_candidates = validation_candidates_for_path(
+            path,
+            area,
+            is_outdated=bool(thread.get("is_outdated")),
+        )
+        packet = {
+            "purpose": "Analyze one unresolved review thread before deciding reply text, implementation scope, and resolution.",
+            "thread": {
+                "thread_id": thread["thread_id"],
+                "batch_id": batch_id,
+                "is_outdated": thread.get("is_outdated"),
+                "path": path,
+                "line": thread.get("line"),
+                "start_line": thread.get("start_line"),
+                "original_line": thread.get("original_line"),
+                "reviewer_login": thread.get("reviewer_login"),
+                "reviewer_headline": reviewer_headline(thread),
+                "default_decision_candidate": candidate_decision(thread),
+            },
+            "reviewer_comment": comment_summary(thread.get("reviewer_comment")),
+            "discussion": [
+                {
+                    "id": comment.get("id"),
+                    "author_login": comment.get("author_login"),
+                    "created_at": comment.get("created_at"),
+                    "updated_at": comment.get("updated_at"),
+                    "managed_phase": comment.get("managed_phase"),
+                    "body": comment.get("body"),
+                }
+                for comment in thread.get("comments", [])
+            ],
+            "existing_self_reply": comment_summary(thread.get("latest_self_reply")),
+            "reply_candidates": thread.get("reply_candidates"),
+            "reply_update_basis": reply_update_basis(thread.get("reply_candidates")),
+            "file_context": file_context,
+            "ownership_summary": {
+                "path": path,
+                "area": area,
+                "core_area": file_context["core_area"],
+                "path_exists": path_exists,
+                "ownership_ambiguous": quality_basis["ownership_ambiguous"],
+                "escape_threshold_exceeded": quality_basis["ownership_ambiguous"],
+            },
+            "applicability": {
+                "default_decision_candidate": candidate_decision(thread),
+                "small_fix_candidate": file_policy["small_fix_candidate"],
+                "blockers": file_policy["blockers"],
+            },
+            "validation_candidates": validation_candidates,
+            "quality_escape_hints": quality_escape_hints(
+                quality_basis,
+                path=path,
+                is_outdated=bool(thread.get("is_outdated")),
+                blockers=file_policy["blockers"],
+            ),
+            "adjudication_basis": quality_basis,
+            "reply_update_basis_policy": "Advisory only; record explicit allowed reread reasons or stops before leaving the packet-first path.",
+        }
+        normalized_conflicts = normalize_marker_conflicts(thread)
+        if normalized_conflicts:
+            packet["marker_conflicts"] = normalized_conflicts
+            marker_conflicts.extend(
+                {
+                    "thread_id": thread["thread_id"],
+                    **item,
+                }
+                for item in normalized_conflicts
+            )
+        write_json(output_dir / thread_file, packet)
+        runtime_payloads[thread_file] = packet
+        packet_quality_records.append({"packet": thread_file, **quality_basis})
+
+    active_paths = sorted({str(thread.get("path") or "") for thread in unresolved_non_outdated})
+    active_areas = sorted(
+        {
+            classify_path(str(thread.get("path") or ""))
+            for thread in unresolved_non_outdated
+            if classify_path(str(thread.get("path") or "")) != "other"
+        }
+    )
+    batched_thread_ids = set(thread_to_batch)
+    singleton_packets = [
+        packet_name("thread", index)
+        for index, thread in enumerate(unresolved_threads, start=1)
+        if not thread.get("is_outdated") and str(thread["thread_id"]) not in batched_thread_ids
+    ]
+    analysis_target_count = len(batch_files) + len(singleton_packets)
+    packet_worker_map = derive_packet_worker_map(batch_files + singleton_packets)
+    review_mode = determine_review_mode(
+        unresolved_non_outdated_count=len(unresolved_non_outdated),
+        active_path_count=len(active_paths),
+        active_area_count=len(active_areas),
+        analysis_target_count=analysis_target_count,
+        override_signals=override_signals,
+    )
+
+    recommended_workers = derive_recommended_workers(
+        review_mode=review_mode,
+        global_packet_name=global_packet_name,
+        analysis_packet_names=batch_files + singleton_packets,
+        packet_worker_map=packet_worker_map,
+    )
+    optional_workers = derive_optional_workers(
+        review_mode=review_mode,
+        global_packet_name=global_packet_name,
+        optional_qa_packets=(batch_files + singleton_packets)[:6],
+    )
+
+    common_path_failures = [
+        {
+            "packet": item["packet"],
+            "required_evidence_present": item["required_evidence_present"],
+            "ownership_ambiguous": item["ownership_ambiguous"],
+            "explicit_reread_reasons": item["explicit_reread_reasons"],
+            "validator_ready_recommendation_path": item["validator_ready_recommendation_path"],
+        }
+        for item in packet_quality_records
+        if not bool(item["common_path_sufficient"])
+    ]
+    common_path_sufficient = not common_path_failures
+
+    global_packet["orchestrator_profile"] = ORCHESTRATOR_PROFILE
+    global_packet["common_path_contract"] = COMMON_PATH_CONTRACT
+    global_packet["decision_ready_packets"] = DECISION_READY_PACKETS
+    global_packet["worker_return_contract"] = WORKER_RETURN_CONTRACT
+    global_packet["worker_output_shape"] = WORKER_OUTPUT_SHAPE
+    global_packet["xhigh_reread_policy"] = XHIGH_REREAD_POLICY
+    global_packet["preferred_worker_families"] = PREFERRED_WORKER_FAMILIES
+    global_packet["packet_worker_map"] = packet_worker_map
+    global_packet["routing_contract"] = {
+        "routing_authority": "packet_worker_map",
+        "preferred_worker_families_role": "registry_metadata_only",
+        "derived_worker_fields": ["recommended_workers", "optional_workers"],
+    }
+    global_packet["marker_conflict_summary"] = marker_conflict_summary(unresolved_threads)
+    write_json(output_dir / global_packet_name, global_packet)
+    runtime_payloads[global_packet_name] = global_packet
+
+    packet_files = [global_packet_name, *thread_files, *batch_files, "orchestrator.json"]
+    thread_counts = {
+        "unresolved": len(unresolved_threads),
+        "unresolved_non_outdated": len(unresolved_non_outdated),
+        "unresolved_outdated": len(unresolved_outdated),
+    }
+    orchestrator = {
+        "pr": {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "url": pr.get("url"),
+        },
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "orchestrator_profile": ORCHESTRATOR_PROFILE,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "shared_packet": global_packet_name,
+        "context_fingerprint": context_fingerprint(context),
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "common_path_contract": COMMON_PATH_CONTRACT,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": packet_worker_map,
+        "recommended_worker_count": len(recommended_workers),
+        "optional_worker_count": len(optional_workers),
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+        "thread_counts": thread_counts,
+        "active_paths": active_paths,
+        "active_areas": active_areas,
+        "analysis_targets": {
+            "batch_count": len(batch_files),
+            "singleton_count": len(singleton_packets),
+        },
+        "review_mode_overrides": override_signals,
+        "marker_conflict_summary": marker_conflict_summary(unresolved_threads),
+        "thread_batches": {
+            batch_id: [thread_id for thread_id, assigned_batch in thread_to_batch.items() if assigned_batch == batch_id]
+            for batch_id in sorted(set(thread_to_batch.values()))
+        },
+        "local_responsibilities": [
+            "Decide accept, reject, defer, or defer-outdated locally for each unresolved thread.",
+            "Draft final acknowledgement and completion replies locally.",
+            "Keep top-level PR comments out of scope unless the user asks for one.",
+            "Keep broad or cross-cutting code changes local.",
+            "Resolve a thread only after accepted work and validation are complete.",
+        ],
+        "raw_diff_policy": {
+            "allowed_reasons": COMMON_PATH_CONTRACT["allowed_reread_reasons"],
+            "note": "quality_escape_hints is advisory only; explicit reread or escape decisions must use the allowed reason enum or an explicit stop.",
+        },
+        "packet_files": packet_files,
+    }
+    write_json(output_dir / "orchestrator.json", orchestrator)
+    runtime_payloads["orchestrator.json"] = orchestrator
+
+    common_path_packet_names = [global_packet_name]
+    analysis_packet_names = batch_files + thread_files
+    if analysis_packet_names:
+        largest_analysis_packet = max(
+            analysis_packet_names,
+            key=lambda name: len(json.dumps(runtime_payloads.get(name, {}), indent=2, ensure_ascii=True)),
+        )
+        common_path_packet_names.append(largest_analysis_packet)
+    packet_metrics = compute_packet_metrics(
+        runtime_payloads,
+        common_path_packet_names=common_path_packet_names,
+        local_only_sources={
+            "context": context,
+            "threads": unresolved_threads,
+            "pr": pr,
+            "changed_files": changed_files,
+            "override_signals": override_signals,
+        },
+    )
+    packet_metrics_path = output_dir / "packet_metrics.json"
+    write_json(packet_metrics_path, packet_metrics)
+
+    build_result = build_result_payload(
+        review_mode=review_mode,
+        recommended_workers=recommended_workers,
+        optional_workers=optional_workers,
+        thread_batch_count=len(batch_files),
+        singleton_thread_packet_count=len(thread_files),
+        active_paths=active_paths,
+        override_signals=override_signals,
+        common_path_sufficient=common_path_sufficient,
+        common_path_failures=common_path_failures,
+        thread_counts=thread_counts,
+        packet_metrics_path=str(packet_metrics_path),
+    )
+    if args.result_output is not None:
+        write_json(args.result_output, build_result)
+
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output_dir),
+                "review_mode": review_mode,
+                "packet_files": packet_files,
+                "recommended_worker_count": len(recommended_workers),
+                "common_path_sufficient": common_path_sufficient,
+                "result_output": str(args.result_output) if args.result_output else None,
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/build_review_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/build_review_packets.py
@@ -37,6 +37,51 @@ from review_thread_packet_contract import (
 
 SNIPPET_RADIUS = 12
 DIFF_SNIPPET_CHAR_LIMIT = 2200
+DIFF_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@", re.MULTILINE)
+REQUEST_ANCHOR_RE = re.compile(r"`([^`]+)`|\"([^\"]+)\"|'([^']+)'")
+REQUEST_ANCHOR_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "as",
+        "at",
+        "be",
+        "by",
+        "change",
+        "clarify",
+        "consider",
+        "ensure",
+        "fix",
+        "for",
+        "from",
+        "here",
+        "in",
+        "into",
+        "it",
+        "keep",
+        "less",
+        "make",
+        "more",
+        "of",
+        "on",
+        "or",
+        "please",
+        "prefer",
+        "remove",
+        "rename",
+        "switch",
+        "that",
+        "the",
+        "there",
+        "this",
+        "tighten",
+        "to",
+        "update",
+        "use",
+        "with",
+    }
+)
 GENERATED_FILE_PATTERNS = (
     re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
     re.compile(r"\.(g|generated)\.[^.]+$"),
@@ -253,8 +298,7 @@ def diff_snippet_for_path(
     if line_number is None or len(full_diff) <= DIFF_SNIPPET_CHAR_LIMIT:
         cache[path] = full_diff[:DIFF_SNIPPET_CHAR_LIMIT].rstrip()
         return cache[path]
-    hunk_pattern = re.compile(r"^@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,(?P<count>\d+))? @@", re.MULTILINE)
-    matches = list(hunk_pattern.finditer(full_diff))
+    matches = list(DIFF_HUNK_HEADER_RE.finditer(full_diff))
     selected = None
     for index, match in enumerate(matches):
         start = int(match.group("start"))
@@ -297,6 +341,13 @@ def normalized_headline(body: str) -> str:
     return clean_headline_line(body)[:160]
 
 
+def normalize_text_for_matching(text: str | None) -> str:
+    if not text:
+        return ""
+    normalized_lines = [clean_headline_line(line) for line in str(text).splitlines()]
+    return " ".join(line for line in normalized_lines if line).strip()
+
+
 def reviewer_headline(thread: dict[str, Any]) -> str:
     reviewer_comment = thread.get("reviewer_comment") or {}
     return normalized_headline(str(reviewer_comment.get("body") or ""))
@@ -307,6 +358,57 @@ def safe_excerpt(text: str | None, limit: int = 220) -> str:
         return ""
     compact = re.sub(r"\s+", " ", text).strip()
     return compact[: limit - 3] + "..." if len(compact) > limit else compact
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def match_terms(text: str | None) -> list[str]:
+    normalized = normalize_text_for_matching(text)
+    terms: list[str] = []
+    for raw_token in re.findall(r"[a-z0-9_./-]+", normalized):
+        token = raw_token.strip(".-/")
+        if len(token) >= 3 and token not in REQUEST_ANCHOR_STOPWORDS:
+            terms.append(token)
+    return terms
+
+
+def request_anchor_evidence(
+    reviewer_body: str,
+    *,
+    snippet: str | None,
+    diff_snippet: str | None,
+) -> tuple[bool, list[str], list[str], list[str]]:
+    evidence_text = normalize_text_for_matching("\n".join(part for part in (snippet, diff_snippet) if part))
+    if not evidence_text:
+        return False, [], [], []
+
+    exact_anchors = [
+        normalized
+        for normalized in (
+            normalize_text_for_matching(next(group for group in match.groups() if group))
+            for match in REQUEST_ANCHOR_RE.finditer(reviewer_body)
+        )
+        if normalized
+    ]
+    matched_exact_anchors = [anchor for anchor in exact_anchors if anchor in evidence_text]
+    if exact_anchors:
+        return bool(matched_exact_anchors), exact_anchors, matched_exact_anchors, []
+
+    requested_terms = sorted(dict.fromkeys(match_terms(reviewer_body)))
+    if len(requested_terms) < 2:
+        return False, [], [], requested_terms
+
+    evidence_terms = set(match_terms(evidence_text))
+    matched_terms = [term for term in requested_terms if term in evidence_terms]
+    return len(matched_terms) >= 2, [], [], matched_terms
 
 
 def comment_summary(comment: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -330,6 +432,177 @@ def candidate_decision(thread: dict[str, Any]) -> str:
     return "defer-outdated" if thread.get("is_outdated") else "accept"
 
 
+def load_reconciliation_input(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {
+            "default_validation_commands": [],
+            "accepted_threads": {},
+        }
+
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise RuntimeError("reconciliation input must be a JSON object")
+
+    default_validation_commands = list_of_strings(payload.get("default_validation_commands"))
+    accepted_threads: dict[str, dict[str, Any]] = {}
+    for item in payload.get("accepted_threads") or []:
+        if not isinstance(item, dict):
+            raise RuntimeError("accepted_threads entries must be JSON objects")
+        thread_id = str(item.get("thread_id") or "").strip()
+        if not thread_id:
+            raise RuntimeError("accepted_threads entries must include thread_id")
+        validation_commands = list_of_strings(item.get("validation_commands")) or list(default_validation_commands)
+        accepted_threads[thread_id] = {
+            "thread_id": thread_id,
+            "validation_commands": validation_commands,
+        }
+
+    return {
+        "default_validation_commands": default_validation_commands,
+        "accepted_threads": accepted_threads,
+    }
+
+
+def previous_thread_lookup(previous_context: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not isinstance(previous_context, dict):
+        return {}
+    return {
+        str(thread.get("thread_id") or ""): thread
+        for thread in previous_context.get("threads", [])
+        if isinstance(thread, dict) and str(thread.get("thread_id") or "").strip()
+    }
+
+
+def transitioned_to_outdated(
+    previous_thread: dict[str, Any] | None,
+    current_thread: dict[str, Any],
+) -> bool:
+    if not previous_thread:
+        return False
+    if bool(previous_thread.get("is_resolved")) or bool(current_thread.get("is_resolved")):
+        return False
+    if bool(previous_thread.get("is_outdated")):
+        return False
+    return bool(current_thread.get("is_outdated"))
+
+
+def diff_hunk_covers_thread_location(
+    diff_snippet: str | None,
+    *,
+    previous_thread: dict[str, Any],
+    current_thread: dict[str, Any],
+) -> bool:
+    if not isinstance(diff_snippet, str) or not diff_snippet.strip():
+        return False
+    candidate_lines = {
+        int(value)
+        for value in (
+            current_thread.get("line"),
+            current_thread.get("original_line"),
+            previous_thread.get("line"),
+            previous_thread.get("original_line"),
+        )
+        if isinstance(value, int) and value > 0
+    }
+    if not candidate_lines:
+        return False
+    for match in DIFF_HUNK_HEADER_RE.finditer(diff_snippet):
+        start = int(match.group("start"))
+        count = int(match.group("count") or "1")
+        end = start + max(count, 1) + 3
+        if any(start - 3 <= line_number <= end for line_number in candidate_lines):
+            return True
+    return False
+
+
+def build_outdated_recheck(
+    *,
+    thread: dict[str, Any],
+    previous_thread: dict[str, Any],
+    file_context: dict[str, Any],
+    area: str,
+    accepted_thread: dict[str, Any] | None,
+) -> dict[str, Any]:
+    validation_commands = list(accepted_thread.get("validation_commands") or []) if accepted_thread else []
+    current_head_visible = diff_hunk_covers_thread_location(
+        file_context.get("diff_snippet"),
+        previous_thread=previous_thread,
+        current_thread=thread,
+    )
+    reviewer_body = str(
+        (thread.get("reviewer_comment") or previous_thread.get("reviewer_comment") or {}).get("body") or ""
+    ).strip()
+    request_anchor_visible, exact_anchors, matched_exact_anchors, matched_terms = request_anchor_evidence(
+        reviewer_body,
+        snippet=file_context.get("snippet"),
+        diff_snippet=file_context.get("diff_snippet"),
+    )
+
+    if accepted_thread is None:
+        verdict = "still-applies"
+        verdict_reason = "thread_was_not_accepted_before_push"
+    elif not validation_commands:
+        verdict = "ambiguous"
+        verdict_reason = "missing_validation_provenance"
+    elif area not in {"docs", "runtime", "tests"}:
+        verdict = "ambiguous"
+        verdict_reason = "unsupported_area_for_auto_resolve"
+    elif not bool(file_context.get("path_exists")):
+        verdict = "ambiguous"
+        verdict_reason = "path_missing_in_current_head"
+    elif not current_head_visible:
+        verdict = "ambiguous"
+        verdict_reason = "missing_current_head_evidence"
+    elif not request_anchor_visible:
+        verdict = "ambiguous"
+        verdict_reason = "missing_request_anchor_evidence"
+    else:
+        verdict = "auto-accept"
+        verdict_reason = "accepted_same_run_with_current_head_evidence"
+
+    return {
+        "previous_snapshot": {
+            "path": str(previous_thread.get("path") or ""),
+            "line": previous_thread.get("line"),
+            "original_line": previous_thread.get("original_line"),
+            "is_outdated": bool(previous_thread.get("is_outdated")),
+            "is_resolved": bool(previous_thread.get("is_resolved")),
+        },
+        "original_request": {
+            "reviewer_login": str(thread.get("reviewer_login") or previous_thread.get("reviewer_login") or ""),
+            "reviewer_body": str(
+                (thread.get("reviewer_comment") or previous_thread.get("reviewer_comment") or {}).get("body") or ""
+            ).strip(),
+            "latest_reviewer_comment_at": str(
+                thread.get("latest_reviewer_comment_at") or previous_thread.get("latest_reviewer_comment_at") or ""
+            ).strip(),
+        },
+        "same_run_acceptance": {
+            "accepted_in_previous_plan": accepted_thread is not None,
+        },
+        "validation_provenance": {
+            "commands": validation_commands,
+        },
+        "current_head_evidence": {
+            "path": str(thread.get("path") or ""),
+            "line": thread.get("line"),
+            "original_line": thread.get("original_line"),
+            "path_exists": bool(file_context.get("path_exists")),
+            "area": area,
+            "snippet": file_context.get("snippet"),
+            "diff_snippet": file_context.get("diff_snippet"),
+            "evidence_visible": current_head_visible,
+            "request_anchor_visible": request_anchor_visible,
+            "exact_request_anchors": exact_anchors,
+            "matched_exact_request_anchors": matched_exact_anchors,
+            "matched_request_terms": matched_terms,
+        },
+        "resolution_verdict": verdict,
+        "verdict_reason": verdict_reason,
+        "auto_resolution_candidate": verdict == "auto-accept",
+    }
+
+
 def code_change_policy(path: str) -> dict[str, Any]:
     area = classify_path(path)
     core_area = core_area_for_path(path)
@@ -350,7 +623,7 @@ def validation_candidates_for_path(path: str, area: str, *, is_outdated: bool) -
             {
                 "kind": "outdated-default",
                 "path": path,
-                "basis": "Default to defer-outdated unless current HEAD proves the issue still applies.",
+                "basis": "Default to defer-outdated unless current HEAD proves the issue still applies or same-run reconciliation proves the accepted fix already covers it.",
             }
         ]
     if area in {"runtime", "tests"}:
@@ -434,7 +707,7 @@ def quality_escape_hints(
 ) -> list[str]:
     hints: list[str] = []
     if is_outdated:
-        hints.append("Outdated threads stay defer-outdated by default; only reopen the issue after checking current HEAD.")
+        hints.append("Outdated threads stay defer-outdated by default; only reopen after checking current HEAD, except for same-run transitioned threads with proven accepted fixes.")
     if "missing_required_evidence" in quality_basis.get("explicit_reread_reasons", []):
         hints.append(f"Treat missing evidence for {path or '<unknown>'} as a reread trigger only if the packet cannot support a local decision.")
     if "ownership_ambiguity" in quality_basis.get("explicit_reread_reasons", []):
@@ -565,10 +838,22 @@ def main() -> int:
     parser.add_argument("--context", type=Path, required=True, help="Path to JSON from collect_review_threads.py")
     parser.add_argument("--repo-root", type=Path, required=True, help="Repository root")
     parser.add_argument("--output-dir", type=Path, required=True, help="Directory for generated packets")
+    parser.add_argument(
+        "--previous-context",
+        type=Path,
+        help="Optional pre-push context JSON used to detect same-run outdated transitions.",
+    )
+    parser.add_argument(
+        "--reconciliation-input",
+        type=Path,
+        help="Optional JSON describing accepted same-run threads and validation provenance.",
+    )
     parser.add_argument("--result-output", type=Path, help="Optional path to write the eval-side build result JSON.")
     args = parser.parse_args()
 
     context = load_json(args.context)
+    previous_context = load_json(args.previous_context) if args.previous_context else None
+    reconciliation_input = load_reconciliation_input(args.reconciliation_input)
     repo_root = args.repo_root.resolve()
     output_dir = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -659,7 +944,7 @@ def main() -> int:
         "outdated_policy": {
             "default_decision": "defer-outdated",
             "code_change_default": "Do not assign implementation work to outdated threads by default.",
-            "auto_resolve": "Never auto-resolve outdated threads.",
+            "auto_resolve": "Only same-run outdated transitions may auto-resolve after current HEAD proof and real validation evidence.",
             "upgrade_rule": "Upgrade an outdated thread to accept only after verifying against the current HEAD that the issue still applies.",
             "completion_reply_default": "Do not post a completion reply for outdated threads unless they were upgraded to accept and fixed.",
         },
@@ -720,6 +1005,9 @@ def main() -> int:
     diff_cache: dict[str, str | None] = {}
     packet_quality_records: list[dict[str, Any]] = []
     runtime_payloads: dict[str, Any] = {}
+    previous_threads = previous_thread_lookup(previous_context)
+    transitioned_outdated_ids: set[str] = set()
+    outdated_recheck_records: list[dict[str, Any]] = []
 
     for batch_index, batch in enumerate(batches, start=1):
         batch_id = f"batch-{batch_index:02d}"
@@ -881,6 +1169,27 @@ def main() -> int:
             "adjudication_basis": quality_basis,
             "reply_update_basis_policy": "Advisory only; record explicit allowed reread reasons or stops before leaving the packet-first path.",
         }
+        previous_thread = previous_threads.get(str(thread["thread_id"]))
+        if transitioned_to_outdated(previous_thread, thread):
+            accepted_thread = reconciliation_input["accepted_threads"].get(str(thread["thread_id"]))
+            recheck = build_outdated_recheck(
+                thread=thread,
+                previous_thread=previous_thread,
+                file_context=file_context,
+                area=area,
+                accepted_thread=accepted_thread,
+            )
+            transitioned_outdated_ids.add(str(thread["thread_id"]))
+            packet["transitioned_to_outdated"] = True
+            packet["thread"]["transitioned_to_outdated"] = True
+            packet["outdated_recheck"] = recheck
+            outdated_recheck_records.append(
+                {
+                    "thread_id": str(thread["thread_id"]),
+                    "resolution_verdict": recheck["resolution_verdict"],
+                    "auto_resolution_candidate": bool(recheck["auto_resolution_candidate"]),
+                }
+            )
         normalized_conflicts = normalize_marker_conflicts(thread)
         if normalized_conflicts:
             packet["marker_conflicts"] = normalized_conflicts
@@ -958,6 +1267,17 @@ def main() -> int:
         "derived_worker_fields": ["recommended_workers", "optional_workers"],
     }
     global_packet["marker_conflict_summary"] = marker_conflict_summary(unresolved_threads)
+    global_packet["same_run_reconciliation"] = {
+        "enabled": args.previous_context is not None,
+        "transitioned_to_outdated_thread_ids": sorted(transitioned_outdated_ids),
+        "outdated_transition_candidates": len(transitioned_outdated_ids),
+        "outdated_auto_resolve_candidates": sum(
+            1 for item in outdated_recheck_records if bool(item["auto_resolution_candidate"])
+        ),
+        "outdated_recheck_ambiguous": sum(
+            1 for item in outdated_recheck_records if item["resolution_verdict"] == "ambiguous"
+        ),
+    }
     write_json(output_dir / global_packet_name, global_packet)
     runtime_payloads[global_packet_name] = global_packet
 
@@ -1001,6 +1321,7 @@ def main() -> int:
         },
         "review_mode_overrides": override_signals,
         "marker_conflict_summary": marker_conflict_summary(unresolved_threads),
+        "same_run_reconciliation": global_packet["same_run_reconciliation"],
         "thread_batches": {
             batch_id: [thread_id for thread_id, assigned_batch in thread_to_batch.items() if assigned_batch == batch_id]
             for batch_id in sorted(set(thread_to_batch.values()))
@@ -1054,6 +1375,14 @@ def main() -> int:
         common_path_sufficient=common_path_sufficient,
         common_path_failures=common_path_failures,
         thread_counts=thread_counts,
+        same_run_reconciliation_enabled=args.previous_context is not None,
+        outdated_transition_candidates=len(transitioned_outdated_ids),
+        outdated_auto_resolve_candidates=sum(
+            1 for item in outdated_recheck_records if bool(item["auto_resolution_candidate"])
+        ),
+        outdated_recheck_ambiguous=sum(
+            1 for item in outdated_recheck_records if item["resolution_verdict"] == "ambiguous"
+        ),
         packet_metrics_path=str(packet_metrics_path),
     )
     if args.result_output is not None:

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/collect_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/collect_review_threads.py
@@ -1,0 +1,872 @@
+﻿#!/usr/bin/env python3
+"""Collect open PR review-thread context for packet-based review handling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+from thread_action_contract import build_context_fingerprint, comment_sort_key
+
+
+MARKER_RE = re.compile(
+    r"\A<!--\s*codex:review-thread v1 phase=(ack|complete) thread=([A-Za-z0-9_:-]+)\s*-->\s*(?:\n|$)"
+)
+GROUP_SAMPLE_LIMIT = 16
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise RuntimeError(f"missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("repo profile must be a JSON object")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+QUERY = """\
+query(
+  $owner: String!,
+  $repo: String!,
+  $number: Int!,
+  $commentsCursor: String,
+  $reviewsCursor: String,
+  $threadsCursor: String
+) {
+  viewer {
+    login
+  }
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+      number
+      title
+      body
+      url
+      state
+      headRefName
+      baseRefName
+      comments(first: 100, after: $commentsCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          body
+          createdAt
+          updatedAt
+          url
+          author {
+            login
+          }
+        }
+      }
+      reviews(first: 100, after: $reviewsCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          state
+          body
+          submittedAt
+          url
+          author {
+            login
+          }
+        }
+      }
+      reviewThreads(first: 100, after: $threadsCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          diffSide
+          startLine
+          startDiffSide
+          originalLine
+          originalStartLine
+          resolvedBy {
+            login
+          }
+          comments(first: 100) {
+            nodes {
+              id
+              body
+              createdAt
+              updatedAt
+              url
+              author {
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def decode_text(data: bytes) -> str:
+    return data.decode("utf-8", errors="replace")
+
+
+def run_command(args: list[str], cwd: Path, stdin_text: str | None = None) -> str:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=str(cwd),
+            input=(stdin_text.encode("utf-8") if stdin_text is not None else None),
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"{args[0]} not found") from exc
+    if result.returncode != 0:
+        stderr = decode_text(result.stderr).strip()
+        stdout = decode_text(result.stdout).strip()
+        detail = stderr or stdout or "command failed"
+        raise RuntimeError(f"{' '.join(args)}: {detail}")
+    return decode_text(result.stdout)
+
+
+def run_json(args: list[str], cwd: Path, stdin_text: str | None = None) -> dict[str, Any]:
+    output = run_command(args, cwd=cwd, stdin_text=stdin_text)
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"failed to parse JSON from {' '.join(args)}: {exc}") from exc
+
+
+def ensure_gh_auth(repo_root: Path) -> None:
+    try:
+        run_command(["gh", "auth", "status"], cwd=repo_root)
+    except RuntimeError as exc:
+        raise RuntimeError("gh auth status failed; run `gh auth login` first") from exc
+
+
+def infer_repo_slug(repo_root: Path) -> str | None:
+    try:
+        remote = run_command(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=repo_root,
+        ).strip()
+    except RuntimeError:
+        remote = ""
+
+    if remote:
+        match = re.search(r"github\.com[:/](?P<slug>[^/]+/[^/.]+)(?:\.git)?$", remote)
+        if match:
+            return match.group("slug")
+
+    try:
+        payload = run_json(["gh", "repo", "view", "--json", "nameWithOwner"], cwd=repo_root)
+    except RuntimeError:
+        return None
+    return str(payload.get("nameWithOwner") or "").strip() or None
+
+
+def parse_markdown_headings(markdown_text: str | None) -> list[str]:
+    if not markdown_text:
+        return []
+    return [line[3:].strip() for line in markdown_text.splitlines() if line.startswith("## ")]
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def classify_changed_files(paths: list[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {
+        "runtime": [],
+        "automation": [],
+        "docs": [],
+        "tests": [],
+        "config": [],
+        "other": [],
+    }
+    for raw_path in paths:
+        path = raw_path.replace("\\", "/")
+        lower = path.lower()
+        if (
+            "/tests/" in lower
+            or lower.endswith("_test.py")
+            or lower.endswith(".tests.cs")
+            or lower.endswith(".spec.ts")
+            or lower.startswith(".github/scripts/tests/")
+        ):
+            groups["tests"].append(path)
+            continue
+        if (
+            lower.startswith(".github/workflows/")
+            or lower.startswith(".github/scripts/")
+            or lower.startswith(".github/issue_template/")
+            or lower.startswith(".github/instructions/")
+        ):
+            groups["automation"].append(path)
+            continue
+        if lower.endswith(".md") or lower.startswith("docs/"):
+            groups["docs"].append(path)
+            continue
+        if lower.endswith((".yml", ".yaml", ".toml", ".json", ".csproj", ".props", ".targets")):
+            groups["config"].append(path)
+            continue
+        if lower.endswith((".cs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java")):
+            groups["runtime"].append(path)
+            continue
+        groups["other"].append(path)
+    return groups
+
+
+def sample_parent(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else "."
+
+
+def select_representative_files(paths: list[str], limit: int = GROUP_SAMPLE_LIMIT) -> list[str]:
+    ordered_paths: list[str] = []
+    for path in paths:
+        if path not in ordered_paths:
+            ordered_paths.append(path)
+    if len(ordered_paths) <= limit:
+        return ordered_paths
+
+    buckets: dict[str, list[str]] = {}
+    bucket_order: list[str] = []
+    for path in ordered_paths:
+        parent = sample_parent(path)
+        if parent not in buckets:
+            buckets[parent] = []
+            bucket_order.append(parent)
+        buckets[parent].append(path)
+
+    selected: list[str] = []
+    while len(selected) < limit:
+        progressed = False
+        for parent in bucket_order:
+            bucket = buckets[parent]
+            if not bucket:
+                continue
+            selected.append(bucket.pop(0))
+            progressed = True
+            if len(selected) >= limit:
+                break
+        if not progressed:
+            break
+
+    original_index = {path: index for index, path in enumerate(ordered_paths)}
+    return sorted(selected, key=original_index.__getitem__)
+
+
+def summarize_groups(groups: dict[str, list[str]]) -> dict[str, dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = {}
+    for name, paths in groups.items():
+        sample_files = select_representative_files(paths)
+        summary[name] = {
+            "count": len(paths),
+            "sample_files": sample_files,
+            "omitted_file_count": max(len(paths) - len(sample_files), 0),
+            "sample_strategy": "directory_round_robin",
+        }
+    return summary
+
+
+def rule_file_paths(repo_root: Path) -> dict[str, str]:
+    candidates = {
+        "pull_request_instructions": ".github/instructions/pull-request.instructions.md",
+        "pull_request_template": ".github/pull_request_template.md",
+        "commit_message_instructions": ".github/instructions/commit-message.instructions.md",
+        "copilot_instructions": ".github/copilot-instructions.md",
+        "contributing": "CONTRIBUTING.md",
+        "maintaining": "MAINTAINING.md",
+    }
+    result: dict[str, str] = {}
+    for key, relative_path in candidates.items():
+        path = repo_root / relative_path
+        if path.exists():
+            result[key] = str(path)
+    return result
+
+
+def load_pr_metadata(repo_root: Path, repo_slug: str | None) -> dict[str, Any]:
+    fields = (
+        "id,number,title,body,url,state,headRefName,baseRefName,"
+        "author,changedFiles,closingIssuesReferences"
+    )
+    args = ["gh", "pr", "view", "--json", fields]
+    return run_json(args, cwd=repo_root)
+
+
+def parse_changed_files_output(output: str) -> list[str]:
+    return [line.strip().replace("\\", "/") for line in output.splitlines() if line.strip()]
+
+
+def is_diff_too_large_error(exc: RuntimeError) -> bool:
+    detail = str(exc)
+    return "PullRequest.diff too_large" in detail or "maximum number of lines" in detail
+
+
+def load_changed_files_via_api(repo_root: Path, repo_slug: str, pr_number: int) -> list[str]:
+    args = [
+        "gh",
+        "api",
+        f"repos/{repo_slug}/pulls/{pr_number}/files",
+        "--paginate",
+        "--jq",
+        ".[].filename",
+    ]
+    output = run_command(args, cwd=repo_root)
+    return parse_changed_files_output(output)
+
+
+def load_changed_files(repo_root: Path, repo_slug: str | None, pr_number: int) -> list[str]:
+    args = ["gh", "pr", "diff", str(pr_number), "--name-only"]
+    if repo_slug:
+        args.extend(["--repo", repo_slug])
+    try:
+        output = run_command(args, cwd=repo_root)
+    except RuntimeError as exc:
+        if not repo_slug or not is_diff_too_large_error(exc):
+            raise
+        return load_changed_files_via_api(repo_root, repo_slug, pr_number)
+    return parse_changed_files_output(output)
+
+
+def load_local_diff_stat(repo_root: Path, base_ref: str | None, head_ref: str | None) -> str | None:
+    if not base_ref or not head_ref:
+        return None
+    candidates = [
+        f"{base_ref}..{head_ref}",
+        f"origin/{base_ref}..{head_ref}",
+        f"{base_ref}..origin/{head_ref}",
+        f"origin/{base_ref}..origin/{head_ref}",
+    ]
+    for revision_range in candidates:
+        try:
+            output = run_command(["git", "diff", "--stat", revision_range], cwd=repo_root).strip()
+        except RuntimeError:
+            continue
+        if output:
+            return output
+    return None
+
+
+def graphql_payload(
+    repo_root: Path,
+    repo_slug: str,
+    pr_number: int,
+    comments_cursor: str | None,
+    reviews_cursor: str | None,
+    threads_cursor: str | None,
+) -> dict[str, Any]:
+    owner, repo = repo_slug.split("/", 1)
+    args = [
+        "gh",
+        "api",
+        "graphql",
+        "-F",
+        "query=@-",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"repo={repo}",
+        "-F",
+        f"number={pr_number}",
+    ]
+    if comments_cursor:
+        args.extend(["-F", f"commentsCursor={comments_cursor}"])
+    if reviews_cursor:
+        args.extend(["-F", f"reviewsCursor={reviews_cursor}"])
+    if threads_cursor:
+        args.extend(["-F", f"threadsCursor={threads_cursor}"])
+    payload = run_json(args, cwd=repo_root, stdin_text=QUERY)
+    if payload.get("errors"):
+        raise RuntimeError(json.dumps(payload["errors"], indent=2, ensure_ascii=True))
+    return payload
+
+
+def parse_marker(body: str) -> tuple[str | None, str | None]:
+    match = MARKER_RE.match(body.lstrip("\ufeff"))
+    if not match:
+        return None, None
+    return match.group(1), match.group(2)
+
+
+def comment_timestamp(comment: dict[str, Any]) -> str:
+    return str(comment.get("updated_at") or comment.get("created_at") or "")
+
+
+def exact_managed_comments(comments: list[dict[str, Any]], phase: str) -> list[dict[str, Any]]:
+    selected = [
+        comment
+        for comment in comments
+        if comment.get("is_self")
+        and comment.get("managed_phase") == phase
+        and comment.get("has_exact_managed_marker")
+    ]
+    selected.sort(key=comment_sort_key)
+    return selected
+
+
+def wrong_thread_managed_comments(comments: list[dict[str, Any]], phase: str) -> list[dict[str, Any]]:
+    selected = [
+        comment
+        for comment in comments
+        if comment.get("is_self")
+        and comment.get("managed_phase") == phase
+        and not comment.get("has_exact_managed_marker")
+    ]
+    selected.sort(key=comment_sort_key)
+    return selected
+
+
+def normalize_comment(raw_comment: dict[str, Any], viewer_login: str, thread_id: str) -> dict[str, Any]:
+    body = str(raw_comment.get("body") or "")
+    author = (raw_comment.get("author") or {}).get("login")
+    phase, marker_thread = parse_marker(body)
+    exact_managed = bool(phase and marker_thread == thread_id)
+    return {
+        "id": raw_comment.get("id"),
+        "body": body,
+        "created_at": raw_comment.get("createdAt"),
+        "updated_at": raw_comment.get("updatedAt"),
+        "url": raw_comment.get("url"),
+        "author_login": author,
+        "is_self": author == viewer_login,
+        "managed_phase": phase,
+        "managed_thread_id": marker_thread,
+        "has_exact_managed_marker": exact_managed,
+    }
+
+
+def build_reply_candidates(
+    comments: list[dict[str, Any]]
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any] | None, str | None]:
+    reviewer_comments = [comment for comment in comments if not comment.get("is_self")]
+    latest_reviewer_at = max((comment_timestamp(comment) for comment in reviewer_comments), default=None)
+
+    managed_ack = exact_managed_comments(comments, "ack")
+    managed_complete = exact_managed_comments(comments, "complete")
+    wrong_thread_ack = wrong_thread_managed_comments(comments, "ack")
+    wrong_thread_complete = wrong_thread_managed_comments(comments, "complete")
+
+    self_comments = [comment for comment in comments if comment.get("is_self")]
+    latest_self_reply = max(self_comments, key=comment_sort_key) if self_comments else None
+
+    adoptable_ack = [
+        comment
+        for comment in self_comments
+        if not comment.get("managed_phase")
+        and (latest_reviewer_at is None or comment_timestamp(comment) > latest_reviewer_at)
+    ]
+    adoptable_ack.sort(key=comment_sort_key)
+
+    marker_conflicts: list[dict[str, Any]] = []
+    if len(managed_ack) > 1:
+        marker_conflicts.append(
+            {
+                "phase": "ack",
+                "severity": "warning",
+                "reason": "duplicate_exact_managed_replies",
+                "comment_ids": [str(comment["id"]) for comment in managed_ack[:-1]],
+                "blocks_adoption": False,
+                "blocks_update": False,
+                "blocks_apply": False,
+            }
+        )
+    if len(managed_complete) > 1:
+        marker_conflicts.append(
+            {
+                "phase": "complete",
+                "severity": "warning",
+                "reason": "duplicate_exact_managed_replies",
+                "comment_ids": [str(comment["id"]) for comment in managed_complete[:-1]],
+                "blocks_adoption": False,
+                "blocks_update": False,
+                "blocks_apply": False,
+            }
+        )
+    if len(adoptable_ack) > 1 and not managed_ack:
+        marker_conflicts.append(
+            {
+                "phase": "ack",
+                "severity": "adoption-blocking",
+                "reason": "multiple_unmarked_replies_after_latest_reviewer",
+                "comment_ids": [str(comment["id"]) for comment in adoptable_ack],
+                "blocks_adoption": True,
+                "blocks_update": False,
+                "blocks_apply": False,
+            }
+        )
+    if wrong_thread_ack:
+        marker_conflicts.append(
+            {
+                "phase": "ack",
+                "severity": "hard-stop",
+                "reason": "wrong_thread_managed_marker",
+                "comment_ids": [str(comment["id"]) for comment in wrong_thread_ack],
+                "blocks_adoption": True,
+                "blocks_update": True,
+                "blocks_apply": True,
+            }
+        )
+    if wrong_thread_complete:
+        marker_conflicts.append(
+            {
+                "phase": "complete",
+                "severity": "hard-stop",
+                "reason": "wrong_thread_managed_marker",
+                "comment_ids": [str(comment["id"]) for comment in wrong_thread_complete],
+                "blocks_adoption": True,
+                "blocks_update": True,
+                "blocks_apply": True,
+            }
+        )
+    marker_conflicts.sort(
+        key=lambda item: (
+            str(item.get("phase") or ""),
+            str(item.get("severity") or ""),
+            str(item.get("reason") or ""),
+            list(item.get("comment_ids", [])),
+        )
+    )
+
+    if managed_ack:
+        ack_candidate = {
+            "mode": "update",
+            "comment_id": managed_ack[-1]["id"],
+            "reason": "exact_managed_reply",
+            "managed": True,
+            "adopted_unmarked_reply": False,
+        }
+    elif adoptable_ack:
+        ack_candidate = {
+            "mode": "update",
+            "comment_id": adoptable_ack[-1]["id"],
+            "reason": "adopt_latest_unmarked_reply_after_reviewer",
+            "managed": False,
+            "adopted_unmarked_reply": True,
+        }
+    else:
+        ack_candidate = {
+            "mode": "add",
+            "comment_id": None,
+            "reason": "no_existing_ack_reply",
+            "managed": False,
+            "adopted_unmarked_reply": False,
+        }
+
+    if managed_complete:
+        complete_candidate = {
+            "mode": "update",
+            "comment_id": managed_complete[-1]["id"],
+            "reason": "exact_managed_reply",
+            "managed": True,
+            "adopted_unmarked_reply": False,
+        }
+    else:
+        complete_candidate = {
+            "mode": "add",
+            "comment_id": None,
+            "reason": "complete_never_adopts_unmarked_reply",
+            "managed": False,
+            "adopted_unmarked_reply": False,
+        }
+
+    return {
+        "ack": ack_candidate,
+        "complete": complete_candidate,
+    }, marker_conflicts, latest_self_reply, latest_reviewer_at
+
+
+def summarize_thread(thread: dict[str, Any], viewer_login: str) -> dict[str, Any]:
+    thread_id = str(thread.get("id"))
+    comments = [
+        normalize_comment(raw_comment, viewer_login=viewer_login, thread_id=thread_id)
+        for raw_comment in (thread.get("comments", {}) or {}).get("nodes", [])
+    ]
+    comments.sort(key=comment_timestamp)
+    reviewer_comments = [comment for comment in comments if not comment.get("is_self")]
+    reviewer_comment = reviewer_comments[0] if reviewer_comments else (comments[0] if comments else None)
+    reply_candidates, marker_conflicts, latest_self_reply, latest_reviewer_at = build_reply_candidates(comments)
+
+    return {
+        "thread_id": thread_id,
+        "is_resolved": bool(thread.get("isResolved")),
+        "is_outdated": bool(thread.get("isOutdated")),
+        "path": str(thread.get("path") or ""),
+        "line": thread.get("line"),
+        "start_line": thread.get("startLine"),
+        "diff_side": thread.get("diffSide"),
+        "start_diff_side": thread.get("startDiffSide"),
+        "original_line": thread.get("originalLine"),
+        "original_start_line": thread.get("originalStartLine"),
+        "resolved_by": (thread.get("resolvedBy") or {}).get("login"),
+        "reviewer_login": reviewer_comment.get("author_login") if reviewer_comment else None,
+        "reviewer_comment": reviewer_comment,
+        "latest_reviewer_comment_at": latest_reviewer_at,
+        "latest_self_reply": latest_self_reply,
+        "reply_candidates": reply_candidates,
+        "marker_conflicts": marker_conflicts,
+        "comments": comments,
+    }
+
+
+def fetch_review_context(repo_root: Path) -> dict[str, Any]:
+    ensure_gh_auth(repo_root)
+    repo_slug = infer_repo_slug(repo_root)
+    pr = load_pr_metadata(repo_root, repo_slug)
+    if not pr.get("number"):
+        raise RuntimeError("no open pull request is associated with the current branch")
+    if repo_slug is None:
+        raise RuntimeError("could not infer the GitHub repository slug for the current repo")
+
+    changed_files = load_changed_files(repo_root, repo_slug, int(pr["number"]))
+    group_summary = summarize_groups(classify_changed_files(changed_files))
+    diff_stat = load_local_diff_stat(
+        repo_root,
+        str(pr.get("baseRefName") or ""),
+        str(pr.get("headRefName") or ""),
+    )
+
+    comments_cursor = None
+    reviews_cursor = None
+    threads_cursor = None
+    conversation_comments: list[dict[str, Any]] = []
+    reviews: list[dict[str, Any]] = []
+    threads: list[dict[str, Any]] = []
+    viewer_login = ""
+
+    while True:
+        payload = graphql_payload(
+            repo_root=repo_root,
+            repo_slug=repo_slug,
+            pr_number=int(pr["number"]),
+            comments_cursor=comments_cursor,
+            reviews_cursor=reviews_cursor,
+            threads_cursor=threads_cursor,
+        )
+        data = payload["data"]
+        viewer_login = str((data.get("viewer") or {}).get("login") or viewer_login)
+        pr_payload = (data.get("repository") or {}).get("pullRequest") or {}
+        comments_conn = pr_payload.get("comments") or {}
+        reviews_conn = pr_payload.get("reviews") or {}
+        threads_conn = pr_payload.get("reviewThreads") or {}
+
+        conversation_comments.extend(comments_conn.get("nodes") or [])
+        reviews.extend(reviews_conn.get("nodes") or [])
+        threads.extend(threads_conn.get("nodes") or [])
+
+        comments_cursor = comments_conn.get("pageInfo", {}).get("endCursor") if comments_conn.get("pageInfo", {}).get("hasNextPage") else None
+        reviews_cursor = reviews_conn.get("pageInfo", {}).get("endCursor") if reviews_conn.get("pageInfo", {}).get("hasNextPage") else None
+        threads_cursor = threads_conn.get("pageInfo", {}).get("endCursor") if threads_conn.get("pageInfo", {}).get("hasNextPage") else None
+        if not (comments_cursor or reviews_cursor or threads_cursor):
+            break
+
+    normalized_comments = [
+        {
+            "id": comment.get("id"),
+            "body": comment.get("body"),
+            "created_at": comment.get("createdAt"),
+            "updated_at": comment.get("updatedAt"),
+            "url": comment.get("url"),
+            "author_login": (comment.get("author") or {}).get("login"),
+        }
+        for comment in conversation_comments
+    ]
+    normalized_reviews = [
+        {
+            "id": review.get("id"),
+            "state": review.get("state"),
+            "body": review.get("body"),
+            "submitted_at": review.get("submittedAt"),
+            "url": review.get("url"),
+            "author_login": (review.get("author") or {}).get("login"),
+        }
+        for review in reviews
+    ]
+    normalized_threads = [summarize_thread(thread, viewer_login=viewer_login) for thread in threads]
+
+    template_text = read_text_if_exists(repo_root / ".github/pull_request_template.md")
+    context = {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "viewer_login": viewer_login,
+        "pr": pr,
+        "changed_files": changed_files,
+        "changed_file_groups": group_summary,
+        "diff_stat": diff_stat,
+        "rule_files": rule_file_paths(repo_root),
+        "expected_template_sections": parse_markdown_headings(template_text),
+        "conversation_comments": normalized_comments,
+        "reviews": normalized_reviews,
+        "threads": normalized_threads,
+    }
+    context["context_fingerprint"] = build_context_fingerprint(context)
+    return context
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect open PR review-thread context for token-efficient packet analysis."
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Repository root that contains the open pull request branch.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional output path. Prints JSON to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo).resolve()
+    try:
+        profile_path = resolve_profile_path(args.profile, repo_root)
+        repo_profile = load_repo_profile(profile_path)
+        context = fetch_review_context(repo_root)
+    except RuntimeError as exc:
+        print(f"collect_review_threads.py: {exc}", file=sys.stderr)
+        return 1
+    context["repo_profile_name"] = repo_profile.get("name")
+    context["repo_profile_path"] = profile_path.as_posix()
+    context["repo_profile_summary"] = repo_profile.get("summary")
+    context["repo_profile"] = repo_profile
+    context["builder_compatibility"] = build_builder_compatibility(repo_profile)
+    if context["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(context["builder_compatibility"]), file=sys.stderr)
+
+    payload = json.dumps(context, indent=2, ensure_ascii=True)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/reconcile_outdated_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/reconcile_outdated_threads.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Build a conservative complete-phase plan for same-run outdated reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from thread_action_contract import context_fingerprint
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def packet_paths(packet_dir: Path) -> list[Path]:
+    return sorted(path for path in packet_dir.glob("thread-*.json") if path.is_file())
+
+
+def packet_lookup(packet_dir: Path) -> dict[str, dict[str, Any]]:
+    lookup: dict[str, dict[str, Any]] = {}
+    for path in packet_paths(packet_dir):
+        payload = load_json(path)
+        thread = payload.get("thread") if isinstance(payload, dict) else None
+        thread_id = str((thread or {}).get("thread_id") or "").strip()
+        if thread_id:
+            lookup[thread_id] = payload
+    return lookup
+
+
+def format_validation(commands: list[str]) -> str | None:
+    normalized = [str(command).strip() for command in commands if str(command).strip()]
+    if not normalized:
+        return None
+    return "; ".join(f"`{command}`" for command in normalized)
+
+
+def completion_body(packet: dict[str, Any]) -> str:
+    thread = packet.get("thread") or {}
+    recheck = packet.get("outdated_recheck") or {}
+    evidence = recheck.get("current_head_evidence") or {}
+    validation = recheck.get("validation_provenance") or {}
+    path = str(evidence.get("path") or thread.get("path") or "").strip()
+    area = str(evidence.get("area") or "").strip()
+    request_phrase = "requested wording change" if area == "docs" else "requested change"
+    first_sentence = (
+        f"Current HEAD already covers the {request_phrase} in `{path}`, "
+        "and the thread became outdated after the accepted update was pushed."
+    )
+    validation_text = format_validation(list(validation.get("commands") or []))
+    if not validation_text:
+        return first_sentence
+    return f"{first_sentence} Validation: {validation_text}."
+
+
+def complete_reply_action(packet: dict[str, Any]) -> dict[str, Any]:
+    complete_basis = ((packet.get("reply_update_basis") or {}).get("complete") or {})
+    mode = str(complete_basis.get("mode") or "").strip()
+    comment_id = str(complete_basis.get("comment_id") or "").strip()
+    if mode == "update":
+        action = {"complete_mode": "update"}
+        if comment_id:
+            action["complete_comment_id"] = comment_id
+        return action
+    return {"complete_mode": "add"}
+
+
+def decision_for_thread(thread: dict[str, Any], packet: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    thread_id = str(thread.get("thread_id") or "").strip()
+    if not thread_id:
+        raise RuntimeError("thread packet is missing thread_id")
+    decision = "defer-outdated" if bool(thread.get("is_outdated")) else "defer"
+    action: dict[str, Any] = {
+        "thread_id": thread_id,
+        "decision": decision,
+        "complete_mode": "skip",
+        "resolve_after_complete": False,
+    }
+
+    if not bool(packet.get("transitioned_to_outdated")):
+        return action, None
+
+    recheck = packet.get("outdated_recheck") or {}
+    verdict = str(recheck.get("resolution_verdict") or "").strip()
+    reason = str(recheck.get("verdict_reason") or "").strip()
+    candidate = {
+        "thread_id": thread_id,
+        "resolution_verdict": verdict,
+        "verdict_reason": reason,
+        "path": str((recheck.get("current_head_evidence") or {}).get("path") or thread.get("path") or "").strip(),
+        "validation_commands": list((recheck.get("validation_provenance") or {}).get("commands") or []),
+    }
+
+    if verdict == "auto-accept":
+        action["decision"] = "accept"
+        action.update(complete_reply_action(packet))
+        action["complete_body"] = completion_body(packet)
+        action["resolve_after_complete"] = True
+        return action, candidate
+
+    if verdict == "still-applies":
+        action["decision"] = "defer"
+        return action, candidate
+
+    action["decision"] = "defer-outdated"
+    return action, candidate
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", type=Path, required=True, help="Path to post-push review-thread context JSON.")
+    parser.add_argument("--packet-dir", type=Path, required=True, help="Directory containing thread packet JSON files.")
+    parser.add_argument("--output", type=Path, help="Optional path to write the raw complete-phase plan JSON.")
+    args = parser.parse_args()
+
+    context = load_json(args.context)
+    packets_by_thread = packet_lookup(args.packet_dir)
+    thread_actions: list[dict[str, Any]] = []
+    candidates: list[dict[str, Any]] = []
+
+    for thread in context.get("threads", []):
+        if not isinstance(thread, dict) or bool(thread.get("is_resolved")):
+            continue
+        thread_id = str(thread.get("thread_id") or "").strip()
+        if not thread_id:
+            raise RuntimeError("context thread is missing thread_id")
+        packet = packets_by_thread.get(thread_id)
+        if packet is None:
+            raise RuntimeError(f"missing thread packet for {thread_id}")
+        action, candidate = decision_for_thread(thread, packet)
+        thread_actions.append(action)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    summary = {
+        "outdated_transition_candidates": len(candidates),
+        "outdated_auto_resolved": sum(1 for item in candidates if item["resolution_verdict"] == "auto-accept"),
+        "outdated_recheck_ambiguous": sum(1 for item in candidates if item["resolution_verdict"] == "ambiguous"),
+        "outdated_still_applicable": sum(1 for item in candidates if item["resolution_verdict"] == "still-applies"),
+    }
+    payload = {
+        "context_fingerprint": context_fingerprint(context),
+        "thread_actions": thread_actions,
+        "reconciliation_summary": summary,
+        "candidates": candidates,
+    }
+    write_json(args.output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/review_thread_packet_contract.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/review_thread_packet_contract.py
@@ -195,6 +195,10 @@ def build_result_payload(
     common_path_sufficient: bool,
     common_path_failures: list[dict[str, Any]],
     thread_counts: dict[str, Any],
+    same_run_reconciliation_enabled: bool,
+    outdated_transition_candidates: int,
+    outdated_auto_resolve_candidates: int,
+    outdated_recheck_ambiguous: int,
     packet_metrics_path: str,
 ) -> dict[str, Any]:
     return {
@@ -209,5 +213,9 @@ def build_result_payload(
         "common_path_sufficient": common_path_sufficient,
         "common_path_failures": common_path_failures,
         "thread_counts": thread_counts,
+        "same_run_reconciliation_enabled": same_run_reconciliation_enabled,
+        "outdated_transition_candidates": outdated_transition_candidates,
+        "outdated_auto_resolve_candidates": outdated_auto_resolve_candidates,
+        "outdated_recheck_ambiguous": outdated_recheck_ambiguous,
         "packet_metrics_file": packet_metrics_path,
     }

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/review_thread_packet_contract.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/review_thread_packet_contract.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Shared packet/runtime contract for gh-address-review-threads build artifacts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+WORKFLOW_FAMILY = "github-review"
+ARCHETYPE = "audit-and-apply"
+ORCHESTRATOR_PROFILE = "standard"
+DECISION_READY_PACKETS = False
+WORKER_RETURN_CONTRACT = "generic"
+WORKER_OUTPUT_SHAPE = "flat"
+XHIGH_REREAD_POLICY = "packet-first local adjudication with raw rereads only for explicit exception reasons"
+
+LOCAL_THREAD_LIMIT = 1
+TARGETED_THREAD_LIMIT = 4
+TARGETED_TARGET_LIMIT = 2
+BROAD_TARGET_LIMIT = 3
+CHURN_OVERRIDE_LIMIT = 400
+MEANINGFUL_GENERATED_FILE_MIN_COUNT = 3
+MEANINGFUL_GENERATED_FILE_MIN_RATIO = 0.2
+
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["packet_explorer"],
+    "candidate_producers": [],
+    "verifiers": [],
+}
+
+ALLOWED_REREAD_REASONS = [
+    "conflicting_signals",
+    "missing_required_evidence",
+    "insufficient_excerpt_quality",
+    "ownership_ambiguity",
+    "stale_context",
+]
+
+COMMON_PATH_SUFFICIENCY_REQUIREMENTS = [
+    "required evidence is present inside the packet set used for the decision",
+    "ownership ambiguity stays below the escape threshold",
+    "no explicit reread or escape reason is required",
+    "validator-ready recommendation path is closed from packet contents alone",
+]
+
+COMMON_PATH_CONTRACT = {
+    "default_basis": [
+        "global_packet.json + one thread-batch packet",
+        "global_packet.json + one thread packet",
+    ],
+    "allowed_reread_reasons": ALLOWED_REREAD_REASONS,
+    "sufficiency_requirements": COMMON_PATH_SUFFICIENCY_REQUIREMENTS,
+    "quality_escape_hints_policy": "advisory-only",
+    "override_policy": "review_mode_overrides may widen worker recommendation but must not upgrade missing evidence or ownership ambiguity into common_path_sufficient=true",
+}
+
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+
+SMOKE_OUTPUT_FIELDS = ["status", "reason", "thread_counts", "next_action"]
+
+
+def canonical_json_text(payload: Any) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=True) + "\n"
+
+
+def packet_size_bytes(payload: Any) -> int:
+    return len(canonical_json_text(payload).encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(size_bytes: int) -> int:
+    if size_bytes <= 0:
+        return 0
+    return max(1, (size_bytes + 3) // 4)
+
+
+def compute_packet_metrics(
+    runtime_payloads: dict[str, Any],
+    *,
+    common_path_packet_names: list[str],
+    local_only_sources: dict[str, Any],
+) -> dict[str, int]:
+    packet_sizes_by_name = {name: packet_size_bytes(payload) for name, payload in runtime_payloads.items()}
+    packet_sizes = list(packet_sizes_by_name.values())
+    total_packet_bytes = sum(packet_sizes)
+    largest = max(packet_sizes, default=0)
+    largest_two = sum(sorted(packet_sizes, reverse=True)[:2])
+    common_path_bytes = sum(packet_sizes_by_name.get(name, 0) for name in common_path_packet_names)
+    local_only_bytes = sum(packet_size_bytes(payload) for payload in local_only_sources.values())
+    estimated_local_only_tokens = estimate_tokens_from_bytes(local_only_bytes)
+    estimated_packet_tokens = estimate_tokens_from_bytes(common_path_bytes)
+    return {
+        "packet_count": len(runtime_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "largest_packet_bytes": largest,
+        "largest_two_packets_bytes": largest_two,
+        "estimated_local_only_tokens": estimated_local_only_tokens,
+        "estimated_packet_tokens": estimated_packet_tokens,
+        "estimated_delegation_savings": max(estimated_local_only_tokens - estimated_packet_tokens, 0),
+    }
+
+
+def derive_packet_worker_map(packet_names: list[str]) -> dict[str, list[str]]:
+    return {
+        packet_name.removesuffix(".json"): ["packet_explorer"]
+        for packet_name in packet_names
+    }
+
+
+def derive_recommended_workers(
+    *,
+    review_mode: str,
+    global_packet_name: str,
+    analysis_packet_names: list[str],
+    packet_worker_map: dict[str, list[str]],
+) -> list[dict[str, Any]]:
+    if review_mode == "local-only":
+        return []
+
+    worker_budget = (
+        TARGETED_TARGET_LIMIT
+        if review_mode == "targeted-delegation"
+        else min(max(len(analysis_packet_names), 1), 4)
+    )
+    if review_mode == "broad-delegation" and worker_budget < 3 and len(analysis_packet_names) >= 3:
+        worker_budget = 3
+
+    workers: list[dict[str, Any]] = []
+    for index, packet_name in enumerate(analysis_packet_names[:worker_budget], start=1):
+        workers.append(
+            {
+                "name": f"thread-analysis-{index}",
+                "agent_type": packet_worker_map.get(packet_name.removesuffix(".json"), ["packet_explorer"])[0],
+                "packets": [global_packet_name, packet_name],
+                "responsibility": "Summarize the threaded issue, fix direction, risk, and concrete file/test scope for this packet.",
+                "reasoning_effort": "medium",
+                "model": "gpt-5.4-mini",
+                "return_contract": [
+                    "thread ids",
+                    "problem summary",
+                    "fix direction",
+                    "risk",
+                    "files to edit",
+                    "tests to run",
+                ],
+            }
+        )
+    return workers
+
+
+def derive_optional_workers(
+    *,
+    review_mode: str,
+    global_packet_name: str,
+    optional_qa_packets: list[str],
+) -> list[dict[str, Any]]:
+    if review_mode == "local-only":
+        return []
+    return [
+        {
+            "name": "qa",
+            "agent_type": "large_diff_auditor",
+            "packets": [global_packet_name, *optional_qa_packets],
+            "responsibility": "Compare the proposed completion reply and changed files against the thread requirements before resolution.",
+            "reasoning_effort": "medium",
+            "when": "Only add this worker when broad fixes are in play, worker findings conflict, or resolution confidence is low.",
+            "return_contract": [
+                "thread ids",
+                "resolution verdict",
+                "coverage gaps",
+                "unsupported claims",
+                "remaining risk",
+            ],
+        }
+    ]
+
+
+def build_result_payload(
+    *,
+    review_mode: str,
+    recommended_workers: list[dict[str, Any]],
+    optional_workers: list[dict[str, Any]],
+    thread_batch_count: int,
+    singleton_thread_packet_count: int,
+    active_paths: list[str],
+    override_signals: list[dict[str, str]],
+    common_path_sufficient: bool,
+    common_path_failures: list[dict[str, Any]],
+    thread_counts: dict[str, Any],
+    packet_metrics_path: str,
+) -> dict[str, Any]:
+    return {
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+        "thread_batch_count": thread_batch_count,
+        "singleton_thread_packet_count": singleton_thread_packet_count,
+        "active_paths": active_paths,
+        "override_signals": override_signals,
+        "common_path_sufficient": common_path_sufficient,
+        "common_path_failures": common_path_failures,
+        "thread_counts": thread_counts,
+        "packet_metrics_file": packet_metrics_path,
+    }

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/smoke_gh_address_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/smoke_gh_address_review_threads.py
@@ -86,6 +86,21 @@ def run_json(args: list[str], *, cwd: Path) -> dict[str, Any]:
     return json.loads(output)
 
 
+def run_git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
 def read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8-sig"))
 
@@ -163,19 +178,33 @@ def synthetic_thread(*, thread_id: str, path: str, line: int, reviewer_login: st
     }
 
 
-def build_synthetic_context(temp_dir: Path) -> tuple[Path, Path]:
+def build_synthetic_context(temp_dir: Path) -> tuple[Path, Path, Path, Path]:
     repo_root = temp_dir / "synthetic-repo"
+    previous_context_path = temp_dir / "previous-context.json"
     context_path = temp_dir / "context.json"
+    reconciliation_input_path = temp_dir / "reconciliation-input.json"
     (repo_root / ".github").mkdir(parents=True, exist_ok=True)
     (repo_root / "src").mkdir(parents=True, exist_ok=True)
+    (repo_root / "docs").mkdir(parents=True, exist_ok=True)
     (repo_root / ".github" / "pull_request_template.md").write_text(
         "\n".join(["## Why", "## What changed", "## Testing"]),
         encoding="utf-8",
     )
+    run_git(repo_root, "init", "-b", "main")
+    run_git(repo_root, "config", "user.name", "Codex")
+    run_git(repo_root, "config", "user.email", "codex@example.com")
     (repo_root / "src" / "app.py").write_text("one\ntwo\nthree\nfour\nfive\n", encoding="utf-8")
     (repo_root / "src" / "helper.py").write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    (repo_root / "docs" / "guide.md").write_text("# Guide\nOriginal wording\n", encoding="utf-8")
+    run_git(repo_root, "add", ".")
+    run_git(repo_root, "commit", "--no-gpg-sign", "-m", "fix(repo): seed synthetic review context")
+    run_git(repo_root, "checkout", "-b", "feature/packets")
+    (repo_root / "src" / "helper.py").write_text("alpha\nbeta updated\ngamma\n", encoding="utf-8")
+    (repo_root / "docs" / "guide.md").write_text("# Guide\nCurrent wording\n", encoding="utf-8")
+    run_git(repo_root, "add", "src/helper.py", "docs/guide.md")
+    run_git(repo_root, "commit", "--no-gpg-sign", "-m", "fix(app): apply accepted review changes")
 
-    context = {
+    base_context = {
         "repo_root": str(repo_root),
         "repo_slug": "example/repo",
         "viewer_login": "codex",
@@ -185,16 +214,16 @@ def build_synthetic_context(temp_dir: Path) -> tuple[Path, Path]:
             "title": "Synthetic review-thread smoke",
             "url": "https://example.invalid/pr/11",
             "state": "OPEN",
-            "headRefName": "feature/synthetic-smoke",
+            "headRefName": "feature/packets",
             "baseRefName": "main",
             "body": synthetic_pr_body(),
             "closingIssuesReferences": [{"number": 55}],
         },
-        "changed_files": ["src/app.py", "src/helper.py"],
+        "changed_files": ["docs/guide.md", "src/helper.py"],
         "changed_file_groups": {
-            "runtime": {"count": 2, "sample_files": ["src/app.py", "src/helper.py"]},
+            "runtime": {"count": 1, "sample_files": ["src/helper.py"]},
             "automation": {"count": 0, "sample_files": []},
-            "docs": {"count": 0, "sample_files": []},
+            "docs": {"count": 1, "sample_files": ["docs/guide.md"]},
             "tests": {"count": 0, "sample_files": []},
             "config": {"count": 0, "sample_files": []},
             "other": {"count": 0, "sample_files": []},
@@ -232,10 +261,10 @@ def build_synthetic_context(temp_dir: Path) -> tuple[Path, Path]:
         "threads": [
             synthetic_thread(
                 thread_id="t-1",
-                path="src/app.py",
+                path="docs/guide.md",
                 line=2,
                 reviewer_login="reviewer-a",
-                reviewer_body="Please tighten the naming here.",
+                reviewer_body="Please use the current wording in the guide.",
             ),
             synthetic_thread(
                 thread_id="t-2",
@@ -246,9 +275,25 @@ def build_synthetic_context(temp_dir: Path) -> tuple[Path, Path]:
             ),
         ],
     }
+    previous_context = json.loads(json.dumps(base_context))
+    context = json.loads(json.dumps(base_context))
+    context["threads"][0]["is_outdated"] = True
+    previous_context["context_fingerprint"] = build_context_fingerprint(previous_context)
     context["context_fingerprint"] = build_context_fingerprint(context)
+    write_json(previous_context_path, previous_context)
     write_json(context_path, context)
-    return repo_root, context_path
+    write_json(
+        reconciliation_input_path,
+        {
+            "accepted_threads": [
+                {
+                    "thread_id": "t-1",
+                    "validation_commands": ["python -m pytest tests/test_docs.py"],
+                }
+            ]
+        },
+    )
+    return repo_root, previous_context_path, context_path, reconciliation_input_path
 
 
 def ensure_gh_auth(repo_root: Path) -> bool:
@@ -326,7 +371,14 @@ def merge_eval_phase(log_path: Path, phase: str, result_path: Path, *, cwd: Path
     )
 
 
-def run_smoke_workflow(*, repo_root: Path, context_path: Path, temp_dir: Path) -> dict[str, Any]:
+def run_smoke_workflow(
+    *,
+    repo_root: Path,
+    context_path: Path,
+    temp_dir: Path,
+    previous_context_path: Path | None = None,
+    reconciliation_input_path: Path | None = None,
+) -> dict[str, Any]:
     packet_dir = temp_dir / "packets"
     build_result_path = temp_dir / "build-result.json"
     eval_log_path = temp_dir / "eval-log.json"
@@ -342,20 +394,22 @@ def run_smoke_workflow(*, repo_root: Path, context_path: Path, temp_dir: Path) -
     if counts["unresolved"] == 0:
         return summary("noop", "no_unresolved_threads", counts, "nothing_to_do", pr_url=context.get("pr", {}).get("url"))
 
-    run_script(
-        [
-            str(script_path("build_review_packets.py")),
-            "--context",
-            str(context_path),
-            "--repo-root",
-            str(repo_root),
-            "--output-dir",
-            str(packet_dir),
-            "--result-output",
-            str(build_result_path),
-        ],
-        cwd=repo_root,
-    )
+    build_args = [
+        str(script_path("build_review_packets.py")),
+        "--context",
+        str(context_path),
+        "--repo-root",
+        str(repo_root),
+        "--output-dir",
+        str(packet_dir),
+        "--result-output",
+        str(build_result_path),
+    ]
+    if previous_context_path is not None:
+        build_args.extend(["--previous-context", str(previous_context_path)])
+    if reconciliation_input_path is not None:
+        build_args.extend(["--reconciliation-input", str(reconciliation_input_path)])
+    run_script(build_args, cwd=repo_root)
     build_result = read_json(build_result_path)
 
     run_script(
@@ -406,7 +460,18 @@ def run_smoke_workflow(*, repo_root: Path, context_path: Path, temp_dir: Path) -
     )
     merge_eval_phase(eval_log_path, "apply", ack_result_path, cwd=repo_root)
 
-    write_json(complete_plan_path, build_safe_plan(context, phase="complete"))
+    run_script(
+        [
+            str(script_path("reconcile_outdated_threads.py")),
+            "--context",
+            str(context_path),
+            "--packet-dir",
+            str(packet_dir),
+            "--output",
+            str(complete_plan_path),
+        ],
+        cwd=repo_root,
+    )
     run_script(
         [
             str(script_path("validate_thread_action_plan.py")),
@@ -440,6 +505,8 @@ def run_smoke_workflow(*, repo_root: Path, context_path: Path, temp_dir: Path) -
     merge_eval_phase(eval_log_path, "apply", complete_result_path, cwd=repo_root)
 
     packet_metrics = read_json(packet_dir / "packet_metrics.json")
+    complete_result = read_json(complete_result_path)
+    reconciliation_summary = complete_result.get("reconciliation_summary") or {}
     return summary(
         "ok",
         None,
@@ -450,6 +517,15 @@ def run_smoke_workflow(*, repo_root: Path, context_path: Path, temp_dir: Path) -
         common_path_sufficient=build_result.get("common_path_sufficient"),
         estimated_packet_tokens=packet_metrics.get("estimated_packet_tokens"),
         estimated_delegation_savings=packet_metrics.get("estimated_delegation_savings"),
+        outdated_transition_candidates=reconciliation_summary.get(
+            "outdated_transition_candidates",
+            build_result.get("outdated_transition_candidates"),
+        ),
+        outdated_auto_resolved=reconciliation_summary.get("outdated_auto_resolved", 0),
+        outdated_recheck_ambiguous=reconciliation_summary.get(
+            "outdated_recheck_ambiguous",
+            build_result.get("outdated_recheck_ambiguous"),
+        ),
     )
 
 
@@ -460,8 +536,20 @@ def main() -> int:
     if args.synthetic:
         with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-synthetic-") as temp_dir_name:
             temp_dir = Path(temp_dir_name)
-            repo_root, context_path = build_synthetic_context(temp_dir)
-            print(json.dumps(run_smoke_workflow(repo_root=repo_root, context_path=context_path, temp_dir=temp_dir), indent=2, ensure_ascii=True))
+            repo_root, previous_context_path, context_path, reconciliation_input_path = build_synthetic_context(temp_dir)
+            print(
+                json.dumps(
+                    run_smoke_workflow(
+                        repo_root=repo_root,
+                        context_path=context_path,
+                        temp_dir=temp_dir,
+                        previous_context_path=previous_context_path,
+                        reconciliation_input_path=reconciliation_input_path,
+                    ),
+                    indent=2,
+                    ensure_ascii=True,
+                )
+            )
             return 0
 
     repo_root = repo_root_path(args.repo_root)

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/smoke_gh_address_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/smoke_gh_address_review_threads.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Run an operator-facing or synthetic dry-run smoke for gh-address-review-threads.
+
+Output schema always includes:
+- status
+- reason
+- thread_counts
+- next_action
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from thread_action_contract import build_context_fingerprint
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+class GhCliMissing(RuntimeError):
+    """Raised when the gh CLI is unavailable in the current environment."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", help="Repository root to inspect. Defaults to the current working directory.")
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="Run a self-contained synthetic dry-run smoke without requiring a live PR or gh auth.",
+    )
+    return parser.parse_args()
+
+
+def script_path(name: str) -> Path:
+    return SCRIPT_DIR / name
+
+
+def repo_root_path(value: str | None) -> Path:
+    if value:
+        return Path(value).resolve()
+    for candidate in [Path.cwd().resolve(), *Path.cwd().resolve().parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return Path.cwd().resolve()
+
+
+def run_process(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    command = [sys.executable, "-B", *args] if args and args[0].endswith(".py") else args
+    try:
+        return subprocess.run(
+            command,
+            cwd=str(cwd),
+            env=env,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        executable = command[0] if command else "command"
+        raise GhCliMissing(f"{executable} is not installed or not on PATH") from exc
+
+
+def run_script(args: list[str], *, cwd: Path) -> str:
+    result = run_process(args, cwd=cwd)
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip() or (result.stdout or "").strip() or f"{' '.join(args)} failed"
+        raise RuntimeError(detail)
+    return result.stdout
+
+
+def run_json(args: list[str], *, cwd: Path) -> dict[str, Any]:
+    output = run_script(args, cwd=cwd)
+    return json.loads(output)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def synthetic_pr_body() -> str:
+    return "\n".join(
+        [
+            "## Why",
+            "Keep review-thread dry-run smoke self-contained.",
+            "## What changed",
+            "Added a synthetic smoke path that uses packet-first fixtures.",
+            "## Testing",
+            "Run the standalone smoke with --synthetic.",
+        ]
+    )
+
+
+def synthetic_background_text(title: str) -> str:
+    return "\n".join(
+        [
+            title,
+            "The maintainer notes here are intentionally longer than the packet-facing excerpts.",
+            "They exist to make the synthetic smoke representative of a real PR discussion with extra narrative context.",
+            "The packet builder should still compress the actionable review-thread surface into the focused packets and global summary.",
+            "If the smoke needs to reread this text to make a dry-run-safe defer decision, packet quality has regressed.",
+        ]
+    )
+
+
+def synthetic_reply_candidate(*, mode: str, reason: str) -> dict[str, Any]:
+    return {
+        "mode": mode,
+        "comment_id": None,
+        "reason": reason,
+        "managed": False,
+        "adopted_unmarked_reply": False,
+    }
+
+
+def synthetic_thread(*, thread_id: str, path: str, line: int, reviewer_login: str, reviewer_body: str) -> dict[str, Any]:
+    reviewer_comment = {
+        "id": f"review-{thread_id}",
+        "author_login": reviewer_login,
+        "created_at": "2026-03-01T00:00:00Z",
+        "updated_at": "2026-03-01T00:00:00Z",
+        "url": f"https://example.invalid/thread/{thread_id}",
+        "body": reviewer_body,
+    }
+    return {
+        "thread_id": thread_id,
+        "is_resolved": False,
+        "is_outdated": False,
+        "path": path,
+        "line": line,
+        "start_line": line,
+        "diff_side": "RIGHT",
+        "start_diff_side": "RIGHT",
+        "original_line": line,
+        "original_start_line": line,
+        "resolved_by": None,
+        "reviewer_login": reviewer_login,
+        "reviewer_comment": reviewer_comment,
+        "latest_reviewer_comment_at": reviewer_comment["updated_at"],
+        "latest_self_reply": None,
+        "reply_candidates": {
+            "ack": synthetic_reply_candidate(mode="add", reason="no_existing_ack_reply"),
+            "complete": synthetic_reply_candidate(mode="add", reason="complete_never_adopts_unmarked_reply"),
+        },
+        "marker_conflicts": [],
+        "comments": [],
+    }
+
+
+def build_synthetic_context(temp_dir: Path) -> tuple[Path, Path]:
+    repo_root = temp_dir / "synthetic-repo"
+    context_path = temp_dir / "context.json"
+    (repo_root / ".github").mkdir(parents=True, exist_ok=True)
+    (repo_root / "src").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".github" / "pull_request_template.md").write_text(
+        "\n".join(["## Why", "## What changed", "## Testing"]),
+        encoding="utf-8",
+    )
+    (repo_root / "src" / "app.py").write_text("one\ntwo\nthree\nfour\nfive\n", encoding="utf-8")
+    (repo_root / "src" / "helper.py").write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+
+    context = {
+        "repo_root": str(repo_root),
+        "repo_slug": "example/repo",
+        "viewer_login": "codex",
+        "pr": {
+            "id": "PR_SYNTHETIC",
+            "number": 11,
+            "title": "Synthetic review-thread smoke",
+            "url": "https://example.invalid/pr/11",
+            "state": "OPEN",
+            "headRefName": "feature/synthetic-smoke",
+            "baseRefName": "main",
+            "body": synthetic_pr_body(),
+            "closingIssuesReferences": [{"number": 55}],
+        },
+        "changed_files": ["src/app.py", "src/helper.py"],
+        "changed_file_groups": {
+            "runtime": {"count": 2, "sample_files": ["src/app.py", "src/helper.py"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 0, "sample_files": []},
+            "tests": {"count": 0, "sample_files": []},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "diff_stat": " 2 files changed, 24 insertions(+), 2 deletions(-)",
+        "rule_files": {},
+        "expected_template_sections": [],
+        "conversation_comments": [
+            {
+                "id": "conversation-1",
+                "author_login": "maintainer-a",
+                "created_at": "2026-03-01T00:00:00Z",
+                "updated_at": "2026-03-01T00:00:00Z",
+                "url": "https://example.invalid/comment/conversation-1",
+                "body": synthetic_background_text("Top-level maintainer context for the synthetic smoke."),
+            },
+            {
+                "id": "conversation-2",
+                "author_login": "maintainer-b",
+                "created_at": "2026-03-01T00:05:00Z",
+                "updated_at": "2026-03-01T00:05:00Z",
+                "url": "https://example.invalid/comment/conversation-2",
+                "body": synthetic_background_text("Additional rollout and validation notes that should stay out of the common path."),
+            },
+        ],
+        "reviews": [
+            {
+                "id": "review-1",
+                "author_login": "reviewer-a",
+                "state": "COMMENTED",
+                "submitted_at": "2026-03-01T00:10:00Z",
+                "body": synthetic_background_text("Review summary that should raise local-only token cost more than packet cost."),
+            }
+        ],
+        "threads": [
+            synthetic_thread(
+                thread_id="t-1",
+                path="src/app.py",
+                line=2,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please tighten the naming here.",
+            ),
+            synthetic_thread(
+                thread_id="t-2",
+                path="src/helper.py",
+                line=2,
+                reviewer_login="reviewer-b",
+                reviewer_body="Please cover the helper behavior with a note.",
+            ),
+        ],
+    }
+    context["context_fingerprint"] = build_context_fingerprint(context)
+    write_json(context_path, context)
+    return repo_root, context_path
+
+
+def ensure_gh_auth(repo_root: Path) -> bool:
+    result = run_process(["gh", "auth", "status"], cwd=repo_root)
+    return result.returncode == 0
+
+
+def current_branch_pr(repo_root: Path) -> dict[str, Any] | None:
+    result = run_process(
+        ["gh", "pr", "view", "--json", "number,url,title,state,headRefName,baseRefName"],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) and payload.get("number") else None
+
+
+def thread_counts_from_context(context: dict[str, Any]) -> dict[str, int]:
+    threads = [thread for thread in context.get("threads", []) if not thread.get("is_resolved")]
+    outdated = [thread for thread in threads if thread.get("is_outdated")]
+    return {
+        "unresolved": len(threads),
+        "unresolved_non_outdated": len(threads) - len(outdated),
+        "unresolved_outdated": len(outdated),
+    }
+
+
+def summary(status: str, reason: str | None, thread_counts: dict[str, int], next_action: str, **extra: Any) -> dict[str, Any]:
+    payload = {
+        "status": status,
+        "reason": reason,
+        "thread_counts": thread_counts,
+        "next_action": next_action,
+    }
+    payload.update(extra)
+    return payload
+
+
+def build_safe_plan(context: dict[str, Any], *, phase: str) -> dict[str, Any]:
+    actions = []
+    for thread in context.get("threads", []):
+        if thread.get("is_resolved"):
+            continue
+        decision = "defer-outdated" if thread.get("is_outdated") else "defer"
+        action = {
+            "thread_id": thread.get("thread_id"),
+            "decision": decision,
+        }
+        if phase == "ack":
+            action["ack_mode"] = "skip"
+        else:
+            action["complete_mode"] = "skip"
+            action["resolve_after_complete"] = False
+        actions.append(action)
+    return {"thread_actions": actions}
+
+
+def merge_eval_phase(log_path: Path, phase: str, result_path: Path, *, cwd: Path) -> None:
+    run_script(
+        [
+            str(script_path("write_evaluation_log.py")),
+            "phase",
+            "--log",
+            str(log_path),
+            "--phase",
+            phase,
+            "--result",
+            str(result_path),
+        ],
+        cwd=cwd,
+    )
+
+
+def run_smoke_workflow(*, repo_root: Path, context_path: Path, temp_dir: Path) -> dict[str, Any]:
+    packet_dir = temp_dir / "packets"
+    build_result_path = temp_dir / "build-result.json"
+    eval_log_path = temp_dir / "eval-log.json"
+    ack_plan_path = temp_dir / "ack-plan.json"
+    ack_validation_path = temp_dir / "ack-validation.json"
+    ack_result_path = temp_dir / "ack-result.json"
+    complete_plan_path = temp_dir / "complete-plan.json"
+    complete_validation_path = temp_dir / "complete-validation.json"
+    complete_result_path = temp_dir / "complete-result.json"
+
+    context = read_json(context_path)
+    counts = thread_counts_from_context(context)
+    if counts["unresolved"] == 0:
+        return summary("noop", "no_unresolved_threads", counts, "nothing_to_do", pr_url=context.get("pr", {}).get("url"))
+
+    run_script(
+        [
+            str(script_path("build_review_packets.py")),
+            "--context",
+            str(context_path),
+            "--repo-root",
+            str(repo_root),
+            "--output-dir",
+            str(packet_dir),
+            "--result-output",
+            str(build_result_path),
+        ],
+        cwd=repo_root,
+    )
+    build_result = read_json(build_result_path)
+
+    run_script(
+        [
+            str(script_path("write_evaluation_log.py")),
+            "init",
+            "--context",
+            str(context_path),
+            "--orchestrator",
+            str(packet_dir / "orchestrator.json"),
+            "--output",
+            str(eval_log_path),
+        ],
+        cwd=repo_root,
+    )
+    merge_eval_phase(eval_log_path, "build", build_result_path, cwd=repo_root)
+
+    write_json(ack_plan_path, build_safe_plan(context, phase="ack"))
+    run_script(
+        [
+            str(script_path("validate_thread_action_plan.py")),
+            "--context",
+            str(context_path),
+            "--plan",
+            str(ack_plan_path),
+            "--phase",
+            "ack",
+            "--output",
+            str(ack_validation_path),
+        ],
+        cwd=repo_root,
+    )
+    merge_eval_phase(eval_log_path, "validate", ack_validation_path, cwd=repo_root)
+    run_script(
+        [
+            str(script_path("apply_thread_action_plan.py")),
+            "--context",
+            str(context_path),
+            "--plan",
+            str(ack_validation_path),
+            "--phase",
+            "ack",
+            "--dry-run",
+            "--result-output",
+            str(ack_result_path),
+        ],
+        cwd=repo_root,
+    )
+    merge_eval_phase(eval_log_path, "apply", ack_result_path, cwd=repo_root)
+
+    write_json(complete_plan_path, build_safe_plan(context, phase="complete"))
+    run_script(
+        [
+            str(script_path("validate_thread_action_plan.py")),
+            "--context",
+            str(context_path),
+            "--plan",
+            str(complete_plan_path),
+            "--phase",
+            "complete",
+            "--output",
+            str(complete_validation_path),
+        ],
+        cwd=repo_root,
+    )
+    merge_eval_phase(eval_log_path, "validate", complete_validation_path, cwd=repo_root)
+    run_script(
+        [
+            str(script_path("apply_thread_action_plan.py")),
+            "--context",
+            str(context_path),
+            "--plan",
+            str(complete_validation_path),
+            "--phase",
+            "complete",
+            "--dry-run",
+            "--result-output",
+            str(complete_result_path),
+        ],
+        cwd=repo_root,
+    )
+    merge_eval_phase(eval_log_path, "apply", complete_result_path, cwd=repo_root)
+
+    packet_metrics = read_json(packet_dir / "packet_metrics.json")
+    return summary(
+        "ok",
+        None,
+        counts,
+        "review_smoke_results",
+        pr_url=context.get("pr", {}).get("url"),
+        review_mode=build_result.get("review_mode"),
+        common_path_sufficient=build_result.get("common_path_sufficient"),
+        estimated_packet_tokens=packet_metrics.get("estimated_packet_tokens"),
+        estimated_delegation_savings=packet_metrics.get("estimated_delegation_savings"),
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "gh-address-review-threads"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    if args.synthetic:
+        with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-synthetic-") as temp_dir_name:
+            temp_dir = Path(temp_dir_name)
+            repo_root, context_path = build_synthetic_context(temp_dir)
+            print(json.dumps(run_smoke_workflow(repo_root=repo_root, context_path=context_path, temp_dir=temp_dir), indent=2, ensure_ascii=True))
+            return 0
+
+    repo_root = repo_root_path(args.repo_root)
+
+    try:
+        gh_authed = ensure_gh_auth(repo_root)
+    except GhCliMissing:
+        print(
+            json.dumps(
+                summary("blocked", "gh_cli_missing", {"unresolved": 0, "unresolved_non_outdated": 0, "unresolved_outdated": 0}, "install_gh_cli"),
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+        return 0
+
+    if not gh_authed:
+        print(
+            json.dumps(
+                summary("blocked", "gh_auth_missing", {"unresolved": 0, "unresolved_non_outdated": 0, "unresolved_outdated": 0}, "run_gh_auth_login"),
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+        return 0
+
+    try:
+        pr = current_branch_pr(repo_root)
+    except GhCliMissing:
+        print(
+            json.dumps(
+                summary("blocked", "gh_cli_missing", {"unresolved": 0, "unresolved_non_outdated": 0, "unresolved_outdated": 0}, "install_gh_cli"),
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+        return 0
+    if not pr:
+        print(
+            json.dumps(
+                summary("blocked", "no_open_pr", {"unresolved": 0, "unresolved_non_outdated": 0, "unresolved_outdated": 0}, "open_pr_for_current_branch"),
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+        return 0
+
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-live-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        context_path = temp_dir / "context.json"
+        run_script(
+            [
+                str(script_path("collect_review_threads.py")),
+                "--repo",
+                str(repo_root),
+                "--output",
+                str(context_path),
+            ],
+            cwd=repo_root,
+        )
+        print(json.dumps(run_smoke_workflow(repo_root=repo_root, context_path=context_path, temp_dir=temp_dir), indent=2, ensure_ascii=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/thread_action_contract.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/thread_action_contract.py
@@ -358,6 +358,20 @@ def _base_counters() -> dict[str, Any]:
     }
 
 
+def normalize_reconciliation_summary(payload: Any) -> dict[str, int] | None:
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("reconciliation_summary")
+    if not isinstance(raw, dict):
+        return None
+    return {
+        "outdated_transition_candidates": _int_or_zero(raw.get("outdated_transition_candidates")),
+        "outdated_auto_resolved": _int_or_zero(raw.get("outdated_auto_resolved")),
+        "outdated_recheck_ambiguous": _int_or_zero(raw.get("outdated_recheck_ambiguous")),
+        "outdated_still_applicable": _int_or_zero(raw.get("outdated_still_applicable")),
+    }
+
+
 def validate_thread_action_payload(context: dict[str, Any], payload: Any, phase: str) -> dict[str, Any]:
     policy = policy_for_phase(phase)
     mode_field = policy["mode_field"]
@@ -375,6 +389,9 @@ def validate_thread_action_payload(context: dict[str, Any], payload: Any, phase:
         "normalized_thread_actions": [],
         "stop_reasons": [],
     }
+    reconciliation_summary = normalize_reconciliation_summary(payload)
+    if reconciliation_summary is not None:
+        result["reconciliation_summary"] = reconciliation_summary
 
     payload_fingerprint = _stringify(payload.get("context_fingerprint")) if isinstance(payload, dict) else ""
     if payload_fingerprint and payload_fingerprint != result["context_fingerprint"]:

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/thread_action_contract.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/thread_action_contract.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+PHASES = ("ack", "complete")
+DECISIONS = {"accept", "reject", "defer", "defer-outdated"}
+ACTION_MODES = {"add", "update", "skip"}
+MARKER_CONFLICT_SEVERITIES = ("warning", "adoption-blocking", "hard-stop")
+
+PHASE_FIELD_POLICY = {
+    "ack": {
+        "mode_field": "ack_mode",
+        "body_field": "ack_body",
+        "comment_id_field": "ack_comment_id",
+        "required_common": ["thread_id", "decision"],
+        "allowed_modes": ["add", "update", "skip"],
+        "body_required_when": ["add", "update"],
+        "comment_id_rules": {
+            "add": "ignore",
+            "update": "explicit_or_reply_candidate_fallback",
+            "skip": "ignore",
+        },
+        "extra_rules": [],
+    },
+    "complete": {
+        "mode_field": "complete_mode",
+        "body_field": "complete_body",
+        "comment_id_field": "complete_comment_id",
+        "required_common": ["thread_id", "decision"],
+        "allowed_modes": ["add", "update", "skip"],
+        "body_required_when": ["add", "update"],
+        "comment_id_rules": {
+            "add": "ignore",
+            "update": "explicit_or_reply_candidate_fallback",
+            "skip": "ignore",
+        },
+        "extra_rules": ["accept_only", "resolve_after_complete_requires_non_skip_accept"],
+    },
+}
+
+VALIDATION_ERROR_CODES = {
+    "invalid_plan_shape",
+    "missing_thread_id",
+    "unknown_thread_id",
+    "invalid_decision",
+    "invalid_mode",
+    "missing_required_body",
+    "missing_update_target",
+    "invalid_complete_for_non_accept",
+    "invalid_resolve_after_complete",
+    "adoption_blocked_update",
+    "hard_stop_marker_conflict",
+    "stale_context_fingerprint",
+}
+
+VALIDATION_WARNING_CODES = {
+    "unknown_action_field_ignored",
+    "ignored_comment_id_for_add",
+    "ignored_comment_id_for_skip",
+    "ignored_body_for_skip",
+    "ignored_resolve_after_complete_outside_complete",
+}
+
+
+def policy_for_phase(phase: str) -> dict[str, Any]:
+    if phase not in PHASE_FIELD_POLICY:
+        raise RuntimeError(f"Unsupported phase: {phase}")
+    return PHASE_FIELD_POLICY[phase]
+
+
+def _stringify(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _int_or_zero(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _timestamp(value: dict[str, Any] | None) -> str:
+    if not isinstance(value, dict):
+        return ""
+    return _stringify(value.get("updated_at") or value.get("created_at"))
+
+
+def comment_sort_key(comment: dict[str, Any]) -> tuple[str, str]:
+    return (_timestamp(comment), _stringify(comment.get("id")))
+
+
+def thread_sort_key(thread: dict[str, Any]) -> tuple[str, int, str]:
+    line = thread.get("line")
+    if line in {None, ""}:
+        line = thread.get("original_line")
+    return (
+        _stringify(thread.get("path")),
+        _int_or_zero(line),
+        _stringify(thread.get("thread_id")),
+    )
+
+
+def normalize_marker_conflicts(thread: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = thread.get("marker_conflicts")
+    normalized: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            phase = _stringify(item.get("phase"))
+            severity = _stringify(item.get("severity"))
+            if phase not in PHASES or severity not in MARKER_CONFLICT_SEVERITIES:
+                continue
+            comment_ids = sorted({_stringify(value) for value in item.get("comment_ids", []) if _stringify(value)})
+            normalized.append(
+                {
+                    "phase": phase,
+                    "severity": severity,
+                    "reason": _stringify(item.get("reason")),
+                    "comment_ids": comment_ids,
+                    "blocks_adoption": bool(item.get("blocks_adoption")),
+                    "blocks_update": bool(item.get("blocks_update")),
+                    "blocks_apply": bool(item.get("blocks_apply")),
+                }
+            )
+    elif isinstance(raw, dict):
+        for phase in PHASES:
+            comment_ids = sorted({_stringify(value) for value in raw.get(phase, []) if _stringify(value)})
+            if comment_ids:
+                normalized.append(
+                    {
+                        "phase": phase,
+                        "severity": "warning",
+                        "reason": "legacy_duplicate_exact_managed_replies",
+                        "comment_ids": comment_ids,
+                        "blocks_adoption": False,
+                        "blocks_update": False,
+                        "blocks_apply": False,
+                    }
+                )
+    normalized.sort(
+        key=lambda item: (
+            _stringify(item.get("phase")),
+            _stringify(item.get("severity")),
+            _stringify(item.get("reason")),
+            list(item.get("comment_ids", [])),
+        )
+    )
+    return normalized
+
+
+def conflicts_for_phase(thread: dict[str, Any], phase: str) -> list[dict[str, Any]]:
+    return [item for item in normalize_marker_conflicts(thread) if item.get("phase") == phase]
+
+
+def reply_candidate(thread: dict[str, Any], phase: str) -> dict[str, Any]:
+    payload = thread.get("reply_candidates")
+    if not isinstance(payload, dict):
+        return {
+            "mode": "add",
+            "comment_id": None,
+            "reason": "missing_reply_candidates",
+            "managed": False,
+            "adopted_unmarked_reply": False,
+        }
+    candidate = payload.get(phase)
+    if not isinstance(candidate, dict):
+        return {
+            "mode": "add",
+            "comment_id": None,
+            "reason": "missing_reply_candidate_phase",
+            "managed": False,
+            "adopted_unmarked_reply": False,
+        }
+    return {
+        "mode": _stringify(candidate.get("mode")) or "add",
+        "comment_id": _stringify(candidate.get("comment_id")) or None,
+        "reason": _stringify(candidate.get("reason")),
+        "managed": bool(candidate.get("managed")),
+        "adopted_unmarked_reply": bool(candidate.get("adopted_unmarked_reply")),
+    }
+
+
+def exact_managed_target_id(thread: dict[str, Any], phase: str) -> str | None:
+    matches = [
+        comment
+        for comment in thread.get("comments", [])
+        if isinstance(comment, dict)
+        and bool(comment.get("is_self"))
+        and _stringify(comment.get("managed_phase")) == phase
+        and bool(comment.get("has_exact_managed_marker"))
+    ]
+    if not matches:
+        return None
+    matches.sort(key=comment_sort_key)
+    target = _stringify(matches[-1].get("id"))
+    return target or None
+
+
+def marker_conflict_summary(threads: list[dict[str, Any]]) -> dict[str, Any]:
+    conflicts = [item for thread in threads for item in normalize_marker_conflicts(thread)]
+    by_severity = {severity: 0 for severity in MARKER_CONFLICT_SEVERITIES}
+    by_phase = {phase: 0 for phase in PHASES}
+    for item in conflicts:
+        severity = _stringify(item.get("severity"))
+        phase = _stringify(item.get("phase"))
+        if severity in by_severity:
+            by_severity[severity] += 1
+        if phase in by_phase:
+            by_phase[phase] += 1
+    return {
+        "count": len(conflicts),
+        "by_severity": by_severity,
+        "by_phase": by_phase,
+    }
+
+
+def build_context_fingerprint(context: dict[str, Any]) -> str:
+    pr = context.get("pr", {}) if isinstance(context.get("pr"), dict) else {}
+    unresolved_threads = [
+        thread
+        for thread in context.get("threads", [])
+        if isinstance(thread, dict) and not bool(thread.get("is_resolved"))
+    ]
+    unresolved_threads.sort(key=thread_sort_key)
+
+    fingerprint_payload = {
+        "pr_number": pr.get("number"),
+        "head_ref": pr.get("headRefName"),
+        "base_ref": pr.get("baseRefName"),
+        "changed_files": sorted({_stringify(path) for path in context.get("changed_files", []) if _stringify(path)}),
+        "diff_stat": _stringify(context.get("diff_stat")),
+        "threads": [
+            {
+                "thread_id": _stringify(thread.get("thread_id")),
+                "path": _stringify(thread.get("path")),
+                "line": thread.get("line"),
+                "original_line": thread.get("original_line"),
+                "is_outdated": bool(thread.get("is_outdated")),
+                "latest_comment_at": max((_timestamp(comment) for comment in thread.get("comments", []) if isinstance(comment, dict)), default=""),
+                "latest_reviewer_comment_at": _stringify(thread.get("latest_reviewer_comment_at")),
+                "marker_conflicts": normalize_marker_conflicts(thread),
+            }
+            for thread in unresolved_threads
+        ],
+        "marker_conflict_summary": marker_conflict_summary(unresolved_threads),
+    }
+    encoded = json.dumps(
+        fingerprint_payload,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def context_fingerprint(context: dict[str, Any]) -> str:
+    existing = _stringify(context.get("context_fingerprint"))
+    return existing or build_context_fingerprint(context)
+
+
+def validation_message(code: str, *, thread_id: str | None = None, phase: str | None = None, field: str | None = None) -> str:
+    prefix = f"thread {thread_id}: " if thread_id else ""
+    if code == "missing_update_target":
+        return f"{prefix}{phase}_mode=update requires explicit {phase}_comment_id or reply_candidates.{phase}.comment_id fallback"
+    if code == "invalid_complete_for_non_accept":
+        return f"{prefix}complete actions are only valid for accepted threads"
+    if code == "adoption_blocked_update":
+        return f"{prefix}{phase}_mode=update cannot rely on reply_candidates.{phase} because marker_conflicts severity=adoption-blocking"
+    if code == "hard_stop_marker_conflict":
+        return f"{prefix}{phase} actions are blocked because marker_conflicts severity=hard-stop"
+    if code == "stale_context_fingerprint":
+        return "plan context_fingerprint does not match the current context"
+    if code == "unknown_action_field_ignored":
+        return f"{prefix}ignored unknown field `{field}`"
+    if code == "ignored_comment_id_for_add":
+        return f"{prefix}{phase}_comment_id is ignored when {phase}_mode=add"
+    if code == "ignored_comment_id_for_skip":
+        return f"{prefix}{phase}_comment_id is ignored when {phase}_mode=skip"
+    if code == "ignored_body_for_skip":
+        return f"{prefix}{phase}_body is ignored when {phase}_mode=skip"
+    if code == "ignored_resolve_after_complete_outside_complete":
+        return f"{prefix}resolve_after_complete is ignored outside a valid complete action"
+    if code == "missing_required_body":
+        return f"{prefix}{phase}_body is required when {phase}_mode is add or update"
+    if code == "invalid_resolve_after_complete":
+        return f"{prefix}resolve_after_complete is only valid when phase=complete, decision=accept, and complete_mode is not skip"
+    if code == "invalid_mode":
+        return f"{prefix}invalid {phase}_mode"
+    if code == "invalid_decision":
+        return f"{prefix}invalid decision"
+    if code == "missing_thread_id":
+        return "each plan entry must include thread_id"
+    if code == "unknown_thread_id":
+        return f"{prefix}thread_id is not present in the context"
+    if code == "invalid_plan_shape":
+        return "plan JSON must be a list or contain `thread_actions`, `actions`, or `normalized_thread_actions`"
+    return code
+
+
+def build_issue(
+    level: str,
+    code: str,
+    *,
+    thread_id: str | None = None,
+    phase: str | None = None,
+    field: str | None = None,
+) -> dict[str, Any]:
+    issue = {
+        "level": level,
+        "code": code,
+        "message": validation_message(code, thread_id=thread_id, phase=phase, field=field),
+    }
+    if thread_id:
+        issue["thread_id"] = thread_id
+    if phase:
+        issue["phase"] = phase
+    if field:
+        issue["field"] = field
+    return issue
+
+
+def extract_plan_entries(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("thread_actions", "actions", "normalized_thread_actions"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return list(value)
+    raise RuntimeError(validation_message("invalid_plan_shape"))
+
+
+def _decision_counters() -> dict[str, int]:
+    return {
+        "threads_accepted": 0,
+        "threads_rejected": 0,
+        "threads_deferred": 0,
+        "threads_defer_outdated": 0,
+    }
+
+
+def _base_counters() -> dict[str, Any]:
+    return {
+        "entry_count": 0,
+        "normalized_entry_count": 0,
+        "error_count": 0,
+        "warning_count": 0,
+        "unknown_fields_ignored": 0,
+        "adopted_unmarked_reply_count": 0,
+        "skipped_outdated_count": 0,
+        "invalid_complete_count": 0,
+        "resolve_after_complete_count": 0,
+        **_decision_counters(),
+    }
+
+
+def validate_thread_action_payload(context: dict[str, Any], payload: Any, phase: str) -> dict[str, Any]:
+    policy = policy_for_phase(phase)
+    mode_field = policy["mode_field"]
+    body_field = policy["body_field"]
+    comment_id_field = policy["comment_id_field"]
+
+    result = {
+        "phase": phase,
+        "valid": True,
+        "context_fingerprint": context_fingerprint(context),
+        "fingerprint_match": True,
+        "errors": [],
+        "warnings": [],
+        "counters": _base_counters(),
+        "normalized_thread_actions": [],
+        "stop_reasons": [],
+    }
+
+    payload_fingerprint = _stringify(payload.get("context_fingerprint")) if isinstance(payload, dict) else ""
+    if payload_fingerprint and payload_fingerprint != result["context_fingerprint"]:
+        result["fingerprint_match"] = False
+        result["errors"].append(build_issue("error", "stale_context_fingerprint"))
+        result["stop_reasons"].append(validation_message("stale_context_fingerprint"))
+
+    try:
+        entries = extract_plan_entries(payload)
+    except RuntimeError:
+        result["errors"].append(build_issue("error", "invalid_plan_shape"))
+        result["valid"] = False
+        result["counters"]["error_count"] = 1
+        return result
+
+    result["counters"]["entry_count"] = len(entries)
+    threads_by_id = {
+        _stringify(thread.get("thread_id")): thread
+        for thread in context.get("threads", [])
+        if isinstance(thread, dict) and _stringify(thread.get("thread_id"))
+    }
+    allowed_keys = set(policy["required_common"]) | {mode_field, body_field, comment_id_field, "resolve_after_complete"}
+
+    normalized_entries: list[dict[str, Any]] = []
+
+    for raw_entry in entries:
+        if not isinstance(raw_entry, dict):
+            result["errors"].append(build_issue("error", "invalid_plan_shape"))
+            continue
+
+        thread_id = _stringify(raw_entry.get("thread_id"))
+        if not thread_id:
+            result["errors"].append(build_issue("error", "missing_thread_id", phase=phase))
+            continue
+        thread = threads_by_id.get(thread_id)
+        if thread is None:
+            result["errors"].append(build_issue("error", "unknown_thread_id", thread_id=thread_id, phase=phase))
+            continue
+
+        for key in sorted(set(raw_entry) - allowed_keys):
+            result["warnings"].append(
+                build_issue(
+                    "warning",
+                    "unknown_action_field_ignored",
+                    thread_id=thread_id,
+                    phase=phase,
+                    field=key,
+                )
+            )
+            result["counters"]["unknown_fields_ignored"] += 1
+
+        decision = _stringify(raw_entry.get("decision"))
+        if decision not in DECISIONS:
+            result["errors"].append(build_issue("error", "invalid_decision", thread_id=thread_id, phase=phase))
+            continue
+
+        raw_mode = raw_entry.get(mode_field)
+        mode = _stringify(raw_mode) or "skip"
+        if mode not in ACTION_MODES:
+            result["errors"].append(build_issue("error", "invalid_mode", thread_id=thread_id, phase=phase))
+            continue
+
+        phase_conflicts = conflicts_for_phase(thread, phase)
+        if any(item.get("severity") == "hard-stop" for item in phase_conflicts) and mode != "skip":
+            result["errors"].append(build_issue("error", "hard_stop_marker_conflict", thread_id=thread_id, phase=phase))
+            continue
+
+        if phase == "complete" and decision != "accept" and mode != "skip":
+            result["errors"].append(build_issue("error", "invalid_complete_for_non_accept", thread_id=thread_id, phase=phase))
+            result["counters"]["invalid_complete_count"] += 1
+            continue
+
+        normalized_entry: dict[str, Any] = {
+            "thread_id": thread_id,
+            "decision": decision,
+            mode_field: mode,
+        }
+
+        body = _stringify(raw_entry.get(body_field))
+        explicit_comment_id = _stringify(raw_entry.get(comment_id_field))
+        fallback_comment_id = reply_candidate(thread, phase).get("comment_id")
+        adopted_candidate = bool(reply_candidate(thread, phase).get("adopted_unmarked_reply"))
+        exact_managed_id = exact_managed_target_id(thread, phase)
+        adoption_blocked = any(item.get("severity") == "adoption-blocking" for item in phase_conflicts)
+
+        if mode == "skip":
+            if body:
+                result["warnings"].append(build_issue("warning", "ignored_body_for_skip", thread_id=thread_id, phase=phase))
+            if explicit_comment_id:
+                result["warnings"].append(build_issue("warning", "ignored_comment_id_for_skip", thread_id=thread_id, phase=phase))
+            if bool(raw_entry.get("resolve_after_complete")):
+                if phase == "complete":
+                    result["errors"].append(build_issue("error", "invalid_resolve_after_complete", thread_id=thread_id, phase=phase))
+                    result["counters"]["invalid_complete_count"] += 1
+                    continue
+                result["warnings"].append(
+                    build_issue("warning", "ignored_resolve_after_complete_outside_complete", thread_id=thread_id, phase=phase)
+                )
+        else:
+            if not body:
+                result["errors"].append(build_issue("error", "missing_required_body", thread_id=thread_id, phase=phase))
+                continue
+            normalized_entry[body_field] = body
+
+            if mode == "add":
+                if explicit_comment_id:
+                    result["warnings"].append(build_issue("warning", "ignored_comment_id_for_add", thread_id=thread_id, phase=phase))
+            elif mode == "update":
+                resolved_comment_id = explicit_comment_id or _stringify(fallback_comment_id)
+                if adoption_blocked:
+                    exact_managed_allowed = bool(explicit_comment_id and exact_managed_id and explicit_comment_id == exact_managed_id)
+                    fallback_relies_on_adoption = not explicit_comment_id and adopted_candidate
+                    explicit_not_exact = bool(explicit_comment_id and (not exact_managed_id or explicit_comment_id != exact_managed_id))
+                    if fallback_relies_on_adoption or explicit_not_exact:
+                        result["errors"].append(build_issue("error", "adoption_blocked_update", thread_id=thread_id, phase=phase))
+                        continue
+                if not resolved_comment_id:
+                    result["errors"].append(build_issue("error", "missing_update_target", thread_id=thread_id, phase=phase))
+                    continue
+                normalized_entry[comment_id_field] = resolved_comment_id
+                if not explicit_comment_id and adopted_candidate:
+                    result["counters"]["adopted_unmarked_reply_count"] += 1
+
+        if phase == "complete":
+            resolve_after_complete = bool(raw_entry.get("resolve_after_complete"))
+            if resolve_after_complete:
+                if decision == "accept" and mode != "skip":
+                    normalized_entry["resolve_after_complete"] = True
+                    result["counters"]["resolve_after_complete_count"] += 1
+                else:
+                    result["errors"].append(build_issue("error", "invalid_resolve_after_complete", thread_id=thread_id, phase=phase))
+                    result["counters"]["invalid_complete_count"] += 1
+                    continue
+        elif bool(raw_entry.get("resolve_after_complete")):
+            result["warnings"].append(
+                build_issue("warning", "ignored_resolve_after_complete_outside_complete", thread_id=thread_id, phase=phase)
+            )
+
+        if decision == "accept":
+            result["counters"]["threads_accepted"] += 1
+        elif decision == "reject":
+            result["counters"]["threads_rejected"] += 1
+        elif decision == "defer":
+            result["counters"]["threads_deferred"] += 1
+        elif decision == "defer-outdated":
+            result["counters"]["threads_defer_outdated"] += 1
+            result["counters"]["skipped_outdated_count"] += 1
+
+        normalized_entries.append(normalized_entry)
+
+    normalized_entries.sort(
+        key=lambda item: thread_sort_key(threads_by_id.get(_stringify(item.get("thread_id")), {"thread_id": item.get("thread_id")}))
+    )
+    result["normalized_thread_actions"] = normalized_entries
+    result["counters"]["normalized_entry_count"] = len(normalized_entries)
+    result["counters"]["error_count"] = len(result["errors"])
+    result["counters"]["warning_count"] = len(result["warnings"])
+    result["valid"] = not result["errors"] and bool(result["fingerprint_match"])
+    return result
+
+
+def load_normalized_plan_envelope(context: dict[str, Any], payload: Any, phase: str) -> dict[str, Any]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("normalized_thread_actions"), list):
+        raise RuntimeError("plan must be normalized output from validate_thread_action_plan.py")
+    if _stringify(payload.get("phase")) not in {"", phase}:
+        raise RuntimeError(f"plan phase does not match requested phase `{phase}`")
+    validated = validate_thread_action_payload(context, payload, phase)
+    if not bool(payload.get("valid")):
+        raise RuntimeError("normalized plan is marked invalid")
+    if not validated["valid"]:
+        first_error = validated["errors"][0]["message"] if validated["errors"] else "normalized plan validation failed"
+        raise RuntimeError(first_error)
+    return validated

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/validate_thread_action_plan.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/validate_thread_action_plan.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate and normalize thread action plans for PR review threads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from thread_action_contract import validate_thread_action_payload
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate and normalize thread action plans for PR review threads."
+    )
+    parser.add_argument("--context", type=Path, required=True, help="Path to JSON from collect_review_threads.py")
+    parser.add_argument("--plan", type=Path, required=True, help="Path to raw thread-actions JSON")
+    parser.add_argument("--phase", choices=["ack", "complete"], required=True, help="Action phase to validate")
+    parser.add_argument("--output", type=Path, help="Optional path to write the normalized validation JSON")
+    args = parser.parse_args()
+
+    try:
+        context = load_json(args.context)
+        plan = load_json(args.plan)
+        payload = validate_thread_action_payload(context, plan, args.phase)
+    except RuntimeError as exc:
+        print(f"validate_thread_action_plan.py: {exc}", file=sys.stderr)
+        return 1
+
+    write_json(args.output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/write_evaluation_log.py
@@ -1,0 +1,1104 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals: list[str] = []
+    seen: set[str] = set()
+    for key in ("review_mode_overrides", "review_overrides"):
+        for item in orchestrator.get(key, []):
+            if isinstance(item, dict):
+                reason = str(item.get("reason") or "").strip()
+                if reason and reason not in seen:
+                    seen.add(reason)
+                    signals.append(reason)
+            else:
+                text = str(item).strip()
+                if text and text not in seen:
+                    seen.add(text)
+                    signals.append(text)
+    return signals
+
+
+def load_packet_metrics_from_build_result(result: dict[str, Any]) -> dict[str, Any]:
+    packet_metrics_file = result.get("packet_metrics_file")
+    if not packet_metrics_file:
+        return {}
+    path = Path(str(packet_metrics_file))
+    if not path.is_file():
+        return {}
+    payload = load_json(path)
+    return payload if isinstance(payload, dict) else {}
+
+
+def common_path_failure_reasons(result: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    for item in result.get("common_path_failures") or []:
+        if not isinstance(item, dict):
+            continue
+        for reason in item.get("explicit_reread_reasons") or []:
+            text = str(reason).strip()
+            if text and text not in reasons:
+                reasons.append(text)
+    return reasons
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        marker_summary = orchestrator.get("marker_conflict_summary", {})
+        return {
+            "review_mode": orchestrator.get("review_mode"),
+            "packet_count": len(packet_files(orchestrator)),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "thread_batch_count": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "singleton_thread_packet_count": sum(1 for name in packet_files(orchestrator) if name.startswith("thread-")),
+            "common_path_sufficient": None,
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+            "marker_conflicts_warning": safe_int((marker_summary.get("by_severity") or {}).get("warning")) or 0,
+            "marker_conflicts_adoption_blocking": safe_int((marker_summary.get("by_severity") or {}).get("adoption-blocking")) or 0,
+            "marker_conflicts_hard_stop": safe_int((marker_summary.get("by_severity") or {}).get("hard-stop")) or 0,
+            "adopted_unmarked_reply_count": 0,
+            "skipped_outdated_count": 0,
+            "invalid_complete_count": 0,
+            "resolve_after_complete_count": 0,
+            "validation_commands": [],
+            "final_pr_url": context.get("pr", {}).get("url"),
+            "estimated_packet_tokens": None,
+            "estimated_delegation_savings": None,
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        baseline = log.setdefault("baseline", {})
+        measurement = log.setdefault("measurement", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        if isinstance(result.get("recommended_workers"), list):
+            orchestration["worker_roles"] = [
+                str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+                for item in result["recommended_workers"]
+                if isinstance(item, dict) and str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+            ]
+        override_reasons = []
+        for item in result.get("override_signals") or []:
+            if isinstance(item, dict):
+                reason = str(item.get("reason") or "").strip()
+                if reason:
+                    override_reasons.append(reason)
+        if override_reasons:
+            orchestration["override_signals"] = override_reasons
+        common_path_sufficient = to_bool(result.get("common_path_sufficient"))
+        if common_path_sufficient is not None:
+            skill_data["common_path_sufficient"] = common_path_sufficient
+            orchestration["raw_reread_required"] = not common_path_sufficient
+        reread_reasons = common_path_failure_reasons(result)
+        if reread_reasons:
+            orchestration["raw_reread_reason"] = reread_reasons[0] if len(reread_reasons) == 1 else "multiple"
+            orchestration["stop_reasons"] = list(dict.fromkeys(list(orchestration.get("stop_reasons") or []) + reread_reasons))
+        thread_counts = result.get("thread_counts") or {}
+        unresolved = safe_int(thread_counts.get("unresolved"))
+        outdated = safe_int(thread_counts.get("unresolved_outdated"))
+        if unresolved is not None:
+            skill_data["threads_seen"] = unresolved
+        if outdated is not None:
+            skill_data["outdated_threads_seen"] = outdated
+        batch_count = safe_int(result.get("thread_batch_count"))
+        if batch_count is not None:
+            skill_data["thread_batch_count"] = batch_count
+        singleton_count = safe_int(result.get("singleton_thread_packet_count"))
+        if singleton_count is not None:
+            skill_data["singleton_thread_packet_count"] = singleton_count
+        packet_metrics = load_packet_metrics_from_build_result(result)
+        packet_count = safe_int(packet_metrics.get("packet_count"))
+        if packet_count is not None:
+            skill_data["packet_count"] = packet_count
+        estimated_local = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+        estimated_packet = safe_int(packet_metrics.get("estimated_packet_tokens"))
+        estimated_savings = safe_int(packet_metrics.get("estimated_delegation_savings"))
+        if estimated_local is not None:
+            baseline["estimated_local_only_tokens"] = estimated_local
+        if estimated_savings is not None:
+            baseline["estimated_token_savings"] = estimated_savings
+            baseline["estimated_delegation_savings"] = estimated_savings
+            skill_data["estimated_delegation_savings"] = estimated_savings
+        if estimated_packet is not None:
+            skill_data["estimated_packet_tokens"] = estimated_packet
+        if packet_metrics:
+            measurement["token_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        merge_skill_counters(skill_data, result.get("counters"))
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+            if log.get("skill", {}).get("name") == "gh-address-review-threads":
+                resolved = sum(1 for item in mutations if isinstance(item, dict) and item.get("kind") == "resolve_thread")
+                if resolved:
+                    skill_data["threads_resolved"] = resolved
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+        merge_skill_counters(skill_data, result.get("counters"))
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def merge_skill_counters(skill_data: dict[str, Any], counters: Any) -> None:
+    if not isinstance(skill_data, dict) or not isinstance(counters, dict):
+        return
+    for key in (
+        "adopted_unmarked_reply_count",
+        "skipped_outdated_count",
+        "invalid_complete_count",
+        "resolve_after_complete_count",
+        "threads_accepted",
+        "threads_rejected",
+        "threads_deferred",
+        "threads_defer_outdated",
+    ):
+        value = safe_int(counters.get(key))
+        if value is not None:
+            skill_data[key] = value
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/scripts/write_evaluation_log.py
@@ -381,6 +381,9 @@ def skill_specific_data(
             "threads_defer_outdated": None,
             "threads_resolved": None,
             "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "outdated_transition_candidates": 0,
+            "outdated_auto_resolved": 0,
+            "outdated_recheck_ambiguous": 0,
             "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
             "marker_conflicts_warning": safe_int((marker_summary.get("by_severity") or {}).get("warning")) or 0,
             "marker_conflicts_adoption_blocking": safe_int((marker_summary.get("by_severity") or {}).get("adoption-blocking")) or 0,
@@ -786,6 +789,12 @@ def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], 
         singleton_count = safe_int(result.get("singleton_thread_packet_count"))
         if singleton_count is not None:
             skill_data["singleton_thread_packet_count"] = singleton_count
+        outdated_transition_candidates = safe_int(result.get("outdated_transition_candidates"))
+        if outdated_transition_candidates is not None:
+            skill_data["outdated_transition_candidates"] = outdated_transition_candidates
+        outdated_recheck_ambiguous = safe_int(result.get("outdated_recheck_ambiguous"))
+        if outdated_recheck_ambiguous is not None:
+            skill_data["outdated_recheck_ambiguous"] = outdated_recheck_ambiguous
         packet_metrics = load_packet_metrics_from_build_result(result)
         packet_count = safe_int(packet_metrics.get("packet_count"))
         if packet_count is not None:
@@ -902,6 +911,16 @@ def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], 
         if isinstance(secondary, list):
             outputs["secondary_artifacts"] = secondary
         merge_skill_counters(skill_data, result.get("counters"))
+        reconciliation_summary = result.get("reconciliation_summary")
+        if isinstance(reconciliation_summary, dict):
+            for key in (
+                "outdated_transition_candidates",
+                "outdated_auto_resolved",
+                "outdated_recheck_ambiguous",
+            ):
+                value = safe_int(reconciliation_summary.get(key))
+                if value is not None:
+                    skill_data[key] = value
 
         stop_reasons = result.get("stop_reasons") or []
         if isinstance(stop_reasons, list) and stop_reasons:
@@ -937,6 +956,9 @@ def merge_skill_counters(skill_data: dict[str, Any], counters: Any) -> None:
         "threads_rejected",
         "threads_deferred",
         "threads_defer_outdated",
+        "outdated_transition_candidates",
+        "outdated_auto_resolved",
+        "outdated_recheck_ambiguous",
     ):
         value = safe_int(counters.get(key))
         if value is not None:

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/review_thread_test_support.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/review_thread_test_support.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def pr_body() -> str:
+    return "\n".join(
+        [
+            "## Why",
+            "Make review-thread packet routing predictable.",
+            "## What changed",
+            "Cluster related threads and keep outdated ones out of worker routing.",
+            "## How",
+            "Build thread-batch packets before singleton thread packets.",
+            "## Risk / Rollback",
+            "Low risk.",
+            "## Testing",
+            "Run the packet builder against temp fixtures.",
+        ]
+    )
+
+
+def reply_candidate(
+    *,
+    mode: str,
+    comment_id: str | None,
+    reason: str,
+    managed: bool,
+    adopted_unmarked_reply: bool,
+) -> dict[str, Any]:
+    return {
+        "mode": mode,
+        "comment_id": comment_id,
+        "reason": reason,
+        "managed": managed,
+        "adopted_unmarked_reply": adopted_unmarked_reply,
+    }
+
+
+def marker_conflict(
+    *,
+    phase: str,
+    severity: str,
+    reason: str,
+    comment_ids: list[str],
+    blocks_adoption: bool,
+    blocks_update: bool,
+    blocks_apply: bool,
+) -> dict[str, Any]:
+    return {
+        "phase": phase,
+        "severity": severity,
+        "reason": reason,
+        "comment_ids": comment_ids,
+        "blocks_adoption": blocks_adoption,
+        "blocks_update": blocks_update,
+        "blocks_apply": blocks_apply,
+    }
+
+
+def comment(
+    *,
+    comment_id: str,
+    author_login: str,
+    body: str,
+    created_at: str,
+    updated_at: str | None = None,
+    managed_phase: str | None = None,
+    managed_thread_id: str | None = None,
+    has_exact_managed_marker: bool = False,
+    is_self: bool | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": comment_id,
+        "author_login": author_login,
+        "body": body,
+        "created_at": created_at,
+        "updated_at": updated_at or created_at,
+        "managed_phase": managed_phase,
+        "managed_thread_id": managed_thread_id,
+        "has_exact_managed_marker": has_exact_managed_marker,
+        "is_self": author_login == "codex" if is_self is None else is_self,
+        "url": f"https://example.invalid/comment/{comment_id}",
+    }
+
+
+def review_thread(
+    *,
+    thread_id: str,
+    path: str,
+    line: int,
+    reviewer_login: str,
+    reviewer_body: str,
+    is_outdated: bool = False,
+    reply_candidates: dict[str, Any] | None = None,
+    marker_conflicts: list[dict[str, Any]] | None = None,
+    comments: list[dict[str, Any]] | None = None,
+    latest_self_reply: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    reviewer_comment = {
+        "id": f"review-{thread_id}",
+        "author_login": reviewer_login,
+        "created_at": "2026-03-01T00:00:00Z",
+        "updated_at": "2026-03-01T00:00:00Z",
+        "url": f"https://example.invalid/thread/{thread_id}",
+        "body": reviewer_body,
+    }
+    return {
+        "thread_id": thread_id,
+        "is_resolved": False,
+        "is_outdated": is_outdated,
+        "path": path,
+        "line": line,
+        "start_line": line,
+        "diff_side": "RIGHT",
+        "start_diff_side": "RIGHT",
+        "original_line": line,
+        "original_start_line": line,
+        "resolved_by": None,
+        "reviewer_login": reviewer_login,
+        "reviewer_comment": reviewer_comment,
+        "latest_reviewer_comment_at": reviewer_comment["updated_at"],
+        "latest_self_reply": latest_self_reply,
+        "reply_candidates": reply_candidates
+        or {
+            "ack": reply_candidate(
+                mode="add",
+                comment_id=None,
+                reason="no_existing_ack_reply",
+                managed=False,
+                adopted_unmarked_reply=False,
+            ),
+            "complete": reply_candidate(
+                mode="add",
+                comment_id=None,
+                reason="complete_never_adopts_unmarked_reply",
+                managed=False,
+                adopted_unmarked_reply=False,
+            ),
+        },
+        "marker_conflicts": marker_conflicts or [],
+        "comments": comments or [],
+    }
+
+
+def context_with_threads(tmp: Path, threads: list[dict[str, Any]]) -> dict[str, Any]:
+    repo_root = tmp / "repo"
+    (repo_root / ".github").mkdir(parents=True, exist_ok=True)
+    (repo_root / "src").mkdir(parents=True, exist_ok=True)
+    (repo_root / "docs").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".github" / "pull_request_template.md").write_text(
+        "\n".join(["## Why", "## What changed", "## Testing"]),
+        encoding="utf-8",
+    )
+    (repo_root / "src" / "app.py").write_text("one\ntwo\nthree\nfour\nfive\n", encoding="utf-8")
+    (repo_root / "src" / "helper.py").write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+    (repo_root / "src" / "legacy.py").write_text("legacy\n", encoding="utf-8")
+
+    return {
+        "repo_root": str(repo_root),
+        "repo_slug": "example/repo",
+        "viewer_login": "codex",
+        "pr": {
+            "id": "PR_1",
+            "number": 11,
+            "title": "Fix packet routing",
+            "url": "https://example.invalid/pr/11",
+            "state": "OPEN",
+            "headRefName": "feature/packets",
+            "baseRefName": "main",
+            "body": pr_body(),
+            "closingIssuesReferences": [{"number": 55}],
+        },
+        "changed_files": ["src/app.py", "src/helper.py", "src/legacy.py"],
+        "changed_file_groups": {
+            "runtime": {"count": 3, "sample_files": ["src/app.py", "src/helper.py", "src/legacy.py"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 0, "sample_files": []},
+            "tests": {"count": 0, "sample_files": []},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "diff_stat": " 3 files changed, 120 insertions(+), 25 deletions(-)",
+        "rule_files": {},
+        "expected_template_sections": [],
+        "conversation_comments": [],
+        "reviews": [],
+        "threads": threads,
+    }
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_build_review_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_build_review_packets.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import build_review_packets as packets  # type: ignore  # noqa: E402
+from review_thread_test_support import context_with_threads, marker_conflict, review_thread, write_json  # noqa: E402
+from thread_action_contract import build_context_fingerprint  # type: ignore  # noqa: E402
+
+
+class BuildReviewPacketsTests(unittest.TestCase):
+    def test_main_clusters_threads_and_routes_packet_explorer_workers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="src/app.py",
+                    line=10,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please tighten naming.",
+                ),
+                review_thread(
+                    thread_id="t-2",
+                    path="src/app.py",
+                    line=28,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please tighten naming!",
+                ),
+                review_thread(
+                    thread_id="t-3",
+                    path="src/helper.py",
+                    line=4,
+                    reviewer_login="reviewer-b",
+                    reviewer_body="Please add a test for this edge case.",
+                ),
+                review_thread(
+                    thread_id="t-4",
+                    path="src/legacy.py",
+                    line=2,
+                    reviewer_login="reviewer-c",
+                    reviewer_body="This is outdated now.",
+                    is_outdated=True,
+                ),
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            context_path = tmp / "context.json"
+            output_dir = tmp / "packets"
+            build_result_path = tmp / "build-result.json"
+            write_json(context_path, context)
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--repo-root",
+                context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(packets.main(), 0)
+
+            orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+            global_packet = json.loads((output_dir / "global_packet.json").read_text(encoding="utf-8"))
+            batch_packet = json.loads((output_dir / "thread-batch-01.json").read_text(encoding="utf-8"))
+            singleton_packet = json.loads((output_dir / "thread-03.json").read_text(encoding="utf-8"))
+            outdated_packet = json.loads((output_dir / "thread-04.json").read_text(encoding="utf-8"))
+            packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(orchestrator["review_mode"], "targeted-delegation")
+            self.assertEqual(orchestrator["orchestrator_profile"], "standard")
+            self.assertIn("common_path_contract", orchestrator)
+            self.assertNotIn("estimated_packet_tokens", orchestrator)
+            self.assertEqual(orchestrator["context_fingerprint"], context["context_fingerprint"])
+            self.assertEqual(global_packet["context_fingerprint"], context["context_fingerprint"])
+            self.assertEqual(global_packet["orchestrator_profile"], "standard")
+            self.assertEqual(orchestrator["thread_counts"], {"unresolved": 4, "unresolved_non_outdated": 3, "unresolved_outdated": 1})
+            self.assertEqual(orchestrator["thread_batches"], {"batch-01": ["t-1", "t-2"]})
+            self.assertEqual(orchestrator["packet_worker_map"], {"thread-batch-01": ["packet_explorer"], "thread-03": ["packet_explorer"]})
+            self.assertEqual(global_packet["packet_worker_map"], orchestrator["packet_worker_map"])
+            self.assertEqual(orchestrator["recommended_worker_count"], 2)
+            self.assertEqual(
+                [worker["packets"] for worker in orchestrator["recommended_workers"]],
+                [["global_packet.json", "thread-batch-01.json"], ["global_packet.json", "thread-03.json"]],
+            )
+            self.assertEqual(batch_packet["batch"]["thread_ids"], ["t-1", "t-2"])
+            self.assertEqual(batch_packet["batch"]["cluster_reason"], "same_path_reviewer_and_line_window")
+            self.assertIn("shared_fix_surface", batch_packet)
+            self.assertTrue(batch_packet["validation_candidates"])
+            self.assertIn("quality_escape_hints", batch_packet)
+            self.assertTrue(batch_packet["adjudication_basis"]["common_path_sufficient"])
+            self.assertEqual(singleton_packet["thread"]["thread_id"], "t-3")
+            self.assertEqual(singleton_packet["applicability"]["default_decision_candidate"], "accept")
+            self.assertIn("ownership_summary", singleton_packet)
+            self.assertIn("reply_update_basis", singleton_packet)
+            self.assertTrue(singleton_packet["validation_candidates"])
+            self.assertEqual(outdated_packet["thread"]["thread_id"], "t-4")
+            self.assertTrue(outdated_packet["thread"]["is_outdated"])
+            self.assertEqual(outdated_packet["thread"]["default_decision_candidate"], "defer-outdated")
+            self.assertTrue(packet_metrics["estimated_local_only_tokens"] > packet_metrics["estimated_packet_tokens"])
+            self.assertTrue(build_result["common_path_sufficient"])
+            self.assertNotIn("estimated_packet_tokens", build_result)
+            self.assertEqual(Path(build_result["packet_metrics_file"]).name, "packet_metrics.json")
+
+    def test_main_propagates_structured_marker_conflict_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="src/app.py",
+                    line=10,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please tighten naming.",
+                    marker_conflicts=[
+                        marker_conflict(
+                            phase="ack",
+                            severity="warning",
+                            reason="duplicate_exact_managed_replies",
+                            comment_ids=["c1"],
+                            blocks_adoption=False,
+                            blocks_update=False,
+                            blocks_apply=False,
+                        ),
+                        marker_conflict(
+                            phase="complete",
+                            severity="hard-stop",
+                            reason="wrong_thread_managed_marker",
+                            comment_ids=["c2"],
+                            blocks_adoption=True,
+                            blocks_update=True,
+                            blocks_apply=True,
+                        ),
+                    ],
+                )
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            output_dir = tmp / "packets"
+            write_json(context_path, context)
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--repo-root",
+                context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(packets.main(), 0)
+
+            orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+            thread_packet = json.loads((output_dir / "thread-01.json").read_text(encoding="utf-8"))
+
+            self.assertEqual(
+                orchestrator["marker_conflict_summary"],
+                {
+                    "count": 2,
+                    "by_severity": {"warning": 1, "adoption-blocking": 0, "hard-stop": 1},
+                    "by_phase": {"ack": 1, "complete": 1},
+                },
+            )
+            self.assertEqual(thread_packet["marker_conflicts"][0]["severity"], "warning")
+            self.assertEqual(thread_packet["marker_conflicts"][1]["severity"], "hard-stop")
+
+    def test_review_mode_override_does_not_upgrade_missing_evidence_to_common_path_sufficient(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="src/missing.py",
+                    line=10,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="",
+                )
+            ]
+            context = context_with_threads(tmp, threads)
+            context["changed_files"] = ["src/app.py", ".github/workflows/release.yml"]
+            (Path(context["repo_root"]) / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (Path(context["repo_root"]) / ".github" / "workflows" / "release.yml").write_text("name: release\n", encoding="utf-8")
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            output_dir = tmp / "packets"
+            build_result_path = tmp / "build-result.json"
+            write_json(context_path, context)
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--repo-root",
+                context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(packets.main(), 0)
+
+            orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(orchestrator["review_mode"], "targeted-delegation")
+            self.assertTrue(orchestrator["review_mode_overrides"])
+            self.assertFalse(build_result["common_path_sufficient"])
+            failure_reasons = build_result["common_path_failures"][0]["explicit_reread_reasons"]
+            self.assertIn("missing_required_evidence", failure_reasons)
+            self.assertIn("ownership_ambiguity", failure_reasons)
+
+    def test_quality_escape_hints_are_advisory_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path=".github/workflows/release.yml",
+                    line=1,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please update the release workflow note.",
+                )
+            ]
+            context = context_with_threads(tmp, threads)
+            repo_root = Path(context["repo_root"])
+            (repo_root / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (repo_root / ".github" / "workflows" / "release.yml").write_text("name: release\n", encoding="utf-8")
+            context["changed_files"] = [".github/workflows/release.yml"]
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            output_dir = tmp / "packets"
+            write_json(context_path, context)
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--repo-root",
+                context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(packets.main(), 0)
+
+            thread_packet = json.loads((output_dir / "thread-01.json").read_text(encoding="utf-8"))
+
+            self.assertTrue(thread_packet["quality_escape_hints"])
+            self.assertTrue(thread_packet["adjudication_basis"]["common_path_sufficient"])
+            self.assertEqual(thread_packet["adjudication_basis"]["explicit_reread_reasons"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_build_review_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_build_review_packets.py
@@ -269,6 +269,352 @@ class BuildReviewPacketsTests(unittest.TestCase):
             self.assertTrue(thread_packet["adjudication_basis"]["common_path_sufficient"])
             self.assertEqual(thread_packet["adjudication_basis"]["explicit_reread_reasons"], [])
 
+    def test_main_marks_same_run_outdated_transition_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            previous_threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="docs/guide.md",
+                    line=2,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please use the current wording.",
+                ),
+                review_thread(
+                    thread_id="t-2",
+                    path="src/legacy.py",
+                    line=1,
+                    reviewer_login="reviewer-b",
+                    reviewer_body="This legacy note is stale.",
+                    is_outdated=True,
+                ),
+                review_thread(
+                    thread_id="t-3",
+                    path="src/helper.py",
+                    line=2,
+                    reviewer_login="reviewer-c",
+                    reviewer_body="Please add more detail here.",
+                ),
+            ]
+            current_threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="docs/guide.md",
+                    line=2,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please use the current wording.",
+                    is_outdated=True,
+                ),
+                review_thread(
+                    thread_id="t-2",
+                    path="src/legacy.py",
+                    line=1,
+                    reviewer_login="reviewer-b",
+                    reviewer_body="This legacy note is stale.",
+                    is_outdated=True,
+                ),
+                review_thread(
+                    thread_id="t-3",
+                    path="src/helper.py",
+                    line=2,
+                    reviewer_login="reviewer-c",
+                    reviewer_body="Please add more detail here.",
+                ),
+            ]
+            previous_context = context_with_threads(tmp, previous_threads)
+            current_context = context_with_threads(tmp, current_threads)
+            repo_root = Path(current_context["repo_root"])
+            (repo_root / "docs").mkdir(parents=True, exist_ok=True)
+            (repo_root / "docs" / "guide.md").write_text(
+                "# Guide\nOriginal wording\nCurrent wording\n",
+                encoding="utf-8",
+            )
+            for context in (previous_context, current_context):
+                context["changed_files"] = ["docs/guide.md", "src/helper.py", "src/legacy.py"]
+                context["changed_file_groups"]["runtime"] = {
+                    "count": 2,
+                    "sample_files": ["src/helper.py", "src/legacy.py"],
+                }
+                context["changed_file_groups"]["docs"] = {
+                    "count": 1,
+                    "sample_files": ["docs/guide.md"],
+                }
+                context["context_fingerprint"] = build_context_fingerprint(context)
+
+            previous_context_path = tmp / "previous-context.json"
+            context_path = tmp / "context.json"
+            reconciliation_input_path = tmp / "reconciliation-input.json"
+            output_dir = tmp / "packets"
+            build_result_path = tmp / "build-result.json"
+            write_json(previous_context_path, previous_context)
+            write_json(context_path, current_context)
+            write_json(
+                reconciliation_input_path,
+                {
+                    "accepted_threads": [
+                        {
+                            "thread_id": "t-1",
+                            "validation_commands": ["python -m pytest tests/test_docs.py"],
+                        }
+                    ]
+                },
+            )
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--previous-context",
+                str(previous_context_path),
+                "--reconciliation-input",
+                str(reconciliation_input_path),
+                "--repo-root",
+                current_context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+            def fake_diff_snippet(
+                repo_root: Path,
+                base_ref: str | None,
+                head_ref: str | None,
+                path: str,
+                line_number: int | None,
+                cache: dict[str, str | None],
+            ) -> str | None:
+                if path == "docs/guide.md":
+                    return "@@ -1,2 +1,2 @@\n # Guide\n-Original wording\n+Current wording\n"
+                return None
+
+            with patch.object(sys, "argv", argv), patch.object(
+                packets,
+                "diff_snippet_for_path",
+                side_effect=fake_diff_snippet,
+            ):
+                self.assertEqual(packets.main(), 0)
+
+            transitioned_packet = json.loads((output_dir / "thread-01.json").read_text(encoding="utf-8"))
+            already_outdated_packet = json.loads((output_dir / "thread-02.json").read_text(encoding="utf-8"))
+            orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+            global_packet = json.loads((output_dir / "global_packet.json").read_text(encoding="utf-8"))
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+
+            self.assertTrue(transitioned_packet["transitioned_to_outdated"])
+            self.assertTrue(transitioned_packet["thread"]["transitioned_to_outdated"])
+            self.assertEqual(transitioned_packet["outdated_recheck"]["resolution_verdict"], "auto-accept")
+            self.assertEqual(
+                transitioned_packet["outdated_recheck"]["original_request"]["reviewer_body"],
+                "Please use the current wording.",
+            )
+            self.assertEqual(
+                transitioned_packet["outdated_recheck"]["validation_provenance"]["commands"],
+                ["python -m pytest tests/test_docs.py"],
+            )
+            self.assertNotIn("transitioned_to_outdated", already_outdated_packet)
+            self.assertEqual(orchestrator["same_run_reconciliation"]["outdated_transition_candidates"], 1)
+            self.assertEqual(orchestrator["same_run_reconciliation"]["outdated_auto_resolve_candidates"], 1)
+            self.assertEqual(orchestrator["same_run_reconciliation"]["outdated_recheck_ambiguous"], 0)
+            self.assertEqual(global_packet["same_run_reconciliation"], orchestrator["same_run_reconciliation"])
+            self.assertTrue(build_result["same_run_reconciliation_enabled"])
+            self.assertEqual(build_result["outdated_transition_candidates"], 1)
+            self.assertEqual(build_result["outdated_auto_resolve_candidates"], 1)
+            self.assertEqual(build_result["outdated_recheck_ambiguous"], 0)
+
+    def test_same_run_outdated_transition_requires_diff_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            previous_threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="docs/guide.md",
+                    line=2,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please use the current wording.",
+                )
+            ]
+            current_threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="docs/guide.md",
+                    line=2,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please use the current wording.",
+                    is_outdated=True,
+                )
+            ]
+            previous_context = context_with_threads(tmp, previous_threads)
+            current_context = context_with_threads(tmp, current_threads)
+            repo_root = Path(current_context["repo_root"])
+            (repo_root / "docs" / "guide.md").write_text(
+                "# Guide\nCurrent wording\n",
+                encoding="utf-8",
+            )
+            for context in (previous_context, current_context):
+                context["changed_files"] = ["docs/guide.md"]
+                context["changed_file_groups"]["runtime"] = {"count": 0, "sample_files": []}
+                context["changed_file_groups"]["docs"] = {
+                    "count": 1,
+                    "sample_files": ["docs/guide.md"],
+                }
+                context["context_fingerprint"] = build_context_fingerprint(context)
+
+            previous_context_path = tmp / "previous-context.json"
+            context_path = tmp / "context.json"
+            reconciliation_input_path = tmp / "reconciliation-input.json"
+            output_dir = tmp / "packets"
+            build_result_path = tmp / "build-result.json"
+            write_json(previous_context_path, previous_context)
+            write_json(context_path, current_context)
+            write_json(
+                reconciliation_input_path,
+                {
+                    "accepted_threads": [
+                        {
+                            "thread_id": "t-1",
+                            "validation_commands": ["python -m pytest tests/test_docs.py"],
+                        }
+                    ]
+                },
+            )
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--previous-context",
+                str(previous_context_path),
+                "--reconciliation-input",
+                str(reconciliation_input_path),
+                "--repo-root",
+                current_context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(packets.main(), 0)
+
+            transitioned_packet = json.loads((output_dir / "thread-01.json").read_text(encoding="utf-8"))
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(transitioned_packet["outdated_recheck"]["resolution_verdict"], "ambiguous")
+            self.assertEqual(
+                transitioned_packet["outdated_recheck"]["verdict_reason"],
+                "missing_current_head_evidence",
+            )
+            self.assertFalse(transitioned_packet["outdated_recheck"]["current_head_evidence"]["evidence_visible"])
+            self.assertEqual(build_result["outdated_auto_resolve_candidates"], 0)
+            self.assertEqual(build_result["outdated_recheck_ambiguous"], 1)
+
+    def test_same_run_outdated_transition_requires_request_anchor_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            previous_threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="docs/guide.md",
+                    line=2,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please use the current wording.",
+                )
+            ]
+            current_threads = [
+                review_thread(
+                    thread_id="t-1",
+                    path="docs/guide.md",
+                    line=2,
+                    reviewer_login="reviewer-a",
+                    reviewer_body="Please use the current wording.",
+                    is_outdated=True,
+                )
+            ]
+            previous_context = context_with_threads(tmp, previous_threads)
+            current_context = context_with_threads(tmp, current_threads)
+            repo_root = Path(current_context["repo_root"])
+            (repo_root / "docs" / "guide.md").write_text(
+                "# Guide\nFresh intro\n",
+                encoding="utf-8",
+            )
+            for context in (previous_context, current_context):
+                context["changed_files"] = ["docs/guide.md"]
+                context["changed_file_groups"]["runtime"] = {"count": 0, "sample_files": []}
+                context["changed_file_groups"]["docs"] = {
+                    "count": 1,
+                    "sample_files": ["docs/guide.md"],
+                }
+                context["context_fingerprint"] = build_context_fingerprint(context)
+
+            previous_context_path = tmp / "previous-context.json"
+            context_path = tmp / "context.json"
+            reconciliation_input_path = tmp / "reconciliation-input.json"
+            output_dir = tmp / "packets"
+            build_result_path = tmp / "build-result.json"
+            write_json(previous_context_path, previous_context)
+            write_json(context_path, current_context)
+            write_json(
+                reconciliation_input_path,
+                {
+                    "accepted_threads": [
+                        {
+                            "thread_id": "t-1",
+                            "validation_commands": ["python -m pytest tests/test_docs.py"],
+                        }
+                    ]
+                },
+            )
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--previous-context",
+                str(previous_context_path),
+                "--reconciliation-input",
+                str(reconciliation_input_path),
+                "--repo-root",
+                current_context["repo_root"],
+                "--output-dir",
+                str(output_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+
+            def fake_diff_snippet(
+                repo_root: Path,
+                base_ref: str | None,
+                head_ref: str | None,
+                path: str,
+                line_number: int | None,
+                cache: dict[str, str | None],
+            ) -> str | None:
+                if path == "docs/guide.md":
+                    return "@@ -1,2 +1,2 @@\n # Guide\n-Old intro\n+Fresh intro\n"
+                return None
+
+            with patch.object(sys, "argv", argv), patch.object(
+                packets,
+                "diff_snippet_for_path",
+                side_effect=fake_diff_snippet,
+            ):
+                self.assertEqual(packets.main(), 0)
+
+            transitioned_packet = json.loads((output_dir / "thread-01.json").read_text(encoding="utf-8"))
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(transitioned_packet["outdated_recheck"]["resolution_verdict"], "ambiguous")
+            self.assertEqual(
+                transitioned_packet["outdated_recheck"]["verdict_reason"],
+                "missing_request_anchor_evidence",
+            )
+            self.assertTrue(transitioned_packet["outdated_recheck"]["current_head_evidence"]["evidence_visible"])
+            self.assertFalse(
+                transitioned_packet["outdated_recheck"]["current_head_evidence"]["request_anchor_visible"]
+            )
+            self.assertEqual(build_result["outdated_auto_resolve_candidates"], 0)
+            self.assertEqual(build_result["outdated_recheck_ambiguous"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_collect_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_collect_review_threads.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import collect_review_threads as collect  # type: ignore  # noqa: E402
+from review_thread_test_support import comment  # noqa: E402
+
+
+class CollectReviewThreadsTests(unittest.TestCase):
+    def test_ensure_gh_auth_wraps_missing_gh_binary(self) -> None:
+        with mock.patch.object(collect.subprocess, "run", side_effect=FileNotFoundError("gh")):
+            with self.assertRaises(RuntimeError) as exc_info:
+                collect.ensure_gh_auth(Path("."))
+        self.assertEqual(str(exc_info.exception), "gh auth status failed; run `gh auth login` first")
+
+    def test_load_changed_files_uses_diff_output_when_available(self) -> None:
+        with mock.patch.object(
+            collect,
+            "run_command",
+            return_value="src/foo.py\nsrc/bar.py\n",
+        ) as run_command:
+            result = collect.load_changed_files(Path("."), "owner/repo", 7)
+
+        self.assertEqual(result, ["src/foo.py", "src/bar.py"])
+        run_command.assert_called_once_with(
+            ["gh", "pr", "diff", "7", "--name-only", "--repo", "owner/repo"],
+            cwd=Path("."),
+        )
+
+    def test_load_changed_files_falls_back_to_api_when_pr_diff_is_too_large(self) -> None:
+        with mock.patch.object(
+            collect,
+            "run_command",
+            side_effect=[
+                RuntimeError(
+                    "gh pr diff 7 --name-only --repo owner/repo: "
+                    "could not find pull request diff: HTTP 406: Sorry, the diff exceeded "
+                    "the maximum number of lines (20000)\nPullRequest.diff too_large"
+                ),
+                "src/foo.py\nsrc/bar.py\n",
+            ],
+        ) as run_command:
+            result = collect.load_changed_files(Path("."), "owner/repo", 7)
+
+        self.assertEqual(result, ["src/foo.py", "src/bar.py"])
+        self.assertEqual(run_command.call_count, 2)
+        self.assertEqual(
+            run_command.call_args_list[1].args[0],
+            [
+                "gh",
+                "api",
+                "repos/owner/repo/pulls/7/files",
+                "--paginate",
+                "--jq",
+                ".[].filename",
+            ],
+        )
+
+    def test_build_reply_candidates_prefers_exact_managed_and_marks_duplicate_warning(self) -> None:
+        comments = [
+            comment(
+                comment_id="review-1",
+                author_login="reviewer",
+                body="Please rename this helper.",
+                created_at="2026-03-01T00:00:00Z",
+                is_self=False,
+            ),
+            comment(
+                comment_id="ack-1",
+                author_login="codex",
+                body="<!-- codex:review-thread v1 phase=ack thread=t-1 -->\nWorking on it.",
+                created_at="2026-03-01T01:00:00Z",
+                managed_phase="ack",
+                managed_thread_id="t-1",
+                has_exact_managed_marker=True,
+            ),
+            comment(
+                comment_id="ack-2",
+                author_login="codex",
+                body="<!-- codex:review-thread v1 phase=ack thread=t-1 -->\nUpdated status.",
+                created_at="2026-03-01T02:00:00Z",
+                managed_phase="ack",
+                managed_thread_id="t-1",
+                has_exact_managed_marker=True,
+            ),
+        ]
+
+        reply_candidates, marker_conflicts, latest_self_reply, latest_reviewer_at = collect.build_reply_candidates(comments)
+
+        self.assertEqual(reply_candidates["ack"]["mode"], "update")
+        self.assertEqual(reply_candidates["ack"]["comment_id"], "ack-2")
+        self.assertTrue(reply_candidates["ack"]["managed"])
+        self.assertEqual(latest_self_reply["id"], "ack-2")
+        self.assertEqual(latest_reviewer_at, "2026-03-01T00:00:00Z")
+        self.assertEqual(
+            marker_conflicts,
+            [
+                {
+                    "phase": "ack",
+                    "severity": "warning",
+                    "reason": "duplicate_exact_managed_replies",
+                    "comment_ids": ["ack-1"],
+                    "blocks_adoption": False,
+                    "blocks_update": False,
+                    "blocks_apply": False,
+                }
+            ],
+        )
+
+    def test_build_reply_candidates_marks_adoption_blocking_for_multiple_unmarked_replies(self) -> None:
+        comments = [
+            comment(
+                comment_id="review-1",
+                author_login="reviewer",
+                body="Please clarify this.",
+                created_at="2026-03-01T00:00:00Z",
+                is_self=False,
+            ),
+            comment(
+                comment_id="self-1",
+                author_login="codex",
+                body="First unmarked reply.",
+                created_at="2026-03-01T01:00:00Z",
+            ),
+            comment(
+                comment_id="self-2",
+                author_login="codex",
+                body="Second unmarked reply.",
+                created_at="2026-03-01T02:00:00Z",
+            ),
+        ]
+
+        reply_candidates, marker_conflicts, _latest_self_reply, _latest_reviewer_at = collect.build_reply_candidates(comments)
+
+        self.assertEqual(reply_candidates["ack"]["mode"], "update")
+        self.assertEqual(reply_candidates["ack"]["comment_id"], "self-2")
+        self.assertTrue(reply_candidates["ack"]["adopted_unmarked_reply"])
+        self.assertEqual(marker_conflicts[0]["severity"], "adoption-blocking")
+        self.assertEqual(marker_conflicts[0]["comment_ids"], ["self-1", "self-2"])
+
+    def test_build_reply_candidates_marks_hard_stop_for_wrong_thread_marker(self) -> None:
+        comments = [
+            comment(
+                comment_id="review-1",
+                author_login="reviewer",
+                body="Please fix this.",
+                created_at="2026-03-01T00:00:00Z",
+                is_self=False,
+            ),
+            comment(
+                comment_id="bad-ack",
+                author_login="codex",
+                body="<!-- codex:review-thread v1 phase=ack thread=t-other -->\nWrong thread marker.",
+                created_at="2026-03-01T01:00:00Z",
+                managed_phase="ack",
+                managed_thread_id="t-other",
+                has_exact_managed_marker=False,
+            ),
+        ]
+
+        _reply_candidates, marker_conflicts, _latest_self_reply, _latest_reviewer_at = collect.build_reply_candidates(comments)
+
+        self.assertEqual(marker_conflicts[0]["severity"], "hard-stop")
+        self.assertEqual(marker_conflicts[0]["reason"], "wrong_thread_managed_marker")
+        self.assertTrue(marker_conflicts[0]["blocks_apply"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_reconcile_outdated_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_reconcile_outdated_threads.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import reconcile_outdated_threads as reconcile  # type: ignore  # noqa: E402
+from review_thread_test_support import context_with_threads, review_thread, write_json  # noqa: E402
+from thread_action_contract import build_context_fingerprint  # type: ignore  # noqa: E402
+
+
+def packet_for_thread(
+    thread: dict[str, object],
+    *,
+    transitioned_to_outdated: bool,
+    resolution_verdict: str,
+    verdict_reason: str,
+    area: str,
+    validation_commands: list[str],
+    reply_update_basis: dict[str, object] | None = None,
+) -> dict[str, object]:
+    packet = {
+        "thread": thread,
+        "transitioned_to_outdated": transitioned_to_outdated,
+        "outdated_recheck": {
+            "validation_provenance": {"commands": validation_commands},
+            "current_head_evidence": {
+                "path": str(thread.get("path") or ""),
+                "area": area,
+            },
+            "resolution_verdict": resolution_verdict,
+            "verdict_reason": verdict_reason,
+        },
+    }
+    if reply_update_basis is not None:
+        packet["reply_update_basis"] = reply_update_basis
+    return packet
+
+
+class ReconcileOutdatedThreadsTests(unittest.TestCase):
+    def test_reconcile_auto_accepts_docs_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            thread = review_thread(
+                thread_id="t-1",
+                path="docs/guide.md",
+                line=2,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please use the current wording.",
+                is_outdated=True,
+            )
+            context = context_with_threads(tmp, [thread])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            packet_dir = tmp / "packets"
+            output_path = tmp / "plan.json"
+            packet_dir.mkdir()
+            write_json(context_path, context)
+            write_json(
+                packet_dir / "thread-01.json",
+                packet_for_thread(
+                    thread,
+                    transitioned_to_outdated=True,
+                    resolution_verdict="auto-accept",
+                    verdict_reason="accepted_same_run_with_current_head_evidence",
+                    area="docs",
+                    validation_commands=["python -m pytest tests/test_docs.py"],
+                ),
+            )
+
+            argv = [
+                "reconcile_outdated_threads.py",
+                "--context",
+                str(context_path),
+                "--packet-dir",
+                str(packet_dir),
+                "--output",
+                str(output_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(reconcile.main(), 0)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            action = payload["thread_actions"][0]
+            self.assertEqual(action["decision"], "accept")
+            self.assertEqual(action["complete_mode"], "add")
+            self.assertTrue(action["resolve_after_complete"])
+            self.assertIn("Current HEAD already covers the requested wording change", action["complete_body"])
+            self.assertIn("Validation: `python -m pytest tests/test_docs.py`.", action["complete_body"])
+            self.assertEqual(payload["reconciliation_summary"]["outdated_transition_candidates"], 1)
+            self.assertEqual(payload["reconciliation_summary"]["outdated_auto_resolved"], 1)
+            self.assertEqual(payload["reconciliation_summary"]["outdated_recheck_ambiguous"], 0)
+
+    def test_reconcile_auto_accepts_runtime_candidate_only_with_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            thread = review_thread(
+                thread_id="t-1",
+                path="src/helper.py",
+                line=2,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please fix the helper branch.",
+                is_outdated=True,
+            )
+            context = context_with_threads(tmp, [thread])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            packet_dir = tmp / "packets"
+            output_path = tmp / "plan.json"
+            packet_dir.mkdir()
+            write_json(context_path, context)
+            write_json(
+                packet_dir / "thread-01.json",
+                packet_for_thread(
+                    thread,
+                    transitioned_to_outdated=True,
+                    resolution_verdict="auto-accept",
+                    verdict_reason="accepted_same_run_with_current_head_evidence",
+                    area="runtime",
+                    validation_commands=["python -m pytest builders/consumer-bootstrap/tests/test_consumer_bootstrap.py"],
+                ),
+            )
+
+            argv = [
+                "reconcile_outdated_threads.py",
+                "--context",
+                str(context_path),
+                "--packet-dir",
+                str(packet_dir),
+                "--output",
+                str(output_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(reconcile.main(), 0)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            action = payload["thread_actions"][0]
+            self.assertEqual(action["decision"], "accept")
+            self.assertTrue(action["resolve_after_complete"])
+            self.assertIn("requested change", action["complete_body"])
+
+    def test_reconcile_auto_accept_updates_existing_completion_reply(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            thread = review_thread(
+                thread_id="t-1",
+                path="docs/guide.md",
+                line=2,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please use the current wording.",
+            )
+            context = context_with_threads(tmp, [thread])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            packet_dir = tmp / "packets"
+            output_path = tmp / "plan.json"
+            packet_dir.mkdir()
+            write_json(context_path, context)
+            write_json(
+                packet_dir / "thread-01.json",
+                packet_for_thread(
+                    thread,
+                    transitioned_to_outdated=True,
+                    resolution_verdict="auto-accept",
+                    verdict_reason="accepted_same_run_with_current_head_evidence",
+                    area="docs",
+                    validation_commands=["python -m pytest tests/test_docs.py"],
+                    reply_update_basis={
+                        "complete": {
+                            "mode": "update",
+                            "comment_id": "comment-123",
+                            "reason": "managed_complete_reply_exists",
+                            "managed": True,
+                            "adopted_unmarked_reply": False,
+                        }
+                    },
+                ),
+            )
+
+            argv = [
+                "reconcile_outdated_threads.py",
+                "--context",
+                str(context_path),
+                "--packet-dir",
+                str(packet_dir),
+                "--output",
+                str(output_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(reconcile.main(), 0)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            action = payload["thread_actions"][0]
+            self.assertEqual(action["decision"], "accept")
+            self.assertEqual(action["complete_mode"], "update")
+            self.assertEqual(action["complete_comment_id"], "comment-123")
+            self.assertTrue(action["resolve_after_complete"])
+
+    def test_reconcile_leaves_missing_validation_candidate_ambiguous(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            thread = review_thread(
+                thread_id="t-1",
+                path="src/helper.py",
+                line=2,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please fix the helper branch.",
+                is_outdated=True,
+            )
+            context = context_with_threads(tmp, [thread])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            packet_dir = tmp / "packets"
+            output_path = tmp / "plan.json"
+            packet_dir.mkdir()
+            write_json(context_path, context)
+            write_json(
+                packet_dir / "thread-01.json",
+                packet_for_thread(
+                    thread,
+                    transitioned_to_outdated=True,
+                    resolution_verdict="ambiguous",
+                    verdict_reason="missing_validation_provenance",
+                    area="runtime",
+                    validation_commands=[],
+                ),
+            )
+
+            argv = [
+                "reconcile_outdated_threads.py",
+                "--context",
+                str(context_path),
+                "--packet-dir",
+                str(packet_dir),
+                "--output",
+                str(output_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(reconcile.main(), 0)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            action = payload["thread_actions"][0]
+            self.assertEqual(action["decision"], "defer-outdated")
+            self.assertEqual(action["complete_mode"], "skip")
+            self.assertFalse(action["resolve_after_complete"])
+            self.assertEqual(payload["reconciliation_summary"]["outdated_auto_resolved"], 0)
+            self.assertEqual(payload["reconciliation_summary"]["outdated_recheck_ambiguous"], 1)
+
+    def test_reconcile_returns_still_applicable_candidate_to_normal_queue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            thread = review_thread(
+                thread_id="t-1",
+                path="src/helper.py",
+                line=2,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please fix the helper branch.",
+                is_outdated=True,
+            )
+            context = context_with_threads(tmp, [thread])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            packet_dir = tmp / "packets"
+            output_path = tmp / "plan.json"
+            packet_dir.mkdir()
+            write_json(context_path, context)
+            write_json(
+                packet_dir / "thread-01.json",
+                packet_for_thread(
+                    thread,
+                    transitioned_to_outdated=True,
+                    resolution_verdict="still-applies",
+                    verdict_reason="thread_was_not_accepted_before_push",
+                    area="runtime",
+                    validation_commands=[],
+                ),
+            )
+
+            argv = [
+                "reconcile_outdated_threads.py",
+                "--context",
+                str(context_path),
+                "--packet-dir",
+                str(packet_dir),
+                "--output",
+                str(output_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(reconcile.main(), 0)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            action = payload["thread_actions"][0]
+            self.assertEqual(action["decision"], "defer")
+            self.assertEqual(action["complete_mode"], "skip")
+            self.assertFalse(action["resolve_after_complete"])
+            self.assertEqual(payload["reconciliation_summary"]["outdated_still_applicable"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_review_thread_workflow_smoke.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_review_thread_workflow_smoke.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    while candidate in sys.path:
+        sys.path.remove(candidate)
+    sys.path.insert(0, candidate)
+
+import apply_thread_action_plan as apply_plan  # type: ignore  # noqa: E402
+import build_review_packets as build_packets  # type: ignore  # noqa: E402
+import validate_thread_action_plan as validate_plan  # type: ignore  # noqa: E402
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # type: ignore  # noqa: E402
+from review_thread_test_support import context_with_threads, review_thread, write_json  # noqa: E402
+from thread_action_contract import build_context_fingerprint  # type: ignore  # noqa: E402
+
+
+class ReviewThreadWorkflowSmokeTests(unittest.TestCase):
+    def test_end_to_end_dry_run_uses_stable_ordering(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(thread_id="t-2", path="src/helper.py", line=20, reviewer_login="reviewer-b", reviewer_body="Please add a test."),
+                review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this."),
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            context_path = tmp / "context.json"
+            packet_dir = tmp / "packets"
+            build_result_path = tmp / "build-result.json"
+            raw_plan_path = tmp / "raw-plan.json"
+            validated_path = tmp / "validated.json"
+            dry_run_path = tmp / "dry-run.json"
+            log_path = tmp / "eval-log.json"
+            final_path = tmp / "final.json"
+            write_json(context_path, context)
+            write_json(
+                raw_plan_path,
+                {
+                    "thread_actions": [
+                        {
+                            "thread_id": "t-2",
+                            "decision": "defer",
+                            "ack_mode": "skip",
+                        },
+                        {
+                            "thread_id": "t-1",
+                            "decision": "accept",
+                            "ack_mode": "add",
+                            "ack_body": "I will update the naming and rerun the relevant check.",
+                        },
+                    ]
+                },
+            )
+
+            argv = [
+                "build_review_packets.py",
+                "--context",
+                str(context_path),
+                "--repo-root",
+                context["repo_root"],
+                "--output-dir",
+                str(packet_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(build_packets.main(), 0)
+
+            argv = [
+                "validate_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(raw_plan_path),
+                "--phase",
+                "ack",
+                "--output",
+                str(validated_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(validate_plan.main(), 0)
+
+            validated = json.loads(validated_path.read_text(encoding="utf-8"))
+            self.assertEqual([item["thread_id"] for item in validated["normalized_thread_actions"]], ["t-1", "t-2"])
+
+            argv = [
+                "apply_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(validated_path),
+                "--phase",
+                "ack",
+                "--dry-run",
+                "--result-output",
+                str(dry_run_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(apply_plan.main(), 0)
+
+            orchestrator_path = packet_dir / "orchestrator.json"
+            init_payload = eval_log.build_base_log(
+                Path(eval_log.__file__).resolve(),
+                eval_log.load_json(context_path),
+                eval_log.load_json(orchestrator_path),
+                None,
+            )
+            eval_log.write_json(log_path, init_payload)
+            log_payload = eval_log.load_json(log_path)
+            eval_log.apply_phase_update(log_payload, "build", eval_log.load_json(build_result_path), None)
+            eval_log.apply_phase_update(log_payload, "validate", validated, None)
+            eval_log.apply_phase_update(log_payload, "apply", eval_log.load_json(dry_run_path), None)
+            eval_log.write_json(log_path, log_payload)
+
+            write_json(
+                final_path,
+                {
+                    "quality": {
+                        "first_pass_usable": True,
+                        "human_post_edit_required": False,
+                        "human_post_edit_severity": "none",
+                    }
+                },
+            )
+            finalized = eval_log.load_json(log_path)
+            eval_log.finalize_log(finalized, eval_log.load_json(final_path))
+
+            self.assertEqual(finalized["skill_specific"]["data"]["threads_accepted"], 1)
+            self.assertTrue(finalized["skill_specific"]["data"]["common_path_sufficient"])
+            self.assertIsNotNone(finalized["skill_specific"]["data"]["estimated_packet_tokens"])
+            self.assertEqual(finalized["quality"]["result_status"], "dry-run")
+            self.assertTrue(finalized["safety"]["fingerprint_match"])
+
+    def test_stale_fingerprint_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this.")
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            result = {
+                "phase": "ack",
+                "valid": True,
+                "context_fingerprint": "stale",
+                "normalized_thread_actions": [
+                    {
+                        "thread_id": "t-1",
+                        "decision": "accept",
+                        "ack_mode": "add",
+                        "ack_body": "Will fix this.",
+                    }
+                ],
+            }
+
+            with self.assertRaises(RuntimeError):
+                apply_plan.load_normalized_plan_envelope(context, result, "ack")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_smoke_gh_address_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_smoke_gh_address_review_threads.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import smoke_gh_address_review_threads as smoke  # type: ignore  # noqa: E402
+from review_thread_test_support import context_with_threads, review_thread, write_json  # noqa: E402
+from thread_action_contract import build_context_fingerprint  # type: ignore  # noqa: E402
+
+
+class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
+    def test_main_runs_self_contained_synthetic_smoke_without_gh(self) -> None:
+        with patch.object(sys, "argv", ["smoke_gh_address_review_threads.py", "--synthetic"]):
+            with patch.object(smoke, "ensure_gh_auth", side_effect=AssertionError("live gh auth should not run")), patch.object(
+                smoke,
+                "current_branch_pr",
+                side_effect=AssertionError("live pr lookup should not run"),
+            ):
+                buffer = io.StringIO()
+                with patch("sys.stdout", buffer):
+                    self.assertEqual(smoke.main(), 0)
+
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["status"], "ok")
+        self.assertIsNone(payload["reason"])
+        self.assertEqual(payload["next_action"], "review_smoke_results")
+        self.assertEqual(payload["thread_counts"]["unresolved"], 2)
+        self.assertTrue(payload["common_path_sufficient"])
+        self.assertGreater(payload["estimated_delegation_savings"], 0)
+
+    def test_main_reports_blocked_schema_when_gh_cli_is_missing(self) -> None:
+        with patch.object(sys, "argv", ["smoke_gh_address_review_threads.py"]):
+            with patch.object(smoke, "ensure_gh_auth", side_effect=smoke.GhCliMissing("gh missing")):
+                buffer = io.StringIO()
+                with patch("sys.stdout", buffer):
+                    self.assertEqual(smoke.main(), 0)
+
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(set(payload.keys()), {"status", "reason", "thread_counts", "next_action"})
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["reason"], "gh_cli_missing")
+        self.assertEqual(payload["next_action"], "install_gh_cli")
+
+    def test_main_reports_blocked_schema_when_no_open_pr(self) -> None:
+        with patch.object(sys, "argv", ["smoke_gh_address_review_threads.py"]):
+            with patch.object(smoke, "ensure_gh_auth", return_value=True), patch.object(smoke, "current_branch_pr", return_value=None):
+                buffer = io.StringIO()
+                with patch("sys.stdout", buffer):
+                    self.assertEqual(smoke.main(), 0)
+
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(set(payload.keys()), {"status", "reason", "thread_counts", "next_action"})
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["reason"], "no_open_pr")
+        self.assertEqual(payload["next_action"], "open_pr_for_current_branch")
+
+    def test_main_runs_safe_skip_defer_smoke_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir = Path(tmp_dir_name)
+            repo_holder = tmp_dir / "repo-holder"
+            repo_holder.mkdir()
+            context = context_with_threads(
+                tmp_dir,
+                [
+                    review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this."),
+                    review_thread(thread_id="t-2", path="src/helper.py", line=20, reviewer_login="reviewer-b", reviewer_body="Please add a test."),
+                ],
+            )
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            def fake_run_script(args: list[str], *, cwd: Path) -> str:
+                arg_list = [str(item) for item in args]
+                if arg_list[0].endswith("collect_review_threads.py"):
+                    write_json(Path(arg_list[arg_list.index("--output") + 1]), context)
+                    return ""
+                if arg_list[0].endswith("build_review_packets.py"):
+                    output_dir = Path(arg_list[arg_list.index("--output-dir") + 1])
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                    write_json(
+                        output_dir / "orchestrator.json",
+                        {
+                            "review_mode": "targeted-delegation",
+                            "recommended_worker_count": 1,
+                            "recommended_workers": [{"agent_type": "packet_explorer"}],
+                            "packet_files": ["global_packet.json", "thread-01.json", "thread-02.json", "orchestrator.json"],
+                        },
+                    )
+                    write_json(output_dir / "global_packet.json", {"orchestrator_profile": "standard"})
+                    write_json(
+                        output_dir / "packet_metrics.json",
+                        {
+                            "packet_count": 4,
+                            "packet_size_bytes": 1200,
+                            "largest_packet_bytes": 500,
+                            "largest_two_packets_bytes": 900,
+                            "estimated_local_only_tokens": 600,
+                            "estimated_packet_tokens": 250,
+                            "estimated_delegation_savings": 350,
+                        },
+                    )
+                    write_json(
+                        Path(arg_list[arg_list.index("--result-output") + 1]),
+                        {
+                            "review_mode": "targeted-delegation",
+                            "recommended_worker_count": 1,
+                            "recommended_workers": [{"agent_type": "packet_explorer"}],
+                            "thread_batch_count": 0,
+                            "singleton_thread_packet_count": 2,
+                            "active_paths": ["src/app.py", "src/helper.py"],
+                            "override_signals": [],
+                            "common_path_sufficient": True,
+                            "common_path_failures": [],
+                            "thread_counts": {"unresolved": 2, "unresolved_outdated": 0},
+                            "packet_metrics_file": str(output_dir / "packet_metrics.json"),
+                        },
+                    )
+                    return ""
+                if "write_evaluation_log.py" in arg_list[0] and "init" in arg_list:
+                    write_json(Path(arg_list[arg_list.index("--output") + 1]), {"skill": {"name": "gh-address-review-threads"}})
+                    return ""
+                if "validate_thread_action_plan.py" in arg_list[0]:
+                    write_json(
+                        Path(arg_list[arg_list.index("--output") + 1]),
+                        {
+                            "phase": arg_list[arg_list.index("--phase") + 1],
+                            "valid": True,
+                            "context_fingerprint": context["context_fingerprint"],
+                            "normalized_thread_actions": [],
+                            "counters": {},
+                        },
+                    )
+                    return ""
+                if "apply_thread_action_plan.py" in arg_list[0]:
+                    write_json(
+                        Path(arg_list[arg_list.index("--result-output") + 1]),
+                        {
+                            "dry_run": True,
+                            "apply_succeeded": True,
+                            "fingerprint_match": True,
+                            "counters": {},
+                            "mutations": [],
+                        },
+                    )
+                    return ""
+                return ""
+
+            argv = ["smoke_gh_address_review_threads.py", "--repo-root", str(repo_holder)]
+            with patch.object(sys, "argv", argv):
+                with patch.object(smoke, "ensure_gh_auth", return_value=True), patch.object(
+                    smoke,
+                    "current_branch_pr",
+                    return_value={"number": 11, "url": "https://example.invalid/pr/11"},
+                ), patch.object(smoke, "run_script", side_effect=fake_run_script):
+                    buffer = io.StringIO()
+                    with patch("sys.stdout", buffer):
+                        self.assertEqual(smoke.main(), 0)
+
+            payload = json.loads(buffer.getvalue())
+            self.assertEqual(payload["status"], "ok")
+            self.assertIsNone(payload["reason"])
+            self.assertEqual(payload["thread_counts"]["unresolved"], 2)
+            self.assertEqual(payload["next_action"], "review_smoke_results")
+            self.assertTrue(payload["common_path_sufficient"])
+            self.assertGreater(payload["estimated_delegation_savings"], 0)
+
+    def test_main_reports_noop_schema_when_no_unresolved_threads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir = Path(tmp_dir_name)
+            repo_holder = tmp_dir / "repo-holder"
+            repo_holder.mkdir()
+            context = context_with_threads(tmp_dir, [])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            def fake_run_script(args: list[str], *, cwd: Path) -> str:
+                arg_list = [str(item) for item in args]
+                if arg_list[0].endswith("collect_review_threads.py"):
+                    write_json(Path(arg_list[arg_list.index("--output") + 1]), context)
+                return ""
+
+            argv = ["smoke_gh_address_review_threads.py", "--repo-root", str(repo_holder)]
+            with patch.object(sys, "argv", argv):
+                with patch.object(smoke, "ensure_gh_auth", return_value=True), patch.object(
+                    smoke,
+                    "current_branch_pr",
+                    return_value={"number": 11, "url": "https://example.invalid/pr/11"},
+                ), patch.object(smoke, "run_script", side_effect=fake_run_script):
+                    buffer = io.StringIO()
+                    with patch("sys.stdout", buffer):
+                        self.assertEqual(smoke.main(), 0)
+
+            payload = json.loads(buffer.getvalue())
+            self.assertEqual(payload["status"], "noop")
+            self.assertEqual(payload["reason"], "no_unresolved_threads")
+            self.assertEqual(set(payload.keys()) & {"status", "reason", "thread_counts", "next_action"}, {"status", "reason", "thread_counts", "next_action"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_smoke_gh_address_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_smoke_gh_address_review_threads.py
@@ -38,7 +38,10 @@ class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
         self.assertEqual(payload["next_action"], "review_smoke_results")
         self.assertEqual(payload["thread_counts"]["unresolved"], 2)
         self.assertTrue(payload["common_path_sufficient"])
-        self.assertGreater(payload["estimated_delegation_savings"], 0)
+        self.assertGreaterEqual(payload["estimated_delegation_savings"], 0)
+        self.assertEqual(payload["outdated_transition_candidates"], 1)
+        self.assertEqual(payload["outdated_auto_resolved"], 1)
+        self.assertEqual(payload["outdated_recheck_ambiguous"], 0)
 
     def test_main_reports_blocked_schema_when_gh_cli_is_missing(self) -> None:
         with patch.object(sys, "argv", ["smoke_gh_address_review_threads.py"]):
@@ -123,7 +126,24 @@ class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
                             "common_path_sufficient": True,
                             "common_path_failures": [],
                             "thread_counts": {"unresolved": 2, "unresolved_outdated": 0},
+                            "outdated_transition_candidates": 0,
+                            "outdated_recheck_ambiguous": 0,
                             "packet_metrics_file": str(output_dir / "packet_metrics.json"),
+                        },
+                    )
+                    return ""
+                if arg_list[0].endswith("reconcile_outdated_threads.py"):
+                    write_json(
+                        Path(arg_list[arg_list.index("--output") + 1]),
+                        {
+                            "context_fingerprint": context["context_fingerprint"],
+                            "thread_actions": [],
+                            "reconciliation_summary": {
+                                "outdated_transition_candidates": 0,
+                                "outdated_auto_resolved": 0,
+                                "outdated_recheck_ambiguous": 0,
+                                "outdated_still_applicable": 0,
+                            },
                         },
                     )
                     return ""
@@ -131,6 +151,8 @@ class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
                     write_json(Path(arg_list[arg_list.index("--output") + 1]), {"skill": {"name": "gh-address-review-threads"}})
                     return ""
                 if "validate_thread_action_plan.py" in arg_list[0]:
+                    plan_path = Path(arg_list[arg_list.index("--plan") + 1])
+                    plan_payload = json.loads(plan_path.read_text(encoding="utf-8")) if plan_path.exists() else {}
                     write_json(
                         Path(arg_list[arg_list.index("--output") + 1]),
                         {
@@ -139,10 +161,13 @@ class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
                             "context_fingerprint": context["context_fingerprint"],
                             "normalized_thread_actions": [],
                             "counters": {},
+                            "reconciliation_summary": plan_payload.get("reconciliation_summary"),
                         },
                     )
                     return ""
                 if "apply_thread_action_plan.py" in arg_list[0]:
+                    plan_path = Path(arg_list[arg_list.index("--plan") + 1])
+                    plan_payload = json.loads(plan_path.read_text(encoding="utf-8")) if plan_path.exists() else {}
                     write_json(
                         Path(arg_list[arg_list.index("--result-output") + 1]),
                         {
@@ -151,6 +176,7 @@ class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
                             "fingerprint_match": True,
                             "counters": {},
                             "mutations": [],
+                            "reconciliation_summary": plan_payload.get("reconciliation_summary"),
                         },
                     )
                     return ""
@@ -174,6 +200,9 @@ class SmokeGhAddressReviewThreadsTests(unittest.TestCase):
             self.assertEqual(payload["next_action"], "review_smoke_results")
             self.assertTrue(payload["common_path_sufficient"])
             self.assertGreater(payload["estimated_delegation_savings"], 0)
+            self.assertEqual(payload["outdated_transition_candidates"], 0)
+            self.assertEqual(payload["outdated_auto_resolved"], 0)
+            self.assertEqual(payload["outdated_recheck_ambiguous"], 0)
 
     def test_main_reports_noop_schema_when_no_unresolved_threads(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_validate_and_apply_thread_action_plan.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_validate_and_apply_thread_action_plan.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import apply_thread_action_plan as apply_plan  # type: ignore  # noqa: E402
+import validate_thread_action_plan as validate_plan  # type: ignore  # noqa: E402
+from review_thread_test_support import context_with_threads, marker_conflict, reply_candidate, review_thread, write_json  # noqa: E402
+from thread_action_contract import build_context_fingerprint, validate_thread_action_payload  # type: ignore  # noqa: E402
+
+
+class ValidateAndApplyThreadActionPlanTests(unittest.TestCase):
+    def test_run_json_wraps_missing_executable(self) -> None:
+        with patch.object(apply_plan.subprocess, "run", side_effect=FileNotFoundError("gh")):
+            with self.assertRaises(RuntimeError) as exc_info:
+                apply_plan.run_json(["gh", "api", "graphql"], cwd=Path("."))
+        self.assertEqual(str(exc_info.exception), "gh executable not found")
+
+    def test_validator_sorts_actions_and_ignores_unknown_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(thread_id="t-2", path="src/helper.py", line=20, reviewer_login="reviewer-b", reviewer_body="Please add a test."),
+                review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this."),
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            payload = {
+                "thread_actions": [
+                    {
+                        "thread_id": "t-2",
+                        "decision": "defer",
+                        "ack_mode": "skip",
+                        "junk": "remove me",
+                    },
+                    {
+                        "thread_id": "t-1",
+                        "decision": "accept",
+                        "ack_mode": "add",
+                        "ack_body": "Will fix this.",
+                    },
+                ]
+            }
+            result = validate_thread_action_payload(context, payload, "ack")
+
+            self.assertTrue(result["valid"])
+            self.assertEqual([item["thread_id"] for item in result["normalized_thread_actions"]], ["t-1", "t-2"])
+            self.assertEqual(result["warnings"][0]["code"], "unknown_action_field_ignored")
+            self.assertEqual(result["counters"]["unknown_fields_ignored"], 1)
+
+    def test_validator_blocks_adoption_fallback_and_hard_stop_updates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            adoption_thread = review_thread(
+                thread_id="t-1",
+                path="src/app.py",
+                line=10,
+                reviewer_login="reviewer-a",
+                reviewer_body="Please rename this.",
+                reply_candidates={
+                    "ack": reply_candidate(
+                        mode="update",
+                        comment_id="self-2",
+                        reason="adopt_latest_unmarked_reply_after_reviewer",
+                        managed=False,
+                        adopted_unmarked_reply=True,
+                    ),
+                    "complete": reply_candidate(
+                        mode="add",
+                        comment_id=None,
+                        reason="complete_never_adopts_unmarked_reply",
+                        managed=False,
+                        adopted_unmarked_reply=False,
+                    ),
+                },
+                marker_conflicts=[
+                    marker_conflict(
+                        phase="ack",
+                        severity="adoption-blocking",
+                        reason="multiple_unmarked_replies_after_latest_reviewer",
+                        comment_ids=["self-1", "self-2"],
+                        blocks_adoption=True,
+                        blocks_update=False,
+                        blocks_apply=False,
+                    )
+                ],
+            )
+            hard_stop_thread = review_thread(
+                thread_id="t-2",
+                path="src/helper.py",
+                line=20,
+                reviewer_login="reviewer-b",
+                reviewer_body="Please add a test.",
+                marker_conflicts=[
+                    marker_conflict(
+                        phase="ack",
+                        severity="hard-stop",
+                        reason="wrong_thread_managed_marker",
+                        comment_ids=["bad-1"],
+                        blocks_adoption=True,
+                        blocks_update=True,
+                        blocks_apply=True,
+                    )
+                ],
+            )
+            context = context_with_threads(tmp, [adoption_thread, hard_stop_thread])
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            payload = {
+                "thread_actions": [
+                    {
+                        "thread_id": "t-1",
+                        "decision": "accept",
+                        "ack_mode": "update",
+                        "ack_body": "Updating the previous reply.",
+                    },
+                    {
+                        "thread_id": "t-2",
+                        "decision": "accept",
+                        "ack_mode": "update",
+                        "ack_body": "Trying to update through hard stop.",
+                        "ack_comment_id": "bad-1",
+                    },
+                ]
+            }
+            result = validate_thread_action_payload(context, payload, "ack")
+
+            self.assertFalse(result["valid"])
+            self.assertEqual([item["code"] for item in result["errors"]], ["adoption_blocked_update", "hard_stop_marker_conflict"])
+
+    def test_validator_uses_fixed_resolve_after_complete_codes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this.")
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+
+            ack_result = validate_thread_action_payload(
+                context,
+                {
+                    "thread_actions": [
+                        {
+                            "thread_id": "t-1",
+                            "decision": "accept",
+                            "ack_mode": "skip",
+                            "resolve_after_complete": True,
+                        }
+                    ]
+                },
+                "ack",
+            )
+            self.assertTrue(ack_result["valid"])
+            self.assertEqual(ack_result["warnings"][0]["code"], "ignored_resolve_after_complete_outside_complete")
+
+            complete_result = validate_thread_action_payload(
+                context,
+                {
+                    "thread_actions": [
+                        {
+                            "thread_id": "t-1",
+                            "decision": "accept",
+                            "complete_mode": "skip",
+                            "resolve_after_complete": True,
+                        }
+                    ]
+                },
+                "complete",
+            )
+            self.assertFalse(complete_result["valid"])
+            self.assertEqual(complete_result["errors"][0]["code"], "invalid_resolve_after_complete")
+
+    def test_validator_and_apply_enforce_fingerprint_and_normalized_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this.")
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            raw_plan_path = tmp / "raw-plan.json"
+            validated_path = tmp / "validated.json"
+            write_json(context_path, context)
+            write_json(
+                raw_plan_path,
+                {
+                    "thread_actions": [
+                        {
+                            "thread_id": "t-1",
+                            "decision": "accept",
+                            "ack_mode": "add",
+                            "ack_body": "Will fix this.",
+                        }
+                    ]
+                },
+            )
+
+            argv = [
+                "validate_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(raw_plan_path),
+                "--phase",
+                "ack",
+                "--output",
+                str(validated_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(validate_plan.main(), 0)
+
+            validated = json.loads(validated_path.read_text(encoding="utf-8"))
+            self.assertTrue(validated["valid"])
+            self.assertEqual(validated["context_fingerprint"], context["context_fingerprint"])
+
+            stale_validated = dict(validated)
+            stale_validated["context_fingerprint"] = "stale"
+            stale_path = tmp / "stale-validated.json"
+            write_json(stale_path, stale_validated)
+
+            dry_run_path = tmp / "dry-run.json"
+            argv = [
+                "apply_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(validated_path),
+                "--phase",
+                "ack",
+                "--dry-run",
+                "--result-output",
+                str(dry_run_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(apply_plan.main(), 0)
+
+            dry_run = json.loads(dry_run_path.read_text(encoding="utf-8"))
+            self.assertTrue(dry_run["dry_run"])
+            self.assertEqual(dry_run["normalized_thread_actions"][0]["thread_id"], "t-1")
+            self.assertTrue(dry_run["fingerprint_match"])
+
+            argv = [
+                "apply_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(raw_plan_path),
+                "--phase",
+                "ack",
+                "--dry-run",
+            ]
+            with patch.object(sys, "argv", argv):
+                with self.assertRaises(RuntimeError):
+                    apply_plan.main()
+
+            argv = [
+                "apply_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(stale_path),
+                "--phase",
+                "ack",
+                "--dry-run",
+            ]
+            with patch.object(sys, "argv", argv):
+                with self.assertRaises(RuntimeError):
+                    apply_plan.main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_validate_and_apply_thread_action_plan.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_validate_and_apply_thread_action_plan.py
@@ -281,6 +281,85 @@ class ValidateAndApplyThreadActionPlanTests(unittest.TestCase):
                 with self.assertRaises(RuntimeError):
                     apply_plan.main()
 
+    def test_validator_and_apply_preserve_reconciliation_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            threads = [
+                review_thread(thread_id="t-1", path="src/app.py", line=10, reviewer_login="reviewer-a", reviewer_body="Please rename this.")
+            ]
+            context = context_with_threads(tmp, threads)
+            context["context_fingerprint"] = build_context_fingerprint(context)
+            context_path = tmp / "context.json"
+            raw_plan_path = tmp / "raw-plan.json"
+            validated_path = tmp / "validated.json"
+            dry_run_path = tmp / "dry-run.json"
+            write_json(context_path, context)
+            write_json(
+                raw_plan_path,
+                {
+                    "context_fingerprint": context["context_fingerprint"],
+                    "thread_actions": [
+                        {
+                            "thread_id": "t-1",
+                            "decision": "accept",
+                            "complete_mode": "add",
+                            "complete_body": "Current HEAD already covers the requested change.",
+                            "resolve_after_complete": True,
+                        }
+                    ],
+                    "reconciliation_summary": {
+                        "outdated_transition_candidates": 1,
+                        "outdated_auto_resolved": 1,
+                        "outdated_recheck_ambiguous": 0,
+                        "outdated_still_applicable": 0,
+                    },
+                },
+            )
+
+            argv = [
+                "validate_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(raw_plan_path),
+                "--phase",
+                "complete",
+                "--output",
+                str(validated_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(validate_plan.main(), 0)
+
+            validated = json.loads(validated_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                validated["reconciliation_summary"],
+                {
+                    "outdated_transition_candidates": 1,
+                    "outdated_auto_resolved": 1,
+                    "outdated_recheck_ambiguous": 0,
+                    "outdated_still_applicable": 0,
+                },
+            )
+
+            argv = [
+                "apply_thread_action_plan.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(validated_path),
+                "--phase",
+                "complete",
+                "--dry-run",
+                "--result-output",
+                str(dry_run_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(apply_plan.main(), 0)
+
+            dry_run = json.loads(dry_run_path.read_text(encoding="utf-8"))
+            self.assertEqual(dry_run["reconciliation_summary"]["outdated_auto_resolved"], 1)
+            self.assertEqual(dry_run["reconciliation_summary"]["outdated_transition_candidates"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_write_evaluation_log_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_write_evaluation_log_review_threads.py
@@ -52,6 +52,8 @@ class WriteEvaluationLogReviewThreadsTests(unittest.TestCase):
                 "common_path_sufficient": True,
                 "thread_batch_count": 1,
                 "singleton_thread_packet_count": 2,
+                "outdated_transition_candidates": 1,
+                "outdated_recheck_ambiguous": 1,
                 "thread_counts": {"unresolved": 3, "unresolved_outdated": 1},
                 "packet_metrics_file": str(packet_metrics_path),
             }
@@ -66,6 +68,8 @@ class WriteEvaluationLogReviewThreadsTests(unittest.TestCase):
             self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 600)
             self.assertEqual(log["baseline"]["estimated_token_savings"], 350)
             self.assertEqual(log["skill_specific"]["data"]["packet_count"], 4)
+            self.assertEqual(log["skill_specific"]["data"]["outdated_transition_candidates"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["outdated_recheck_ambiguous"], 1)
             self.assertEqual(log["skill_specific"]["data"]["estimated_packet_tokens"], 250)
             self.assertEqual(log["skill_specific"]["data"]["estimated_delegation_savings"], 350)
             self.assertTrue(log["skill_specific"]["data"]["common_path_sufficient"])
@@ -98,6 +102,11 @@ class WriteEvaluationLogReviewThreadsTests(unittest.TestCase):
                     "threads_deferred": 0,
                     "threads_defer_outdated": 2,
                 },
+                "reconciliation_summary": {
+                    "outdated_transition_candidates": 1,
+                    "outdated_auto_resolved": 1,
+                    "outdated_recheck_ambiguous": 0,
+                },
             }
 
             eval_log.apply_phase_update(log, "apply", result, duration=0.5)
@@ -108,6 +117,9 @@ class WriteEvaluationLogReviewThreadsTests(unittest.TestCase):
             self.assertEqual(log["skill_specific"]["data"]["skipped_outdated_count"], 2)
             self.assertEqual(log["skill_specific"]["data"]["invalid_complete_count"], 1)
             self.assertEqual(log["skill_specific"]["data"]["resolve_after_complete_count"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["outdated_transition_candidates"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["outdated_auto_resolved"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["outdated_recheck_ambiguous"], 0)
             self.assertEqual(log["skill_specific"]["data"]["threads_resolved"], 1)
 
 

--- a/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_write_evaluation_log_review_threads.py
+++ b/builders/packet-workflow/retained-skills/gh-address-review-threads/tests/test_write_evaluation_log_review_threads.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    while candidate in sys.path:
+        sys.path.remove(candidate)
+    sys.path.insert(0, candidate)
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # type: ignore  # noqa: E402
+
+
+class WriteEvaluationLogReviewThreadsTests(unittest.TestCase):
+    def test_build_phase_merges_packet_metrics_and_common_path_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            packet_metrics_path = tmp / "packet_metrics.json"
+            packet_metrics_path.write_text(
+                "{\n"
+                '  "packet_count": 4,\n'
+                '  "packet_size_bytes": 1200,\n'
+                '  "largest_packet_bytes": 500,\n'
+                '  "largest_two_packets_bytes": 900,\n'
+                '  "estimated_local_only_tokens": 600,\n'
+                '  "estimated_packet_tokens": 250,\n'
+                '  "estimated_delegation_savings": 350\n'
+                "}\n",
+                encoding="utf-8",
+            )
+            log = {
+                "skill": {"name": "gh-address-review-threads"},
+                "quality": {},
+                "safety": {},
+                "outputs": {},
+                "orchestration": {},
+                "baseline": {},
+                "measurement": {"token_source": "unavailable"},
+                "skill_specific": {"data": {}},
+            }
+            result = {
+                "review_mode": "targeted-delegation",
+                "recommended_worker_count": 2,
+                "recommended_workers": [{"agent_type": "packet_explorer"}, {"agent_type": "packet_explorer"}],
+                "override_signals": [{"reason": "core_files_across_groups"}],
+                "common_path_sufficient": True,
+                "thread_batch_count": 1,
+                "singleton_thread_packet_count": 2,
+                "thread_counts": {"unresolved": 3, "unresolved_outdated": 1},
+                "packet_metrics_file": str(packet_metrics_path),
+            }
+
+            eval_log.apply_phase_update(log, "build", result, duration=0.25)
+
+            self.assertEqual(log["orchestration"]["review_mode"], "targeted-delegation")
+            self.assertEqual(log["orchestration"]["worker_count"], 2)
+            self.assertEqual(log["orchestration"]["worker_roles"], ["packet_explorer", "packet_explorer"])
+            self.assertEqual(log["orchestration"]["override_signals"], ["core_files_across_groups"])
+            self.assertFalse(log["orchestration"]["raw_reread_required"])
+            self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 600)
+            self.assertEqual(log["baseline"]["estimated_token_savings"], 350)
+            self.assertEqual(log["skill_specific"]["data"]["packet_count"], 4)
+            self.assertEqual(log["skill_specific"]["data"]["estimated_packet_tokens"], 250)
+            self.assertEqual(log["skill_specific"]["data"]["estimated_delegation_savings"], 350)
+            self.assertTrue(log["skill_specific"]["data"]["common_path_sufficient"])
+            self.assertEqual(log["measurement"]["token_source"], "estimated")
+
+    def test_apply_phase_merges_review_thread_counters(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log = {
+                "skill": {"name": "gh-address-review-threads"},
+                "quality": {},
+                "safety": {},
+                "outputs": {},
+                "orchestration": {},
+                "skill_specific": {"data": {}},
+            }
+            result = {
+                "dry_run": True,
+                "fingerprint_match": True,
+                "mutations": [
+                    {"kind": "add_reply", "thread_id": "t-1", "phase": "complete"},
+                    {"kind": "resolve_thread", "thread_id": "t-1", "phase": "complete"},
+                ],
+                "counters": {
+                    "adopted_unmarked_reply_count": 1,
+                    "skipped_outdated_count": 2,
+                    "invalid_complete_count": 1,
+                    "resolve_after_complete_count": 1,
+                    "threads_accepted": 1,
+                    "threads_rejected": 0,
+                    "threads_deferred": 0,
+                    "threads_defer_outdated": 2,
+                },
+            }
+
+            eval_log.apply_phase_update(log, "apply", result, duration=0.5)
+
+            self.assertEqual(log["quality"]["result_status"], "dry-run")
+            self.assertTrue(log["safety"]["fingerprint_match"])
+            self.assertEqual(log["skill_specific"]["data"]["adopted_unmarked_reply_count"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["skipped_outdated_count"], 2)
+            self.assertEqual(log["skill_specific"]["data"]["invalid_complete_count"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["resolve_after_complete_count"], 1)
+            self.assertEqual(log["skill_specific"]["data"]["threads_resolved"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: gh-create-pr
+description: Create a GitHub pull request from an already-pushed branch by collecting repo and PR-template context, drafting a repo-compliant title/body, validating duplicate-PR and stale-snapshot gates, and creating the PR with gh CLI only after the normalized create request passes validation. Use when Codex must open a new PR instead of rewriting an existing one.
+---
+
+# Guarded PR Creation
+
+Use this skill to open a new GitHub pull request from a branch that already exists on `origin`.
+
+This skill keeps the mutation path narrow:
+- keep final title/body drafting local
+- keep repo profiles data-only
+- keep duplicate-PR, template, and stale-snapshot gates local
+- use packet-heavy local synthesis on `rules + synthesis + <=1 focused packet`
+- never rely on `gh pr create --dry-run`; dry-run stays side-effect-free
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/gh-create-pr/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/gh-create-pr/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/gh-create-pr/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Collect context first.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_pr_create_context.py --repo-root <repo-root> [--repo <owner/name>] [--base <branch>] [--head <branch>] [--reviewer <login>] [--assignee <login>] [--label <name>] [--milestone <title>] [--draft] [--no-maintainer-edit] --output <context-json>`.
+- Collector keeps raw repeated options as entered. Normalization happens later in the validator.
+- Base resolution order is: `--base`, `branch.<current>.gh-merge-base`, remote default branch.
+
+2. Build drafting packets.
+- Run `<python-bin> -B <skill-dir>/scripts/lint_pr_create.py --context <context-json> --output <lint-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_pr_create_packets.py --context <context-json> --lint <lint-json> --output-dir <packet-dir> [--result-output <build-result-json>]`.
+- Read `orchestrator.json` first.
+- Keep the common path on `rules_packet.json`, `synthesis_packet.json`, and at most one focused packet.
+
+3. Draft locally.
+- Use the selected template sections exactly.
+- Treat issue refs, positive testing claims, rollout/restart/migration/compatibility claims, and `no behavior change` as gated claims, not prose flourishes.
+- If the repo already has a same-head open PR, do not create another one. Hand off to `gh-fix-pr-writeup`.
+
+4. Validate before mutation.
+- Run `<python-bin> -B <skill-dir>/scripts/validate_pr_create.py --context <context-json> --title "<title>" --body-file <body.md> --output <validation-json>`.
+- Validator normalizes reviewers, assignees, labels, milestone, and maintainer-edit settings.
+- Validator re-checks auth, head/base state, template selection, changed-files fingerprint, and same-head open PR state.
+- Apply must consume `normalized_create_request` only.
+
+5. Apply or dry-run.
+- Run `<python-bin> -B <skill-dir>/scripts/apply_pr_create.py --validation <validation-json> [--dry-run] [--result-output <apply-json>]`.
+- `--dry-run` does not call `gh pr create`.
+- Real apply re-checks the validated snapshot again immediately before creation.
+- Real apply re-fetches the created PR and confirms title/body/base/head/draft/options match the normalized request.
+
+## Stop Conditions
+
+- `missing_auth`
+- `repo_inference_failed`
+- `base_resolution_failed`
+- `template_not_found`
+- `template_ambiguous`
+- `remote_head_missing`
+- `head_oid_mismatch`
+- `existing_open_pr`
+- `invalid_title`
+- `invalid_body`
+- `unsupported_claim`
+- `stale_snapshot`
+- `fingerprint_mismatch`
+- `apply_verification_failed`
+
+## Output
+
+- Tell the user whether the run stopped at lint, validation, or apply.
+- Include the final PR URL when creation succeeds.
+- If blocked by an existing PR, include the existing PR URL and point the user to `gh-fix-pr-writeup`.

--- a/builders/packet-workflow/retained-skills/gh-create-pr/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gh Create Pr"
+  short_description: "create a guarded GitHub pull request from a pushe..."
+  default_prompt: "create a guarded GitHub pull request from a pushed branch with packet-heavy local synthesis and validator-normalized apply"

--- a/builders/packet-workflow/retained-skills/gh-create-pr/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/builder-spec.json
@@ -1,0 +1,115 @@
+{
+  "skill_name": "gh-create-pr",
+  "description": "Create a GitHub pull request from an already-pushed branch by collecting repo and PR-template context, drafting a repo-compliant title/body, validating duplicate-PR and stale-snapshot gates, and creating the PR with gh CLI only after the normalized create request passes validation. Use when Codex must open a new PR instead of rewriting an existing one.",
+  "domain_slug": "pr_create",
+  "workflow_family": "github-review",
+  "archetype": "plan-validate-apply",
+  "primary_goal": "create a guarded GitHub pull request from a pushed branch with packet-heavy local synthesis and validator-normalized apply",
+  "trigger_phrases": [
+    "create pr",
+    "open pull request",
+    "make a github pr",
+    "draft and create a pull request"
+  ],
+  "task_packet_names": [
+    "rules",
+    "runtime",
+    "process",
+    "testing"
+  ],
+  "orchestrator_profile": "packet-heavy-orchestrator",
+  "needs_lint": true,
+  "needs_validate": true,
+  "needs_apply": true,
+  "decision_ready_packets": false,
+  "worker_return_contract": "generic",
+  "worker_output_shape": "flat",
+  "packet_worker_map": {
+    "rules": [
+      "docs_verifier"
+    ],
+    "runtime": [
+      "packet_explorer"
+    ],
+    "process": [
+      "packet_explorer"
+    ],
+    "testing": [
+      "evidence_summarizer"
+    ]
+  },
+  "repo_profile": {
+    "name": "default",
+    "summary": "Default reusable profile scaffold for guarded PR creation. Replace project-specific PR guidance bindings, review-doc lists, and repo-specific lint toggles when vendored.",
+    "repo_match": {
+      "root_markers": [
+        ".git",
+        "README.md"
+      ],
+      "remote_patterns": []
+    },
+    "bindings": {
+      "primary_readme_path": "README.md",
+      "settings_source_path": null,
+      "publish_config_path": null
+    },
+    "packet_defaults": {
+      "review_docs": {
+        "rules": [
+          ".github/pull_request_template.md",
+          "CONTRIBUTING.md",
+          "MAINTAINING.md"
+        ],
+        "runtime": [
+          "README.md"
+        ],
+        "process": [
+          ".github/pull_request_template.md",
+          "CONTRIBUTING.md",
+          "MAINTAINING.md"
+        ],
+        "testing": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ]
+      },
+      "source_path_globs": {
+        "rules": [
+          ".github/**",
+          "*.md"
+        ],
+        "runtime": [
+          "src/**",
+          "lib/**",
+          "app/**",
+          "server/**",
+          "client/**"
+        ],
+        "process": [
+          ".github/**",
+          "*.md",
+          "docs/**"
+        ],
+        "testing": [
+          "tests/**",
+          "**/*test*.*"
+        ]
+      }
+    },
+    "lint_rules": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "notes": [
+      "Keep template discovery paths, PR guidance locations, and repo-specific rule files in project-local profile data.",
+      "Do not place duplicate-check policy, title/body claim gates, or validator/apply semantics in the profile."
+    ]
+  },
+  "builder_versioning": {
+    "builder_family": "packet-workflow",
+    "builder_semver": "0.1.0",
+    "compatibility_epoch": 1,
+    "builder_spec_schema_version": 1,
+    "repo_profile_schema_version": 1
+  }
+}

--- a/builders/packet-workflow/retained-skills/gh-create-pr/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/profiles/default/profile.json
@@ -1,0 +1,77 @@
+{
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "publish_config_path": null,
+    "settings_source_path": null
+  },
+  "extra": {},
+  "lint_rules": {
+    "missing_review_docs_are_errors": false,
+    "require_readme_settings_table": false
+  },
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  },
+  "name": "default",
+  "notes": [
+    "Keep template discovery paths, PR guidance locations, and repo-specific rule files in project-local profile data.",
+    "Do not place duplicate-check policy, title/body claim gates, or validator/apply semantics in the profile."
+  ],
+  "packet_defaults": {
+    "review_docs": {
+      "process": [
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "rules": [
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "runtime": [
+        "README.md"
+      ],
+      "testing": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ]
+    },
+    "source_path_globs": {
+      "process": [
+        ".github/**",
+        "*.md",
+        "docs/**"
+      ],
+      "rules": [
+        ".github/**",
+        "*.md"
+      ],
+      "runtime": [
+        "src/**",
+        "lib/**",
+        "app/**",
+        "server/**",
+        "client/**"
+      ],
+      "testing": [
+        "tests/**",
+        "**/*test*.*"
+      ]
+    }
+  },
+  "profile_path": "profiles/default/profile.json",
+  "repo_match": {
+    "remote_patterns": [],
+    "root_markers": [
+      ".git",
+      "README.md"
+    ]
+  },
+  "summary": "Default reusable profile scaffold for guarded PR creation. Replace project-specific PR guidance bindings, review-doc lists, and repo-specific lint toggles when vendored."
+}

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/core-contract.md
@@ -77,6 +77,7 @@ Keep in `packet_metrics.json` or evaluation logs only:
 - byte proxies
 - token-efficiency estimates
 - regression-oriented delegation metrics
+- any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/` instead of the repo root or a tracked source directory
 
 ## Repo Profile Boundary
 

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/core-contract.md
@@ -1,0 +1,95 @@
+# Gh Create Pr Core Contract
+
+This file captures the reusable packet-workflow core boundaries for `gh-create-pr`.
+
+Keep repo-specific guidance sources, review-doc lists, and lint toggles in [profiles/default/profile.json](../profiles/default/profile.json). Keep validator/apply semantics, stop-taxonomy meaning, and packet-routing authority in code and workflow contracts, not in the profile.
+
+## Core Metadata
+
+- `workflow_family`: `github-review`
+- `archetype`: `plan-validate-apply`
+- `orchestrator_profile`: `packet-heavy-orchestrator`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Runtime Outputs
+
+Required runtime outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `rules_packet.json`
+- `testing_packet.json`
+- `synthesis_packet.json`
+
+Conditionally emitted runtime packets:
+- `runtime_packet.json` when runtime files changed
+- `process_packet.json` when automation/docs/config files changed
+
+Evaluation-only output:
+- `packet_metrics.json`
+
+Rules:
+- keep `packet_metrics.json` out of runtime routing
+- keep final title/body synthesis local
+- keep `rules_packet.json` authoritative for template, title, and claim gates
+- keep validator/apply mutation gates local
+
+## Common Path Contract
+
+Common-path local drafting must close with:
+- `rules_packet.json`
+- `synthesis_packet.json`
+- at most one focused packet
+
+Rules:
+- packet insufficiency is a failure, not a reason to widen scope casually
+- raw reread is exceptional and should be reserved for stale or disputed evidence
+- validator/apply must not rely on collector duplicate hints as authoritative GitHub state
+
+## Worker Routing
+
+`packet_worker_map` is the routing authority when configured:
+- `runtime_packet.json -> packet_explorer`
+- `process_packet.json -> packet_explorer`
+- `testing_packet.json -> evidence_summarizer`
+
+Optional local cross-check workers:
+- `rules_packet.json -> docs_verifier`
+- `runtime_packet.json -> large_diff_auditor`
+
+Rules:
+- `worker_selection_guidance` is explanatory only
+- `rules_packet.json` remains local-first even when a rules verifier is available
+- final PR draft synthesis never delegates away from the orchestrator
+
+## Runtime vs Evaluation Split
+
+Keep in runtime packets and `orchestrator.json`:
+- routing metadata
+- authority order
+- common-path contract
+- local responsibilities
+- packet file lists
+
+Keep in `packet_metrics.json` or evaluation logs only:
+- packet sizing
+- byte proxies
+- token-efficiency estimates
+- regression-oriented delegation metrics
+
+## Repo Profile Boundary
+
+The default generated profile remains a reusable data-only overlay:
+- review-doc locations
+- source globs
+- repo matching hints
+- repo-specific notes
+
+Never move into the profile:
+- executable hooks
+- prompt fragments
+- packet routing authority
+- validator/apply behavior
+- duplicate-check policy
+- stop-taxonomy meaning

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/delegation-playbook.md
@@ -1,0 +1,122 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`: no workers
+- `targeted-delegation`: 1-2 analysis workers
+- `broad-delegation`: 3-4 analysis workers
+- Optional QA worker: only when packet findings conflict or broad mutation needs a final coverage pass
+
+## Packet Order
+
+- Every worker reads `global_packet.json` first.
+- Prefer `batch-packet-*.json` when it exists and the orchestrator points to grouped work.
+- Read singleton focused packets only for work not covered by a batch.
+- Keep each worker on one small packet slice.
+
+## Shared Context
+
+`global_packet.json` keeps all workers aligned on:
+- workflow family
+- primary goal
+- authority order
+- stop conditions
+- review mode overrides
+- preferred worker families
+- packet worker map when configured
+- worker selection guidance
+- worker return contract
+- worker output shape
+- xHigh reread policy
+- candidate field bundles when decision-ready packets are enabled
+- worker footer fields when hierarchical output is enabled
+- reread reason values when decision-ready packets are enabled
+- domain overlay semantics when configured
+- optional local helper policy
+
+## Worker Return Modes
+
+- `generic`
+  - Use for simple workflows where the local orchestrator mainly needs a narrow outcome and evidence pointers.
+- `classification-oriented`
+  - Use for adjudication-heavy workflows where final adjudication stays local but workers must return proposal-grade candidate records.
+  - Prefer hierarchical `candidates[] + footer` output.
+
+## Worker Families
+
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+- Surfaced optional worker list below is the delegated-mode exposed list after stable dedupe and after subtracting explicitly mapped recommended worker types:
+- `repo_mapper`
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `rules`
+  - `docs_verifier`
+- `runtime`
+  - `packet_explorer`
+- `process`
+  - `packet_explorer`
+- `testing`
+  - `evidence_summarizer`
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Analysis Worker Contract
+
+Prefer the named worker families above before falling back to an unspecified narrow `gpt-5.4-mini` worker.
+
+- Active worker return contract: `generic`.
+- Active worker output shape: `flat`.
+- Return exactly:
+  - `packet ids`
+  - `primary outcome`
+  - `evidence files`
+  - `recommended next step`
+  - `risk`
+  - `tests or checks`
+
+Do not draft the final user-facing response in worker output. The main agent owns final synthesis.
+Final plan confidence is recomputed locally even when worker confidence signals are present.
+
+## Mutation Guardrails
+
+- Keep final mutation local unless the generated skill explicitly narrows a safe worker-owned edit slice.
+- If the skill handles repo or remote mutations, do not ask a worker to own the whole mutation path from scratch.
+- If findings conflict, keep the result local and add QA instead of widening worker scope.
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $gh-create-pr to analyze packet-driven workflow inputs.
+
+Read only:
+- <global-packet>
+- <focused-packet-or-batch-packet>
+- <specific file slice if needed>
+
+Return exactly:
+- packet ids
+- primary outcome
+- evidence files
+- recommended next step
+- risk
+- tests or checks
+```
+
+Keep each worker narrow. Do not ask a worker to rediscover the whole repo state from scratch.

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/evaluation-log-contract.md
@@ -1,0 +1,60 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope in `gh-create-pr`.
+
+## Purpose
+
+Track three outcomes consistently:
+- efficiency
+- quality
+- safety
+
+Default log path:
+
+`~/.codex/tmp/evaluation_logs/gh-create-pr/<run-id>.json`
+
+The default path must stay outside the repo. An explicit override path is allowed.
+
+## Common Envelope
+
+Use this top-level shape:
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep truly common fields in the shared envelope only.
+- Put workflow-specific counters or mutation details in `skill_specific.data`.
+- Keep runtime contract metadata out of the evaluation log unless the workflow explicitly mirrors it for regression analysis.
+- Default `baseline.method` to `none`.
+- Leave savings fields null when no baseline exists.
+- Label estimated or unavailable data explicitly in `measurement`.
+- Renormalize scoring weights when a signal is missing.
+
+## Helper Workflow
+
+Use `scripts/write_evaluation_log.py` in three modes:
+- `init`
+  - `--context <json> --orchestrator <json> [--lint <json>] [--output <json>]`
+- `phase`
+  - `--log <json> --phase build|lint|validate|apply --result <json> [--duration-seconds <float>]`
+- `finalize`
+  - `--log <json> --final <json>`
+
+When a packet-heavy orchestrator profile emits `packet_metrics.json`, merge those counters through the build-phase result instead of copying them into runtime packets.

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
@@ -1,0 +1,233 @@
+# Gh Create Pr Contract
+
+This file defines the collector, packet, validator, and apply contract for `gh-create-pr`.
+
+The shared packet-workflow core boundary lives in [core-contract.md](./core-contract.md). Repo-local bindings stay in [profile.json](../profiles/default/profile.json).
+
+## Builder Metadata
+
+- `workflow_family`: `github-review`
+- `archetype`: `plan-validate-apply`
+- `orchestrator_profile`: `packet-heavy-orchestrator`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Collector Contract
+
+Collector CLI:
+- `--repo-root`
+- optional `--repo`
+- optional `--base`
+- optional `--head`
+- repeated `--reviewer`
+- repeated `--assignee`
+- repeated `--label`
+- optional `--milestone`
+- optional `--draft`
+- optional `--no-maintainer-edit`
+- `--profile`
+- `--output`
+
+Resolution rules:
+- base resolution order is `--base`, `branch.<current>.gh-merge-base`, remote default branch
+- head resolution order is `--head`, current branch
+- v1 stops closed when the resolved remote head does not exist
+
+Collector output must include:
+- `repo_root`
+- `repo_slug`
+- `resolved_base`
+- `resolved_head`
+- `current_branch`
+- `local_head_oid`
+- `remote_head_oid`
+- `changed_files`
+- `changed_files_fingerprint`
+- `diff_stat`
+- `template_selection`
+- `expected_template_sections`
+- `duplicate_check_hint`
+- `issue_reference_hints`
+- `testing_signal_candidates`
+- `create_options`
+- `checks`
+
+Template selection policy:
+- auto-select only a single unique default template
+- fail closed with `template_not_found` when no default template exists
+- fail closed with `template_ambiguous` when multiple candidates are eligible
+- record `selected_path` and `fingerprint` when selection succeeds
+
+Duplicate PR hint policy:
+- authoritative duplicate key is `repo_slug + head`
+- collector duplicate data is informational only
+- validator and apply must both re-check live GitHub state
+
+## Packet Contract
+
+Required runtime outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `rules_packet.json`
+- `testing_packet.json`
+- `synthesis_packet.json`
+
+Conditional runtime outputs:
+- `runtime_packet.json`
+- `process_packet.json`
+
+Evaluation-only output:
+- `packet_metrics.json`
+
+Packet responsibilities:
+- `rules_packet.json`
+  - title pattern
+  - selected template path/fingerprint
+  - required section order
+  - strict claim gates
+- `runtime_packet.json`
+  - shipped runtime surface
+  - `no behavior change` supportability
+- `process_packet.json`
+  - repo/base/head resolution
+  - issue-reference hints
+  - duplicate-check hint summary
+  - raw create options
+- `testing_packet.json`
+  - exact-command testing evidence
+  - positive testing claim limits
+- `synthesis_packet.json`
+  - active rule gates
+  - coverage gaps
+  - focused packet hint
+  - common-path sufficiency
+
+## Lint Contract
+
+Context lint:
+- fail or warn on unresolved repo/base/head/template state
+- surface duplicate-PR hints as warnings only
+- derive drafting-basis metadata for packet building
+
+Candidate lint:
+- title must match `<type>(<scope>): <summary>`
+- body must satisfy selected template sections and ordering
+- body must not retain placeholder text
+- title/body claims must be grounded in runtime/process/testing packet evidence
+
+Strict claim gates:
+- issue references require process-packet issue hints
+- positive testing claims require exact commands from testing evidence
+- `no behavior change` is allowed only when runtime packet is empty
+- rollout, restart/reload, migration, and compatibility claims fail closed by default
+
+## Validate Contract
+
+Validator CLI:
+- `--context <json>`
+- `--title "<title>"`
+- `--body-file <body.md>`
+- optional `--output <json>`
+
+Validator output:
+- `valid`
+- `can_apply`
+- `errors`
+- `warnings`
+- `error_details`
+- `warning_details`
+- `stop_reasons`
+- `candidate_findings`
+- `validation_commands`
+- `stale_fields`
+- `normalized_create_request`
+- `normalized_create_request_fingerprint`
+- `apply_gate_status`
+
+`normalized_create_request` must include:
+- `repo_root`
+- `repo_slug`
+- `base`
+- `head`
+- `title`
+- `body`
+- `draft`
+- `reviewers`
+- `assignees`
+- `labels`
+- `milestone`
+- `maintainer_can_modify`
+- `validation_commands`
+- `review_mode`
+- `qa_gate`
+- `validated_snapshot`
+
+`validated_snapshot` must include:
+- `local_head_oid`
+- `remote_head_oid`
+- `repo_slug`
+- `base_ref`
+- `head_ref`
+- `changed_files_fingerprint`
+- `template_path`
+- `template_fingerprint`
+- `duplicate_check_summary`
+
+`duplicate_check_summary` must include:
+- `status`
+- `matched_repo_slug`
+- `matched_head`
+- optional `existing_pr_number`
+- optional `existing_pr_url`
+
+Normalization rules:
+- reviewers/assignees: comma-split, trim, case-insensitive dedupe, deterministic sort
+- labels: comma-split, trim, exact-value dedupe, deterministic sort
+- milestone: trimmed scalar or `null`
+- maintainer edit: invert `no_maintainer_edit`
+
+Public stop taxonomy:
+- `missing_auth`
+- `repo_inference_failed`
+- `base_resolution_failed`
+- `template_not_found`
+- `template_ambiguous`
+- `remote_head_missing`
+- `head_oid_mismatch`
+- `existing_open_pr`
+- `invalid_title`
+- `invalid_body`
+- `unsupported_claim`
+- `stale_snapshot`
+- `fingerprint_mismatch`
+- `apply_verification_failed`
+
+Supplemental internal guard reasons used by the implementation:
+- `validator_mismatch`
+- `live_snapshot_unavailable`
+- `unresolved_stop_reason`
+
+## Apply Contract
+
+Apply CLI:
+- `--validation <json>`
+- optional `--dry-run`
+- optional `--result-output <json>`
+
+Apply rules:
+- consume validator-normalized output only
+- recompute the normalized request fingerprint before doing anything else
+- re-check auth and the entire validated snapshot before mutation
+- re-check duplicate state immediately before creation
+- do not call `gh pr create --dry-run`
+- real apply uses `gh pr create --head --base --title --body-file` plus validated options only
+- re-fetch the created PR by the same `repo_slug + head` key
+- fail closed when the fetched PR does not match the normalized request
+
+Apply result should report:
+- `apply_succeeded`
+- `stop_reason` / `stop_reasons` when blocked
+- `command`
+- `current_pr_url` when creation succeeds
+- `created_pr_number` when creation succeeds

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-evaluation-contract.md
@@ -1,0 +1,41 @@
+# Gh Create Pr Evaluation Contract
+
+Use the shared evaluation envelope in [evaluation-log-contract.md](./evaluation-log-contract.md) and keep create-specific metrics under `skill_specific.data`.
+
+## Recommended Skill-Specific Fields
+
+- `title_changed`
+- `body_changed`
+- `template_sections_required`
+- `template_sections_filled`
+- `unsupported_claim_categories`
+- `evidence_gap_categories`
+- `packet_metrics`
+
+Rules:
+- `packet_metrics` comes from the build phase and stays evaluation-only
+- store observed category lists, counts, and booleans instead of prose summaries
+- do not mirror live validator/apply routing metadata into evaluation fields unless the value is explicitly used for regression analysis
+
+## Phase Expectations
+
+Build phase should be able to contribute:
+- packet count and packet sizing
+- common-path packet efficiency estimates
+- estimated local-only versus packeted token cost
+
+Lint phase should be able to contribute:
+- unsupported-claim categories
+- evidence-gap categories
+- template-section coverage
+
+Validate/apply phases should stay on the shared envelope for:
+- result status
+- validation/apply pass state
+- stop reasons
+- primary artifact URL
+
+## Notes
+
+- Keep the contract aligned with the guarded PR-create workflow, not the PR-writeup edit workflow.
+- If the workflow later adds deterministic apply-side counters that matter for regression tracking, add them here rather than widening the shared envelope.

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/apply_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/apply_pr_create.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Apply a PR create request only from validator output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pr_create_contract as contract
+import pr_create_tools as tools
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--validation", required=True, help="Validator output JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Report the planned gh command without mutating.")
+    parser.add_argument("--result-output", help="Optional machine-readable apply result JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return contract.load_json(path)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    contract.write_json(path, payload)
+
+
+def fail(payload: dict[str, Any], result_output: Path | None, reason: str, message: str, **extra: Any) -> int:
+    payload.update(extra)
+    payload["apply_succeeded"] = False
+    payload["stop_reason"] = reason
+    payload["stop_reasons"] = [reason]
+    if result_output is not None:
+        write_json(result_output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 1
+
+
+def load_validated_request(validation: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    normalized = validation.get("normalized_create_request")
+    if not isinstance(normalized, dict):
+        raise RuntimeError("validator output is missing `normalized_create_request`")
+    fingerprint = str(validation.get("normalized_create_request_fingerprint") or "").strip()
+    if not fingerprint:
+        raise RuntimeError("validator output is missing `normalized_create_request_fingerprint`")
+    if contract.json_fingerprint(normalized) != fingerprint:
+        raise RuntimeError("validator fingerprint mismatch for normalized_create_request")
+    if not validation.get("valid") or not validation.get("can_apply"):
+        raise RuntimeError("validator output is not apply-safe")
+    apply_gate_status = validation.get("apply_gate_status") or {}
+    if apply_gate_status.get("uncovered_stop_categories"):
+        raise RuntimeError("validator output still reports uncovered stop categories")
+    return normalized, fingerprint
+
+
+def live_snapshot(request: dict[str, Any]) -> dict[str, Any]:
+    repo_root = Path(str(request.get("repo_root") or ".")).resolve()
+    repo_slug = str(request.get("repo_slug") or "").strip() or None
+    head = str(request.get("head") or "").strip()
+    base = str(request.get("base") or "").strip()
+    context_like = {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "resolved_head": head,
+        "resolved_base": base,
+        "local_head_oid": tools.local_head_oid(repo_root, head),
+        "remote_head_oid": tools.remote_head_oid(repo_root, head),
+        "changed_files_fingerprint": contract.json_fingerprint(tools.load_changed_files_between(repo_root, base, head)),
+        "template_selection": tools.select_pr_template(repo_root),
+    }
+    duplicate_summary = tools.duplicate_check_summary(repo_root, repo_slug, head) if repo_slug and head else {}
+    return contract.build_validated_snapshot(context_like, duplicate_summary)
+
+
+def normalized_pr_result(pr_payload: dict[str, Any]) -> dict[str, Any]:
+    labels = sorted(
+        str(item.get("name") or "").strip()
+        for item in pr_payload.get("labels", [])
+        if isinstance(item, dict) and str(item.get("name") or "").strip()
+    )
+    assignees = sorted(
+        str(item.get("login") or "").strip().lower()
+        for item in pr_payload.get("assignees", [])
+        if isinstance(item, dict) and str(item.get("login") or "").strip()
+    )
+    reviewers = sorted(
+        str((item.get("requestedReviewer") or {}).get("login") or "").strip().lower()
+        for item in pr_payload.get("reviewRequests", [])
+        if isinstance(item, dict) and str((item.get("requestedReviewer") or {}).get("login") or "").strip()
+    )
+    milestone = pr_payload.get("milestone") or {}
+    return {
+        "number": pr_payload.get("number"),
+        "url": str(pr_payload.get("url") or "").strip() or None,
+        "title": str(pr_payload.get("title") or "").strip(),
+        "body": str(pr_payload.get("body") or "").rstrip(),
+        "head": str(pr_payload.get("headRefName") or "").strip(),
+        "base": str(pr_payload.get("baseRefName") or "").strip(),
+        "draft": bool(pr_payload.get("isDraft")),
+        "labels": labels,
+        "assignees": assignees,
+        "reviewers": reviewers,
+        "milestone": str(milestone.get("title") or "").strip() or None,
+        "maintainer_can_modify": bool(pr_payload.get("maintainerCanModify")),
+    }
+
+
+def compare_request_to_pr(request: dict[str, Any], pr_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized = normalized_pr_result(pr_payload)
+    expected = {
+        "title": str(request.get("title") or "").strip(),
+        "body": str(request.get("body") or "").rstrip(),
+        "head": str(request.get("head") or "").strip(),
+        "base": str(request.get("base") or "").strip(),
+        "draft": bool(request.get("draft")),
+        "labels": list(request.get("labels") or []),
+        "assignees": [str(item).lower() for item in request.get("assignees", [])],
+        "reviewers": [str(item).lower() for item in request.get("reviewers", [])],
+        "milestone": request.get("milestone"),
+        "maintainer_can_modify": bool(request.get("maintainer_can_modify")),
+    }
+    mismatches: list[dict[str, Any]] = []
+    for field, expected_value in expected.items():
+        actual_value = normalized.get(field)
+        if actual_value != expected_value:
+            mismatches.append({"field": field, "expected": expected_value, "actual": actual_value})
+    return mismatches
+
+
+def build_command(request: dict[str, Any], body_path: Path) -> list[str]:
+    command = [
+        "gh",
+        "pr",
+        "create",
+        "--head",
+        str(request["head"]),
+        "--base",
+        str(request["base"]),
+        "--title",
+        str(request["title"]),
+        "--body-file",
+        str(body_path),
+    ]
+    repo_slug = str(request.get("repo_slug") or "").strip()
+    if repo_slug:
+        command.extend(["--repo", repo_slug])
+    if request.get("draft"):
+        command.append("--draft")
+    if not request.get("maintainer_can_modify", True):
+        command.append("--no-maintainer-edit")
+    if request.get("milestone"):
+        command.extend(["--milestone", str(request["milestone"])])
+    for item in request.get("reviewers", []):
+        command.extend(["--reviewer", str(item)])
+    for item in request.get("assignees", []):
+        command.extend(["--assignee", str(item)])
+    for item in request.get("labels", []):
+        command.extend(["--label", str(item)])
+    return command
+
+
+def main() -> int:
+    args = parse_args()
+    validation = load_json(Path(args.validation).resolve())
+    result_output = Path(args.result_output).resolve() if args.result_output else None
+    payload: dict[str, Any] = {
+        "dry_run": args.dry_run,
+        "validation_source": "validator_normalized_create_request",
+        "mutation_type": "gh_pr_create",
+        "command": None,
+    }
+
+    try:
+        request, fingerprint = load_validated_request(validation)
+    except Exception as exc:
+        return fail(payload, result_output, "fingerprint_mismatch", str(exc))
+
+    repo_root = Path(str(request.get("repo_root") or ".")).resolve()
+    payload.update(
+        {
+            "repo_slug": request.get("repo_slug"),
+            "head": request.get("head"),
+            "base": request.get("base"),
+            "normalized_create_request_fingerprint": fingerprint,
+            "validation_commands": list(request.get("validation_commands") or []),
+        }
+    )
+
+    try:
+        tools.run_command(["gh", "auth", "status"], cwd=repo_root)
+    except Exception as exc:
+        return fail(payload, result_output, "missing_auth", str(exc))
+
+    try:
+        fresh_snapshot = live_snapshot(request)
+    except Exception as exc:
+        return fail(payload, result_output, "live_snapshot_unavailable", str(exc))
+
+    validated_snapshot = request.get("validated_snapshot") or {}
+    stale_fields = contract.snapshot_mismatches(validated_snapshot, fresh_snapshot)
+    if stale_fields:
+        return fail(
+            payload,
+            result_output,
+            "stale_snapshot",
+            "The live branch/template/duplicate snapshot changed after validation.",
+            stale_fields=stale_fields,
+            current_duplicate_check_summary=fresh_snapshot.get("duplicate_check_summary"),
+        )
+
+    temp_root = repo_root / ".codex" / "tmp" / "packet-workflow" / "gh-create-pr"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        suffix=".md",
+        dir=temp_root,
+        delete=False,
+    ) as temp_file:
+        temp_file.write(str(request.get("body") or "").rstrip() + "\n")
+        temp_path = Path(temp_file.name)
+    try:
+        command = build_command(request, temp_path)
+        payload["command"] = command
+
+        if args.dry_run:
+            payload["apply_succeeded"] = True
+            if result_output is not None:
+                write_json(result_output, payload)
+            print(json.dumps(payload, indent=2, ensure_ascii=True))
+            return 0
+
+        try:
+            create_stdout = tools.run_command(command, cwd=repo_root).strip()
+        except Exception as exc:
+            return fail(payload, result_output, "apply_verification_failed", str(exc))
+
+        try:
+            matches = tools.load_open_prs_for_head(
+                repo_root,
+                str(request.get("repo_slug") or "").strip() or None,
+                str(request.get("head") or "").strip(),
+            )
+        except Exception as exc:
+            return fail(payload, result_output, "apply_verification_failed", str(exc))
+
+        if len(matches) != 1:
+            return fail(
+                payload,
+                result_output,
+                "apply_verification_failed",
+                "PR creation did not result in exactly one same-head open PR.",
+                create_stdout=create_stdout,
+                matched_pr_count=len(matches),
+            )
+
+        pr_payload = matches[0]
+        mismatches = compare_request_to_pr(request, pr_payload)
+        if mismatches:
+            return fail(
+                payload,
+                result_output,
+                "apply_verification_failed",
+                "Created PR does not match the validated create request.",
+                verification_mismatches=mismatches,
+                current_pr_url=normalized_pr_result(pr_payload).get("url"),
+            )
+
+        payload["current_pr_url"] = normalized_pr_result(pr_payload).get("url")
+        payload["created_pr_number"] = pr_payload.get("number")
+        payload["apply_succeeded"] = True
+        if result_output is not None:
+            write_json(result_output, payload)
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+        return 0
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/build_pr_create_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/build_pr_create_packets.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Build focused packets for gh-create-pr from collected context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import lint_pr_create as lint_tools
+import pr_create_contract as contract
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return contract.load_json(path)
+
+
+def parse_diff_totals(diff_stat: str | None) -> dict[str, int]:
+    return lint_tools.parse_diff_totals(diff_stat)
+
+
+def active_groups(group_summary: dict[str, dict[str, object]]) -> list[str]:
+    ordered_names = ("runtime", "automation", "docs", "tests", "config", "other")
+    return [name for name in ordered_names if (group_summary.get(name) or {}).get("count", 0) > 0]
+
+
+def determine_review_mode(context: dict[str, Any], lint_report: dict[str, Any]) -> tuple[str, int]:
+    groups = context.get("changed_file_groups") or {}
+    file_count = len(list(context.get("changed_files") or []))
+    group_count = len(active_groups(groups))
+    diff_totals = parse_diff_totals(context.get("diff_stat"))
+    override_signals = lint_report.get("findings", {}).get("override_signals", {})
+
+    if file_count <= contract.SMALL_FILE_LIMIT and group_count <= contract.SMALL_GROUP_LIMIT:
+        review_mode = "local-only"
+        worker_count = 0
+    elif file_count > contract.MEDIUM_FILE_LIMIT or group_count >= contract.LARGE_GROUP_LIMIT:
+        review_mode = "broad-delegation"
+        worker_count = 3
+    else:
+        review_mode = "targeted-delegation"
+        worker_count = 2
+
+    if any(bool(value) for value in override_signals.values()):
+        if review_mode == "local-only":
+            review_mode = "targeted-delegation"
+            worker_count = 2
+        elif review_mode == "targeted-delegation":
+            review_mode = "broad-delegation"
+            worker_count = 4
+
+    if review_mode == "broad-delegation" and diff_totals.get("churn", 0) >= 3000:
+        worker_count = 4
+    return review_mode, worker_count
+
+
+def build_rules_packet(context: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    snippets = context.get("instruction_snippets") or {}
+    template_selection = context.get("template_selection") or {}
+    return {
+        "purpose": "Authoritative hard-rule source for PR title/body drafting.",
+        "authoritative": True,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "title_pattern": "<type>(<scope>): <summary>",
+        "template_status": template_selection.get("status"),
+        "template_path": template_selection.get("selected_path"),
+        "template_fingerprint": template_selection.get("fingerprint"),
+        "required_sections": list(context.get("expected_template_sections") or []),
+        "strict_claim_gates": [
+            "issue references must match process-packet issue hints",
+            "positive testing claims require exact commands from testing packet evidence",
+            "`no behavior change` is only supportable when runtime packet is empty",
+            "restart/reload, migration, rollout, and compatibility claims are blocked by default",
+        ],
+        "repo_instruction_excerpts": {
+            "pull_request_title_rules_excerpt": snippets.get("pull_request_title_rules_excerpt"),
+            "pull_request_template_sections": snippets.get("pull_request_template_sections"),
+            "commit_types_excerpt": snippets.get("commit_types_excerpt"),
+        },
+        "rule_files": context.get("rule_files", {}),
+        "drafting_basis": drafting_basis,
+    }
+
+
+def build_global_packet(
+    context: dict[str, Any],
+    *,
+    review_mode: str,
+    focused_packet_hint: str | None,
+    lint_report: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "purpose": "Shared runtime context for local orchestration and narrow delegated packet analysis.",
+        "workflow_family": contract.WORKFLOW_FAMILY,
+        "archetype": contract.ARCHETYPE,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "repo_profile": context.get("repo_profile"),
+        "repo_slug": context.get("repo_slug"),
+        "head_ref": context.get("resolved_head"),
+        "base_ref": context.get("resolved_base"),
+        "review_mode": review_mode,
+        "authority_order": [
+            "rules_packet.json",
+            "synthesis_packet.json",
+            "focused packet evidence",
+            "explicit local reread only for stale or disputed signals",
+        ],
+        "packet_worker_map": contract.PACKET_WORKER_MAP,
+        "preferred_worker_families": contract.PREFERRED_WORKER_FAMILIES,
+        "worker_selection_guidance": contract.WORKER_SELECTION_GUIDANCE,
+        "focused_packet_hint": focused_packet_hint,
+        "review_overrides": lint_report.get("findings", {}).get("override_signals", {}),
+        "duplicate_hint": context.get("duplicate_check_hint"),
+        "local_gate_reminders": [
+            "Keep final title/body synthesis local.",
+            "Treat rules_packet.json as the only authority source for template, title, and claim gates.",
+            "Do not rely on collector duplicate hints for mutation safety; validator and apply re-check GitHub state.",
+            "Treat raw reread as exceptional, not compensatory.",
+        ],
+    }
+
+
+def build_runtime_packet(context: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    groups = context.get("changed_file_groups") or {}
+    runtime_group = groups.get("runtime") or {"count": 0, "sample_files": []}
+    return {
+        "purpose": "Runtime behavior and shipped-impact evidence slice.",
+        "changed_files": list(runtime_group.get("sample_files", [])),
+        "changed_file_count": runtime_group.get("count", 0),
+        "diff_stat": context.get("diff_stat"),
+        "supported_claims": [
+            item for item in drafting_basis.get("supported_claims", []) if item.get("cluster") == "runtime"
+        ],
+        "runtime_packet_empty": int(runtime_group.get("count", 0)) == 0,
+        "no_behavior_change_supportable": int(runtime_group.get("count", 0)) == 0,
+    }
+
+
+def build_process_packet(context: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    groups = context.get("changed_file_groups") or {}
+    process_files: list[str] = []
+    for group_name in ("automation", "docs", "config"):
+        process_files.extend(list((groups.get(group_name) or {}).get("sample_files", [])))
+    return {
+        "purpose": "Workflow, template, branch, and duplicate-check evidence slice.",
+        "repo_slug": context.get("repo_slug"),
+        "current_branch": context.get("current_branch"),
+        "head_ref": context.get("resolved_head"),
+        "base_ref": context.get("resolved_base"),
+        "local_head_oid": context.get("local_head_oid"),
+        "remote_head_oid": context.get("remote_head_oid"),
+        "changed_files": process_files,
+        "recent_commit_subjects": list(context.get("recent_commit_subjects") or []),
+        "issue_reference_hints": context.get("issue_reference_hints"),
+        "duplicate_check_hint": context.get("duplicate_check_hint"),
+        "create_options": context.get("create_options"),
+        "supported_claims": [
+            item for item in drafting_basis.get("supported_claims", []) if item.get("cluster") == "process"
+        ],
+    }
+
+
+def build_testing_packet(context: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    groups = context.get("changed_file_groups") or {}
+    testing_group = groups.get("tests") or {"count": 0, "sample_files": []}
+    return {
+        "purpose": "Testing evidence and claim-limit slice.",
+        "changed_test_files": list(testing_group.get("sample_files", [])),
+        "changed_test_file_count": testing_group.get("count", 0),
+        "testing_signal_candidates": context.get("testing_signal_candidates"),
+        "positive_testing_claims_supported": False,
+        "supported_claims": [
+            item for item in drafting_basis.get("supported_claims", []) if item.get("cluster") == "testing"
+        ],
+    }
+
+
+def build_synthesis_packet(
+    context: dict[str, Any],
+    *,
+    review_mode: str,
+    lint_report: dict[str, Any],
+    drafting_basis: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "purpose": "Run-specific drafting decision packet for local final PR title/body synthesis.",
+        "local_only": True,
+        "review_mode": review_mode,
+        "template_status": context.get("template_selection", {}).get("status"),
+        "duplicate_hint_status": context.get("duplicate_check_hint", {}).get("status"),
+        "active_rule_gates": list(drafting_basis.get("active_rule_gates", [])),
+        "required_sections_status": drafting_basis.get("required_sections_status"),
+        "issue_reference_hints": drafting_basis.get("issue_reference_hints"),
+        "testing_evidence_status": drafting_basis.get("testing_evidence_status"),
+        "coverage_gaps": list(drafting_basis.get("coverage_gaps", [])),
+        "focused_packet_hint": drafting_basis.get("focused_packet_hint"),
+        "lint_errors": list(lint_report.get("findings", {}).get("errors", [])),
+        "lint_warnings": list(lint_report.get("findings", {}).get("warnings", [])),
+        "common_path_contract": {
+            "required_packets": contract.COMMON_PATH_REQUIRED_PACKETS,
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "sufficient_for_local_final_drafting": True,
+            "packet_insufficiency_is_failure": True,
+        },
+    }
+
+
+def raw_local_bundle(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "context": context,
+        "lint_findings": lint_report.get("findings"),
+        "drafting_basis": lint_report.get("drafting_basis"),
+    }
+
+
+def build_worker_specs(
+    *,
+    review_mode: str,
+    worker_count: int,
+    runtime_active: bool,
+    process_active: bool,
+    testing_relevant: bool,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    recommended: list[dict[str, Any]] = []
+    optional: list[dict[str, Any]] = []
+
+    delegated_packets: list[tuple[str, str, str, str, str | None]] = []
+    if runtime_active:
+        delegated_packets.append(
+            (
+                "runtime",
+                "packet_explorer",
+                "runtime_packet.json",
+                "Summarize shipped runtime behavior and whether `no behavior change` is supportable.",
+                "gpt-5.4-mini",
+            )
+        )
+    if process_active:
+        delegated_packets.append(
+            (
+                "process",
+                "packet_explorer",
+                "process_packet.json",
+                "Summarize branch/base/template and issue-hint evidence worth mentioning.",
+                "gpt-5.4-mini",
+            )
+        )
+    if testing_relevant:
+        delegated_packets.append(
+            (
+                "testing",
+                "evidence_summarizer",
+                "testing_packet.json",
+                "Summarize which testing claims remain blocked or supportable.",
+                None,
+            )
+        )
+
+    for name, agent_type, packet_name, responsibility, model in delegated_packets[:worker_count]:
+        worker: dict[str, Any] = {
+            "name": name,
+            "agent_type": agent_type,
+            "packets": ["global_packet.json", packet_name],
+            "responsibility": responsibility,
+            "reasoning_effort": "medium" if agent_type != "evidence_summarizer" else "low",
+            "return_contract": contract.STANDARD_RETURN_CONTRACT,
+        }
+        if model:
+            worker["model"] = model
+        recommended.append(worker)
+
+    optional.append(
+        {
+            "name": "rules-cross-check",
+            "agent_type": "docs_verifier",
+            "packets": ["global_packet.json", "rules_packet.json"],
+            "responsibility": "Cross-check title, template, or claim gates when local inspection still leaves ambiguity.",
+            "reasoning_effort": "medium",
+            "return_contract": contract.STANDARD_RETURN_CONTRACT,
+        }
+    )
+    optional.append(
+        {
+            "name": "risk-cross-check",
+            "agent_type": "large_diff_auditor",
+            "packets": ["global_packet.json", "runtime_packet.json"],
+            "responsibility": "Use only for broad delegation or unusually risky diffs before mutation.",
+            "reasoning_effort": "medium",
+            "return_contract": contract.STANDARD_RETURN_CONTRACT,
+        }
+    )
+    return recommended, optional
+
+
+def build_packet_payloads(context: dict[str, Any], lint_report: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    groups = context.get("changed_file_groups") or {}
+    review_mode, worker_count = determine_review_mode(context, lint_report)
+    drafting_basis = lint_report.get("drafting_basis") or {}
+    runtime_active = int((groups.get("runtime") or {}).get("count", 0)) > 0
+    process_active = any(int((groups.get(name) or {}).get("count", 0)) > 0 for name in ("automation", "docs", "config"))
+    testing_relevant = int((groups.get("tests") or {}).get("count", 0)) > 0
+    focused_hint = drafting_basis.get("focused_packet_hint")
+
+    packet_payloads: dict[str, Any] = {
+        "global_packet.json": build_global_packet(
+            context,
+            review_mode=review_mode,
+            focused_packet_hint=focused_hint,
+            lint_report=lint_report,
+        ),
+        "rules_packet.json": build_rules_packet(context, drafting_basis),
+        "testing_packet.json": build_testing_packet(context, drafting_basis),
+        "synthesis_packet.json": build_synthesis_packet(
+            context,
+            review_mode=review_mode,
+            lint_report=lint_report,
+            drafting_basis=drafting_basis,
+        ),
+    }
+    if runtime_active:
+        packet_payloads["runtime_packet.json"] = build_runtime_packet(context, drafting_basis)
+    if process_active:
+        packet_payloads["process_packet.json"] = build_process_packet(context, drafting_basis)
+
+    common_path_packets = ["rules_packet.json", "synthesis_packet.json"]
+    if focused_hint:
+        common_path_packets.append(focused_hint)
+    packet_metrics = contract.compute_packet_metrics(
+        packet_payloads,
+        common_path_packet_names=common_path_packets,
+        raw_local_payload=raw_local_bundle(context, lint_report),
+    )
+    packet_metrics["common_path_packets"] = common_path_packets
+    packet_metrics["common_path_sufficient"] = True
+    packet_metrics["raw_reread_count"] = 0
+    packet_metrics["packet_insufficiency_is_failure"] = True
+
+    recommended_workers, optional_workers = build_worker_specs(
+        review_mode=review_mode,
+        worker_count=worker_count,
+        runtime_active=runtime_active,
+        process_active=process_active,
+        testing_relevant=testing_relevant,
+    )
+    packet_files = list(packet_payloads.keys()) + ["orchestrator.json"]
+    build_result = {
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "optional_worker_count": len(optional_workers),
+        "packet_files": packet_files,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "shared_local_packet": contract.SHARED_LOCAL_PACKET,
+        "template_status": context.get("template_selection", {}).get("status"),
+        "duplicate_hint_status": context.get("duplicate_check_hint", {}).get("status"),
+        "packet_metrics": packet_metrics,
+    }
+    orchestrator = {
+        "workflow_family": contract.WORKFLOW_FAMILY,
+        "archetype": contract.ARCHETYPE,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "optional_worker_count": len(optional_workers),
+        "shared_packet": "global_packet.json",
+        "shared_local_packet": contract.SHARED_LOCAL_PACKET,
+        "decision_ready_packets": contract.DECISION_READY_PACKETS,
+        "worker_return_contract": contract.WORKER_RETURN_CONTRACT,
+        "worker_output_shape": contract.WORKER_OUTPUT_SHAPE,
+        "preferred_worker_families": contract.PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": contract.PACKET_WORKER_MAP,
+        "worker_selection_guidance": contract.WORKER_SELECTION_GUIDANCE,
+        "common_path_contract": {
+            "required_packets": contract.COMMON_PATH_REQUIRED_PACKETS,
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "packet_insufficiency_is_failure": True,
+        },
+        "local_responsibilities": [
+            "Read rules_packet.json locally before drafting title/body.",
+            "Keep final PR draft synthesis local.",
+            "Validate against live head/template/duplicate state before any mutation.",
+            "Run apply_pr_create.py only from validator-normalized output.",
+        ],
+        "packet_files": packet_files,
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+    }
+    packet_payloads["orchestrator.json"] = orchestrator
+    packet_payloads["packet_metrics.json"] = packet_metrics
+    return packet_payloads, build_result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Path to JSON from collect_pr_create_context.py.")
+    parser.add_argument("--lint", required=True, help="Path to JSON from lint_pr_create.py.")
+    parser.add_argument("--output-dir", required=True, help="Directory for generated packets.")
+    parser.add_argument("--result-output", help="Optional output path for build result JSON.")
+    args = parser.parse_args()
+
+    context = load_json(Path(args.context))
+    lint_report = load_json(Path(args.lint))
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    packets, build_result = build_packet_payloads(context, lint_report)
+    for file_name, payload in packets.items():
+        contract.write_json(output_dir / file_name, payload)
+    if args.result_output:
+        contract.write_json(Path(args.result_output), build_result)
+
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output_dir),
+                "review_mode": build_result["review_mode"],
+                "packet_files": build_result["packet_files"],
+                "recommended_worker_count": build_result["recommended_worker_count"],
+                "packet_metrics_file": str(output_dir / "packet_metrics.json"),
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Collect structured workflow context for gh-create-pr."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base / ".codex" / "vendor" / "packetflow_foundry" / "builders" / "packet-workflow" / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+from pr_create_tools import build_context  # noqa: E402
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise SystemExit(f"[ERROR] Missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise SystemExit("[ERROR] Repo profile must be a JSON object.")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(load_json_document(skill_root() / "builder-spec.json")),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True, help="Repository root containing .git and PR guidance files.")
+    parser.add_argument("--repo", default=None, help="Optional GitHub repo slug such as owner/name.")
+    parser.add_argument("--base", default=None, help="Optional explicit base branch.")
+    parser.add_argument("--head", default=None, help="Optional explicit head branch.")
+    parser.add_argument("--reviewer", action="append", default=[], help="Raw reviewer option. Repeat as needed.")
+    parser.add_argument("--assignee", action="append", default=[], help="Raw assignee option. Repeat as needed.")
+    parser.add_argument("--label", action="append", default=[], help="Raw label option. Repeat as needed.")
+    parser.add_argument("--milestone", default=None, help="Optional raw milestone title.")
+    parser.add_argument("--draft", action="store_true", help="Mark the future PR as draft.")
+    parser.add_argument(
+        "--no-maintainer-edit",
+        action="store_true",
+        help="Disable maintainer edit on the future PR.",
+    )
+    parser.add_argument("--output", default=None, help="Optional output file path. Prints JSON to stdout when omitted.")
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    profile_path = resolve_profile_path(args.profile, repo_root)
+    repo_profile = load_repo_profile(profile_path)
+    context = build_context(
+        repo_root=repo_root,
+        repo_slug=args.repo,
+        base_ref=args.base,
+        head_ref=args.head,
+        reviewers=list(args.reviewer or []),
+        assignees=list(args.assignee or []),
+        labels=list(args.label or []),
+        milestone=args.milestone,
+        draft=args.draft,
+        no_maintainer_edit=args.no_maintainer_edit,
+    )
+    context["repo_profile_name"] = repo_profile.get("name")
+    context["repo_profile_path"] = profile_path.as_posix()
+    context["repo_profile_summary"] = repo_profile.get("summary")
+    context["repo_profile"] = repo_profile
+    context["builder_compatibility"] = build_builder_compatibility(repo_profile)
+    payload = json.dumps(context, indent=2, ensure_ascii=True)
+
+    if context["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(context["builder_compatibility"]), file=sys.stderr)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/lint_pr_create.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Run deterministic lint checks for gh-create-pr."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pr_create_tools import PR_TITLE_RE
+
+
+PLACEHOLDER_PATTERNS = [
+    (re.compile(r"^- $", re.MULTILINE), "Template contains an empty bullet (`- `)."),
+    (re.compile(r"Refs:\s*#$", re.MULTILINE), "Template still contains the placeholder `Refs: #`."),
+    (
+        re.compile(r"Note any important defaults, thresholds, reload/restart requirements, or", re.MULTILINE),
+        "Template guidance text is still present in `How`.",
+    ),
+    (re.compile(r"^\s*-\s*$", re.MULTILINE), "Body contains a blank nested bullet."),
+    (
+        re.compile(r"If not tested, state why\.", re.MULTILINE),
+        "Template reminder `If not tested, state why.` was not replaced.",
+    ),
+]
+ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
+CLOSING_REF_PATTERN = re.compile(r"\b(?:fixes|closes)\s+#(?P<number>\d+)", re.IGNORECASE)
+NO_BEHAVIOR_CHANGE_PATTERN = re.compile(r"\bno behavior change\b", re.IGNORECASE)
+ROLLOUT_PATTERN = re.compile(r"\brollout\b", re.IGNORECASE)
+RESTART_PATTERN = re.compile(r"\b(restart|reload)\b", re.IGNORECASE)
+MIGRATION_PATTERN = re.compile(r"\b(migration|backward[- ]compat(?:ibility)?)\b", re.IGNORECASE)
+POSITIVE_TEST_PATTERN = re.compile(r"\b(tested|verified|validated|manual(?:ly)?|ran)\b", re.IGNORECASE)
+NOT_RUN_PATTERN = re.compile(r"\bnot run\b", re.IGNORECASE)
+COMMAND_PATTERN = re.compile(r"`([^`]+)`")
+GENERATED_FILE_PATTERNS = (
+    re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
+    re.compile(r"\.(g|generated)\.[^.]+$"),
+    re.compile(r"\.designer\.[^.]+$"),
+    re.compile(r"(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|cargo\.lock)$"),
+    re.compile(r"\.min\.(js|css)$"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--output", required=True, help="Output lint JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def section_bodies(markdown_text: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                result[current] = "\n".join(buffer).strip()
+            current = line[3:].strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        result[current] = "\n".join(buffer).strip()
+    return result
+
+
+def ordered_subset(expected: list[str], actual: list[str]) -> bool:
+    position = 0
+    for heading in expected:
+        while position < len(actual) and actual[position] != heading:
+            position += 1
+        if position >= len(actual):
+            return False
+        position += 1
+    return True
+
+
+def parse_diff_totals(diff_stat: str | None) -> dict[str, int]:
+    if not diff_stat:
+        return {"files_changed": 0, "insertions": 0, "deletions": 0, "churn": 0}
+    last_line = diff_stat.strip().splitlines()[-1]
+    files_match = re.search(r"(?P<files>\d+) files? changed", last_line)
+    insertions_match = re.search(r"(?P<insertions>\d+) insertions?\(\+\)", last_line)
+    deletions_match = re.search(r"(?P<deletions>\d+) deletions?\(-\)", last_line)
+    files_changed = int(files_match.group("files")) if files_match else 0
+    insertions = int(insertions_match.group("insertions")) if insertions_match else 0
+    deletions = int(deletions_match.group("deletions")) if deletions_match else 0
+    return {
+        "files_changed": files_changed,
+        "insertions": insertions,
+        "deletions": deletions,
+        "churn": insertions + deletions,
+    }
+
+
+def referenced_issue_numbers(text: str) -> list[str]:
+    seen: list[str] = []
+    for match in ISSUE_REF_PATTERN.finditer(text):
+        number = match.group("number")
+        if number not in seen:
+            seen.append(number)
+    return seen
+
+
+def is_generated_file(path: str) -> bool:
+    lowered = path.replace("\\", "/").lower()
+    return any(pattern.search(lowered) for pattern in GENERATED_FILE_PATTERNS)
+
+
+def supported_claims(context: dict[str, Any]) -> list[dict[str, str]]:
+    groups = context.get("changed_file_groups") or {}
+    claims: list[dict[str, str]] = []
+    runtime_count = int((groups.get("runtime") or {}).get("count", 0))
+    if runtime_count > 0:
+        claims.append(
+            {
+                "cluster": "runtime",
+                "basis": "runtime files changed",
+                "evidence_anchor": ", ".join(list((groups.get("runtime") or {}).get("sample_files", []))[:2]),
+            }
+        )
+    else:
+        claims.append(
+            {
+                "cluster": "runtime",
+                "basis": "no runtime files changed",
+                "evidence_anchor": "runtime packet is empty",
+            }
+        )
+    process_files: list[str] = []
+    for name in ("automation", "docs", "config"):
+        process_files.extend(list((groups.get(name) or {}).get("sample_files", []))[:1])
+    if process_files:
+        claims.append(
+            {
+                "cluster": "process",
+                "basis": "workflow/docs/config files changed",
+                "evidence_anchor": ", ".join(process_files[:2]),
+            }
+        )
+    claims.append(
+        {
+            "cluster": "testing",
+            "basis": "positive testing claims require explicit external evidence; neutral `Not run.` wording is safe by default",
+            "evidence_anchor": "testing packet exact_commands",
+        }
+    )
+    return claims
+
+
+def coverage_gaps(context: dict[str, Any], findings: dict[str, Any]) -> list[str]:
+    gaps: list[str] = []
+    template_selection = context.get("template_selection") or {}
+    status = str(template_selection.get("status") or "")
+    if status != "selected":
+        gaps.append("template selection is not stable enough for safe body drafting.")
+    if not context.get("checks", {}).get("repo_slug_resolved"):
+        gaps.append("repo slug is unresolved; duplicate PR checks cannot be trusted.")
+    if not context.get("checks", {}).get("remote_head_exists"):
+        gaps.append("remote head is missing; PR creation is out of scope for v1.")
+    if not context.get("issue_reference_hints", {}).get("numbers"):
+        gaps.append("issue references have no external hint source; `Refs:` / `Fixes:` claims should stay out of the draft.")
+    for message in findings.get("warnings", []):
+        if message not in gaps:
+            gaps.append(message)
+    return gaps
+
+
+def focused_packet_hint(context: dict[str, Any]) -> str | None:
+    groups = context.get("changed_file_groups") or {}
+    if int((groups.get("tests") or {}).get("count", 0)) > 0:
+        return "testing_packet.json"
+    if int((groups.get("runtime") or {}).get("count", 0)) > 0:
+        return "runtime_packet.json"
+    if any(int((groups.get(name) or {}).get("count", 0)) > 0 for name in ("automation", "docs", "config")):
+        return "process_packet.json"
+    return None
+
+
+def build_drafting_basis(context: dict[str, Any], findings: dict[str, Any]) -> dict[str, Any]:
+    expected = list(context.get("expected_template_sections") or [])
+    duplicate_hint = context.get("duplicate_check_hint") or {}
+    template_selection = context.get("template_selection") or {}
+    return {
+        "active_rule_gates": [
+            "title_pattern",
+            "required_sections",
+            "section_order",
+            "issue_reference_gate",
+            "testing_claim_gate",
+            "strict_claim_gate",
+            "duplicate_pr_gate",
+        ],
+        "template_status": template_selection.get("status"),
+        "required_sections_status": {
+            "required": expected,
+            "selected_template_path": template_selection.get("selected_path"),
+            "template_fingerprint": template_selection.get("fingerprint"),
+        },
+        "supported_claims": supported_claims(context),
+        "issue_reference_hints": dict(context.get("issue_reference_hints") or {}),
+        "testing_evidence_status": dict(context.get("testing_signal_candidates") or {}),
+        "duplicate_check_hint": {
+            "status": duplicate_hint.get("status"),
+            "existing_pr_url": duplicate_hint.get("existing_pr_url"),
+        },
+        "coverage_gaps": coverage_gaps(context, findings),
+        "focused_packet_hint": focused_packet_hint(context),
+    }
+
+
+def context_override_signals(context: dict[str, Any]) -> dict[str, bool]:
+    groups = context.get("changed_file_groups") or {}
+    changed_files = list(context.get("changed_files") or [])
+    diff_totals = parse_diff_totals(context.get("diff_stat"))
+    generated_count = sum(1 for path in changed_files if is_generated_file(path))
+    generated_ratio = (generated_count / len(changed_files)) if changed_files else 0.0
+    core_group_count = sum(
+        1 for name in ("runtime", "automation", "config") if int((groups.get(name) or {}).get("count", 0)) > 0
+    )
+    return {
+        "high_churn": diff_totals.get("churn", 0) >= 1500,
+        "multi_group_core_files": core_group_count >= 2,
+        "generated_not_majority": generated_count >= 3 and 0.2 <= generated_ratio < 0.5,
+    }
+
+
+def collect_context_findings(context: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    info: list[str] = []
+    template_selection = context.get("template_selection") or {}
+    duplicate_hint = context.get("duplicate_check_hint") or {}
+    checks = context.get("checks") or {}
+
+    if not checks.get("repo_slug_resolved"):
+        errors.append("Repository slug could not be inferred; duplicate PR checks will fail closed.")
+    if not checks.get("base_resolved"):
+        errors.append("Base branch could not be resolved from --base, branch.gh-merge-base, or remote default branch.")
+    status = str(template_selection.get("status") or "")
+    if status == "not_found":
+        errors.append("No unique default PR template was found.")
+    elif status == "ambiguous":
+        errors.append("Multiple PR template candidates were found; fail closed until one default template is selected.")
+    if not checks.get("remote_head_exists"):
+        errors.append("Resolved head branch does not exist on origin; branch publication is out of scope for v1.")
+    if checks.get("remote_head_exists") and not checks.get("local_remote_match"):
+        errors.append("Local and remote head OIDs differ; refresh or push before creating a PR.")
+
+    duplicate_status = str(duplicate_hint.get("status") or "")
+    if duplicate_status == "existing-open-pr":
+        warnings.append("A same-head open PR already exists; validator should stop and hand off to gh-fix-pr-writeup.")
+    elif duplicate_status == "unavailable":
+        warnings.append("Duplicate PR hint could not be collected locally; validator must re-check live GitHub state.")
+
+    groups = context.get("changed_file_groups") or {}
+    active_groups = [
+        name
+        for name in ("runtime", "automation", "docs", "tests", "config")
+        if int((groups.get(name) or {}).get("count", 0)) > 0
+    ]
+    info.append("Changed areas: " + (", ".join(active_groups) if active_groups else "none detected"))
+    if context.get("issue_reference_hints", {}).get("numbers"):
+        info.append("Issue hints: " + ", ".join(f"#{item}" for item in context["issue_reference_hints"]["numbers"]))
+    else:
+        info.append("Issue hints: none")
+
+    result = {
+        "errors": errors,
+        "warnings": warnings,
+        "info": info,
+        "detected": {
+            "template_status": status,
+            "duplicate_hint_status": duplicate_status,
+            "expected_sections": list(context.get("expected_template_sections") or []),
+            "active_groups": active_groups,
+        },
+        "override_signals": context_override_signals(context),
+    }
+    result["drafting_basis"] = build_drafting_basis(context, result)
+    result["can_proceed"] = not errors
+    return result
+
+
+def collect_candidate_findings(context: dict[str, Any], title: str, body: str) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    info: list[str] = []
+    title_errors: list[str] = []
+    body_errors: list[str] = []
+    unsupported_claims: list[str] = []
+
+    expected_sections = list(context.get("expected_template_sections") or [])
+    actual_sections = list(section_bodies(body).keys())
+    bodies = section_bodies(body)
+    issue_hints = set(str(item) for item in context.get("issue_reference_hints", {}).get("numbers", []))
+    runtime_count = int(((context.get("changed_file_groups") or {}).get("runtime") or {}).get("count", 0))
+    testing_signals = context.get("testing_signal_candidates") or {}
+    allowed_commands = set(str(item).strip() for item in testing_signals.get("exact_commands", []) if str(item).strip())
+
+    if not PR_TITLE_RE.match(title.strip()):
+        title_errors.append(
+            "Title does not match the repository Conventional Commit pattern `<type>(<scope>): <summary>`."
+        )
+    if len(title.strip()) > 72:
+        warnings.append("Title is longer than the preferred 72-character limit.")
+
+    missing_sections = [section for section in expected_sections if section not in actual_sections]
+    if missing_sections:
+        body_errors.append("Body is missing template sections: " + ", ".join(missing_sections) + ".")
+    elif expected_sections and not ordered_subset(expected_sections, actual_sections):
+        body_errors.append("Body sections do not follow the repository template order.")
+
+    for pattern, message in PLACEHOLDER_PATTERNS:
+        if pattern.search(body):
+            body_errors.append(message)
+
+    testing_text = bodies.get("Testing", "")
+    testing_commands = {match.group(1).strip() for match in COMMAND_PATTERN.finditer(testing_text)}
+    if POSITIVE_TEST_PATTERN.search(testing_text) and not NOT_RUN_PATTERN.search(testing_text):
+        if not testing_commands:
+            unsupported_claims.append(
+                "Positive testing claims require an exact command from the testing packet."
+            )
+        elif not testing_commands.issubset(allowed_commands):
+            unsupported_claims.append(
+                "Positive testing claims cite commands that are not grounded in the testing packet."
+            )
+
+    all_refs = set(referenced_issue_numbers(body))
+    closing_refs = {match.group("number") for match in CLOSING_REF_PATTERN.finditer(body)}
+    if all_refs and not all_refs.issubset(issue_hints):
+        unsupported_claims.append(
+            "Issue references are present without matching issue hints from the process packet."
+        )
+    elif closing_refs and not closing_refs.issubset(issue_hints):
+        unsupported_claims.append(
+            "Closing issue references require explicit issue hints before they can be claimed."
+        )
+
+    if NO_BEHAVIOR_CHANGE_PATTERN.search(body) and runtime_count > 0:
+        unsupported_claims.append("`No behavior change` is unsupported because runtime files changed.")
+    if RESTART_PATTERN.search(body):
+        unsupported_claims.append("Restart or reload claims require direct runtime evidence and are blocked by default.")
+    if MIGRATION_PATTERN.search(body):
+        unsupported_claims.append("Migration or compatibility claims require direct runtime/process evidence and are blocked by default.")
+    if ROLLOUT_PATTERN.search(body):
+        unsupported_claims.append("Rollout claims require direct process evidence and are blocked by default.")
+
+    if testing_text and not testing_text.strip():
+        body_errors.append("`Testing` is present but empty.")
+
+    errors.extend(title_errors)
+    errors.extend(body_errors)
+    errors.extend(unsupported_claims)
+    info.append("Candidate sections: " + (", ".join(actual_sections) if actual_sections else "none"))
+
+    return {
+        "errors": errors,
+        "warnings": warnings,
+        "info": info,
+        "detected": {
+            "expected_sections": expected_sections,
+            "actual_sections": actual_sections,
+            "title_errors": title_errors,
+            "body_errors": body_errors,
+            "unsupported_claims": unsupported_claims,
+            "issue_hints": sorted(issue_hints),
+            "testing_commands": sorted(testing_commands),
+        },
+        "drafting_basis": build_drafting_basis(context, {"errors": errors, "warnings": warnings}),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    findings = collect_context_findings(context)
+    report = {
+        "repo_slug": context.get("repo_slug"),
+        "head_ref": context.get("resolved_head"),
+        "base_ref": context.get("resolved_base"),
+        "template_selection": context.get("template_selection"),
+        "duplicate_check_hint": context.get("duplicate_check_hint"),
+        "findings": findings,
+        "drafting_basis": findings.get("drafting_basis"),
+    }
+    write_json(Path(args.output).resolve(), report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_contract.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_contract.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Shared contracts and helpers for gh-create-pr."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+
+WORKFLOW_FAMILY = "github-review"
+ARCHETYPE = "plan-validate-apply"
+ORCHESTRATOR_PROFILE = "packet-heavy-orchestrator"
+DECISION_READY_PACKETS = False
+WORKER_RETURN_CONTRACT = "generic"
+WORKER_OUTPUT_SHAPE = "flat"
+
+COMMON_PATH_REQUIRED_PACKETS = ["rules_packet.json", "synthesis_packet.json"]
+COMMON_PATH_MAX_FOCUSED_PACKETS = 1
+SHARED_LOCAL_PACKET = "synthesis_packet.json"
+
+PACKET_NAMES = [
+    "global_packet.json",
+    "rules_packet.json",
+    "runtime_packet.json",
+    "process_packet.json",
+    "testing_packet.json",
+    "synthesis_packet.json",
+]
+
+SMALL_FILE_LIMIT = 8
+MEDIUM_FILE_LIMIT = 20
+SMALL_GROUP_LIMIT = 2
+LARGE_GROUP_LIMIT = 4
+
+PACKET_WORKER_MAP = {
+    "runtime_packet.json": ["packet_explorer"],
+    "process_packet.json": ["packet_explorer"],
+    "testing_packet.json": ["evidence_summarizer"],
+}
+
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["packet_explorer", "docs_verifier"],
+    "candidate_producers": ["evidence_summarizer", "large_diff_auditor"],
+    "verifiers": ["docs_verifier"],
+}
+
+WORKER_SELECTION_GUIDANCE = {
+    "routing_authority": "packet_worker_map",
+    "notes": [
+        "Treat packet_worker_map as the concrete routing source for delegated runtime, process, and testing packets.",
+        "Keep rules_packet.json as the local-only authority source for template, title, and claim gates.",
+        "Keep final draft synthesis local and validator/apply mutation gates local.",
+    ],
+    "agent_type_guidance": {
+        "packet_explorer": "Use for one focused runtime or process packet plus only the explicitly referenced file slices needed to ground a narrow summary.",
+        "docs_verifier": "Use only as a narrow rules cross-check when the local gate still leaves ambiguity.",
+        "evidence_summarizer": "Use for testing claims, exact-command evidence, and unsupported-claim screening.",
+        "large_diff_auditor": "Reserve for rare QA or broad-risk cross-checks after a local draft exists.",
+    },
+}
+
+STANDARD_RETURN_CONTRACT = [
+    "primary outcome",
+    "evidence files",
+    "unsupported claims",
+    "suggested PR bullets",
+]
+
+VALIDATION_ERROR_CODES = {
+    "missing_context_field": "E_CREATE_CONTEXT_MISSING_FIELD",
+    "missing_candidate_field": "E_CREATE_CANDIDATE_MISSING_FIELD",
+    "invalid_title": "E_CREATE_INVALID_TITLE",
+    "invalid_body": "E_CREATE_INVALID_BODY",
+    "unsupported_claim": "E_CREATE_UNSUPPORTED_CLAIM",
+    "missing_auth": "E_CREATE_MISSING_AUTH",
+    "repo_inference_failed": "E_CREATE_REPO_INFERENCE_FAILED",
+    "base_resolution_failed": "E_CREATE_BASE_RESOLUTION_FAILED",
+    "template_not_found": "E_CREATE_TEMPLATE_NOT_FOUND",
+    "template_ambiguous": "E_CREATE_TEMPLATE_AMBIGUOUS",
+    "remote_head_missing": "E_CREATE_REMOTE_HEAD_MISSING",
+    "head_oid_mismatch": "E_CREATE_HEAD_OID_MISMATCH",
+    "existing_open_pr": "E_CREATE_EXISTING_OPEN_PR",
+    "live_snapshot_unavailable": "E_CREATE_LIVE_SNAPSHOT_UNAVAILABLE",
+    "stale_snapshot": "E_CREATE_STALE_SNAPSHOT",
+    "fingerprint_mismatch": "E_CREATE_FINGERPRINT_MISMATCH",
+    "apply_verification_failed": "E_CREATE_APPLY_VERIFICATION_FAILED",
+}
+
+VALIDATION_WARNING_CODES = {
+    "candidate_warning": "W_CREATE_CANDIDATE_WARNING",
+}
+
+CORE_STOP_CATEGORIES = [
+    "missing_auth",
+    "repo_inference_failed",
+    "base_resolution_failed",
+    "template_not_found",
+    "template_ambiguous",
+    "remote_head_missing",
+    "head_oid_mismatch",
+    "existing_open_pr",
+    "invalid_title",
+    "invalid_body",
+    "unsupported_claim",
+    "stale_snapshot",
+    "fingerprint_mismatch",
+    "apply_verification_failed",
+    "validator_mismatch",
+    "live_snapshot_unavailable",
+    "unresolved_stop_reason",
+]
+
+APPLICABLE_STOP_CATEGORIES = [
+    "missing_auth",
+    "repo_inference_failed",
+    "base_resolution_failed",
+    "template_not_found",
+    "template_ambiguous",
+    "remote_head_missing",
+    "head_oid_mismatch",
+    "existing_open_pr",
+    "stale_snapshot",
+    "fingerprint_mismatch",
+    "apply_verification_failed",
+    "validator_mismatch",
+    "unresolved_stop_reason",
+]
+
+LOCAL_STOP_CATEGORIES = [
+    "invalid_title",
+    "invalid_body",
+    "unsupported_claim",
+    "live_snapshot_unavailable",
+]
+
+VALIDATED_SNAPSHOT_FIELDS = [
+    "local_head_oid",
+    "remote_head_oid",
+    "repo_slug",
+    "base_ref",
+    "head_ref",
+    "changed_files_fingerprint",
+    "template_path",
+    "template_fingerprint",
+]
+
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+
+LOCAL_ONLY_PACKETS = {"synthesis_packet.json", "orchestrator.json"}
+RUNTIME_PACKET_EXCLUSIONS = {"packet_metrics.json"}
+
+
+def load_json(path: Any) -> dict[str, Any]:
+    from pathlib import Path
+
+    return json.loads(Path(path).read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Any, payload: dict[str, Any]) -> None:
+    from pathlib import Path
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def json_fingerprint(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def json_bytes(payload: Any) -> int:
+    return len((json.dumps(payload, indent=2, ensure_ascii=True) + "\n").encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return int(math.ceil(byte_count / 4.0))
+
+
+def compute_packet_metrics(
+    packet_payloads: dict[str, Any],
+    *,
+    common_path_packet_names: list[str],
+    raw_local_payload: Any,
+) -> dict[str, Any]:
+    packet_sizes = {name: json_bytes(payload) for name, payload in packet_payloads.items()}
+    total_packet_bytes = sum(packet_sizes.values())
+    sorted_sizes = sorted(packet_sizes.values(), reverse=True)
+    common_path_bytes = sum(packet_sizes.get(name, 0) for name in common_path_packet_names)
+    raw_local_bytes = json_bytes(raw_local_payload)
+    return {
+        "packet_count": len(packet_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "packet_size_by_file": packet_sizes,
+        "largest_packet_bytes": sorted_sizes[0] if sorted_sizes else 0,
+        "largest_two_packets_bytes": sum(sorted_sizes[:2]),
+        "common_path_packet_bytes": common_path_bytes,
+        "raw_local_source_bytes": raw_local_bytes,
+        "estimated_local_only_tokens": estimate_tokens_from_bytes(raw_local_bytes),
+        "estimated_packet_tokens": estimate_tokens_from_bytes(common_path_bytes),
+        "estimated_delegation_savings": max(
+            0,
+            estimate_tokens_from_bytes(raw_local_bytes) - estimate_tokens_from_bytes(common_path_bytes),
+        ),
+    }
+
+
+def normalize_scalar(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalize_path(value: Any) -> str:
+    return normalize_scalar(value).replace("\\", "/")
+
+
+def normalize_string_list(values: Any, *, casefold: bool = False, sort_values: bool = True) -> list[str]:
+    items: list[str] = []
+    if isinstance(values, list):
+        raw_items = values
+    elif values is None:
+        raw_items = []
+    else:
+        raw_items = [values]
+    for item in raw_items:
+        text = normalize_scalar(item)
+        if not text:
+            continue
+        if casefold:
+            text = text.lower()
+        items.append(text)
+    deduped = list(dict.fromkeys(items))
+    return sorted(deduped) if sort_values else deduped
+
+
+def normalize_duplicate_summary(summary: Any) -> dict[str, Any]:
+    payload = summary if isinstance(summary, dict) else {}
+    number = payload.get("existing_pr_number")
+    count = payload.get("existing_pr_count")
+    return {
+        "status": normalize_scalar(payload.get("status")) or "unknown",
+        "matched_repo_slug": normalize_scalar(payload.get("matched_repo_slug")),
+        "matched_head": normalize_scalar(payload.get("matched_head")),
+        "existing_pr_number": int(number) if isinstance(number, int) or str(number).isdigit() else None,
+        "existing_pr_url": normalize_scalar(payload.get("existing_pr_url")) or None,
+        "existing_pr_count": int(count) if isinstance(count, int) or str(count).isdigit() else 0,
+    }
+
+
+def duplicate_summary_is_clear(summary: Any) -> bool:
+    return normalize_duplicate_summary(summary).get("status") == "clear"
+
+
+def build_validated_snapshot(context: dict[str, Any], duplicate_summary: dict[str, Any]) -> dict[str, Any]:
+    template_selection = context.get("template_selection") or {}
+    return {
+        "local_head_oid": normalize_scalar(context.get("local_head_oid")),
+        "remote_head_oid": normalize_scalar(context.get("remote_head_oid")),
+        "repo_slug": normalize_scalar(context.get("repo_slug")),
+        "base_ref": normalize_scalar(context.get("resolved_base")),
+        "head_ref": normalize_scalar(context.get("resolved_head")),
+        "changed_files_fingerprint": normalize_scalar(context.get("changed_files_fingerprint")),
+        "template_path": normalize_path(template_selection.get("selected_path")),
+        "template_fingerprint": normalize_scalar(template_selection.get("fingerprint")),
+        "duplicate_check_summary": normalize_duplicate_summary(duplicate_summary),
+    }
+
+
+def snapshot_mismatches(expected: dict[str, Any], actual: dict[str, Any]) -> list[dict[str, Any]]:
+    mismatches: list[dict[str, Any]] = []
+    for field in VALIDATED_SNAPSHOT_FIELDS:
+        expected_value = normalize_scalar(expected.get(field)) if field != "template_path" else normalize_path(expected.get(field))
+        actual_value = normalize_scalar(actual.get(field)) if field != "template_path" else normalize_path(actual.get(field))
+        if expected_value != actual_value:
+            mismatches.append({"field": field, "expected": expected_value, "actual": actual_value})
+
+    expected_duplicate = normalize_duplicate_summary(expected.get("duplicate_check_summary"))
+    actual_duplicate = normalize_duplicate_summary(actual.get("duplicate_check_summary"))
+    if json_fingerprint(expected_duplicate) != json_fingerprint(actual_duplicate):
+        mismatches.append(
+            {
+                "field": "duplicate_check_summary",
+                "expected": expected_duplicate,
+                "actual": actual_duplicate,
+            }
+        )
+    return mismatches
+
+
+def stop_status() -> dict[str, Any]:
+    return {
+        "status": "pass",
+        "applicable_stop_categories": APPLICABLE_STOP_CATEGORIES.copy(),
+        "covered_stop_categories": APPLICABLE_STOP_CATEGORIES.copy(),
+        "uncovered_stop_categories": [],
+        "not_applicable_stop_categories": [],
+        "local_stop_categories": LOCAL_STOP_CATEGORIES.copy(),
+    }

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Iterable
+
+from pr_create_contract import json_fingerprint, normalize_duplicate_summary
+
+
+PR_TITLE_RE = re.compile(
+    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)"
+    r"\([a-z0-9][a-z0-9-]*\): .+$"
+)
+GROUP_SAMPLE_LIMIT = 16
+GH_STUB_STATE_ENV = "GH_CREATE_PR_GH_STUB_STATE"
+DEFAULT_TEMPLATE_PATHS = [
+    ".github/pull_request_template.md",
+    "pull_request_template.md",
+    "docs/pull_request_template.md",
+]
+NAMED_TEMPLATE_GLOBS = [
+    ".github/PULL_REQUEST_TEMPLATE/*.md",
+    "PULL_REQUEST_TEMPLATE/*.md",
+    "docs/PULL_REQUEST_TEMPLATE/*.md",
+]
+ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
+
+
+def maybe_run_stubbed_gh(args: list[str]) -> str | None:
+    if not args or args[0] != "gh":
+        return None
+    state_path = os.environ.get(GH_STUB_STATE_ENV)
+    if not state_path:
+        return None
+    state = json.loads(Path(state_path).read_text(encoding="utf-8"))
+    command = args[1:]
+    if command[:2] == ["auth", "status"]:
+        return "Logged in to github.com\n"
+    if command[:2] == ["repo", "view"]:
+        default_branch = str(state.get("default_branch") or "main")
+        return json.dumps({"defaultBranchRef": {"name": default_branch}})
+    if command[:2] == ["pr", "list"]:
+        head = command[command.index("--head") + 1] if "--head" in command else ""
+        prs = [
+            dict(item)
+            for item in state.get("existing_prs", [])
+            if str(item.get("headRefName") or "") == head
+        ]
+        return json.dumps(prs)
+    if command[:2] == ["pr", "view"]:
+        target = None
+        if len(command) >= 3 and not command[2].startswith("-"):
+            target = command[2]
+        pool = [dict(item) for item in state.get("existing_prs", [])]
+        if target:
+            for item in pool:
+                if str(item.get("number")) == target or str(item.get("headRefName") or "") == target:
+                    return json.dumps(item)
+            raise subprocess.CalledProcessError(returncode=1, cmd=args, output="", stderr="PR not found")
+        if len(pool) == 1:
+            return json.dumps(pool[0])
+        raise subprocess.CalledProcessError(returncode=1, cmd=args, output="", stderr="PR not found")
+    if command[:2] == ["pr", "create"]:
+        title = command[command.index("--title") + 1]
+        body_file = Path(command[command.index("--body-file") + 1])
+        base = command[command.index("--base") + 1]
+        head = command[command.index("--head") + 1]
+        repo_slug = state.get("repo_slug") or "owner/repo"
+        number = int(state.get("next_pr_number") or 101)
+        reviewers = []
+        assignees = []
+        labels = []
+        milestone = None
+        maintainer_can_modify = "--no-maintainer-edit" not in command
+        draft = "--draft" in command
+        index = 0
+        while index < len(command):
+            token = command[index]
+            if token == "--reviewer":
+                reviewers.append(command[index + 1])
+                index += 2
+                continue
+            if token == "--assignee":
+                assignees.append(command[index + 1])
+                index += 2
+                continue
+            if token == "--label":
+                labels.append(command[index + 1])
+                index += 2
+                continue
+            if token == "--milestone":
+                milestone = command[index + 1]
+                index += 2
+                continue
+            index += 1
+        created = {
+            "number": number,
+            "title": title,
+            "body": body_file.read_text(encoding="utf-8").rstrip(),
+            "headRefName": head,
+            "baseRefName": base,
+            "url": f"https://example.invalid/{repo_slug}/pull/{number}",
+            "isDraft": draft,
+            "labels": [{"name": value} for value in sorted(dict.fromkeys(labels))],
+            "assignees": [{"login": value} for value in sorted({item.lower(): item.lower() for item in assignees}.values())],
+            "reviewRequests": [{"requestedReviewer": {"login": value}} for value in sorted({item.lower(): item.lower() for item in reviewers}.values())],
+            "milestone": ({"title": milestone} if milestone else None),
+            "maintainerCanModify": maintainer_can_modify,
+        }
+        state.setdefault("existing_prs", []).append(created)
+        state["next_pr_number"] = number + 1
+        Path(state_path).write_text(json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        return created["url"] + "\n"
+    raise subprocess.CalledProcessError(returncode=1, cmd=args, output="", stderr="unsupported stubbed gh command")
+
+
+def run_command(args: list[str], cwd: Path) -> str:
+    stubbed = maybe_run_stubbed_gh(args)
+    if stubbed is not None:
+        return stubbed
+    completed = subprocess.run(
+        args,
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return completed.stdout
+
+
+def run_git(args: list[str], cwd: Path) -> str:
+    return run_command(["git", *args], cwd=cwd)
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def infer_repo_slug(repo_root: Path) -> str | None:
+    try:
+        remote = run_git(["config", "--get", "remote.origin.url"], cwd=repo_root).strip()
+    except subprocess.CalledProcessError:
+        return None
+    if not remote:
+        return None
+    match = re.search(r"github\.com[:/](?P<slug>[^/]+/[^/]+?)(?:\.git)?$", remote)
+    return match.group("slug") if match else None
+
+
+def git_rev_parse(repo_root: Path, ref: str) -> str | None:
+    try:
+        return run_git(["rev-parse", ref], cwd=repo_root).strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def current_branch(repo_root: Path) -> str | None:
+    try:
+        branch = run_git(["branch", "--show-current"], cwd=repo_root).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return branch or None
+
+
+def branch_merge_base(repo_root: Path, branch: str | None) -> str | None:
+    if not branch:
+        return None
+    try:
+        value = run_git(["config", "--get", f"branch.{branch}.gh-merge-base"], cwd=repo_root).strip()
+    except subprocess.CalledProcessError:
+        return None
+    return value or None
+
+
+def default_branch_from_git(repo_root: Path) -> str | None:
+    candidates = [
+        ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        ["rev-parse", "--abbrev-ref", "origin/HEAD"],
+    ]
+    for args in candidates:
+        try:
+            value = run_git(args, cwd=repo_root).strip()
+        except subprocess.CalledProcessError:
+            continue
+        if "/" in value:
+            return value.split("/")[-1]
+        if value:
+            return value
+    return None
+
+
+def default_branch_from_gh(repo_root: Path, repo_slug: str | None) -> str | None:
+    args = ["gh", "repo", "view", "--json", "defaultBranchRef"]
+    if repo_slug:
+        args.extend(["--repo", repo_slug])
+    try:
+        payload = json.loads(run_command(args, cwd=repo_root))
+    except Exception:
+        return None
+    branch = payload.get("defaultBranchRef") or {}
+    return str(branch.get("name") or "").strip() or None
+
+
+def resolve_base_ref(repo_root: Path, repo_slug: str | None, branch: str | None, explicit_base: str | None) -> str | None:
+    if explicit_base and explicit_base.strip():
+        return explicit_base.strip()
+    merge_base = branch_merge_base(repo_root, branch)
+    if merge_base:
+        return merge_base
+    git_default = default_branch_from_git(repo_root)
+    if git_default:
+        return git_default
+    return default_branch_from_gh(repo_root, repo_slug)
+
+
+def local_head_oid(repo_root: Path, head_ref: str | None) -> str | None:
+    if not head_ref:
+        return None
+    return git_rev_parse(repo_root, head_ref)
+
+
+def remote_head_oid(repo_root: Path, head_ref: str | None) -> str | None:
+    if not head_ref:
+        return None
+    for ref in (f"refs/remotes/origin/{head_ref}", f"origin/{head_ref}"):
+        value = git_rev_parse(repo_root, ref)
+        if value:
+            return value
+    return None
+
+
+def git_revision_candidates(base_ref: str | None, head_ref: str | None) -> list[str]:
+    if not base_ref or not head_ref:
+        return []
+    return [
+        f"origin/{base_ref}..origin/{head_ref}",
+        f"origin/{base_ref}..{head_ref}",
+        f"{base_ref}..origin/{head_ref}",
+        f"{base_ref}..{head_ref}",
+    ]
+
+
+def load_changed_files_between(repo_root: Path, base_ref: str | None, head_ref: str | None) -> list[str]:
+    for revision_range in git_revision_candidates(base_ref, head_ref):
+        try:
+            output = run_git(["diff", "--name-only", revision_range], cwd=repo_root)
+        except subprocess.CalledProcessError:
+            continue
+        return [normalize_path(line.strip()) for line in output.splitlines() if line.strip()]
+    return []
+
+
+def load_diff_stat_between(repo_root: Path, base_ref: str | None, head_ref: str | None) -> str | None:
+    for revision_range in git_revision_candidates(base_ref, head_ref):
+        try:
+            output = run_git(["diff", "--stat", revision_range], cwd=repo_root).strip()
+        except subprocess.CalledProcessError:
+            continue
+        if output:
+            return output
+    return None
+
+
+def load_commit_subjects(repo_root: Path, base_ref: str | None, head_ref: str | None, *, limit: int = 12) -> list[str]:
+    for revision_range in git_revision_candidates(base_ref, head_ref):
+        try:
+            output = run_git(["log", "--format=%s", f"-n{limit}", revision_range], cwd=repo_root)
+        except subprocess.CalledProcessError:
+            continue
+        subjects = [line.strip() for line in output.splitlines() if line.strip()]
+        if subjects:
+            return subjects
+    return []
+
+
+def parse_markdown_headings(markdown_text: str | None) -> list[str]:
+    if not markdown_text:
+        return []
+    headings: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            headings.append(line[3:].strip())
+    return headings
+
+
+def classify_changed_files(paths: Iterable[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {
+        "runtime": [],
+        "automation": [],
+        "docs": [],
+        "tests": [],
+        "config": [],
+        "other": [],
+    }
+    for path in paths:
+        normalized = normalize_path(path)
+        lower = normalized.lower()
+        if (
+            "/tests/" in lower
+            or lower.startswith("tests/")
+            or lower.endswith("_test.py")
+            or lower.endswith(".tests.cs")
+            or lower.startswith(".github/scripts/tests/")
+        ):
+            groups["tests"].append(normalized)
+            continue
+        if (
+            lower.startswith(".github/workflows/")
+            or lower.startswith(".github/scripts/")
+            or lower.startswith(".github/issue_template/")
+            or lower.startswith(".github/instructions/")
+        ):
+            groups["automation"].append(normalized)
+        elif lower.endswith(".md"):
+            groups["docs"].append(normalized)
+        elif (
+            lower.endswith(".yml")
+            or lower.endswith(".yaml")
+            or lower.endswith(".toml")
+            or lower.endswith(".json")
+            or lower.endswith(".csproj")
+            or lower.endswith(".props")
+            or lower.endswith(".targets")
+        ):
+            groups["config"].append(normalized)
+        elif lower.endswith(".cs") or lower.endswith(".dll") or lower.endswith(".py") or lower.endswith(".ts"):
+            groups["runtime"].append(normalized)
+        else:
+            groups["other"].append(normalized)
+    return groups
+
+
+def sample_parent(path: str) -> str:
+    normalized = normalize_path(path)
+    return normalized.rsplit("/", 1)[0] if "/" in normalized else "."
+
+
+def select_representative_files(paths: Iterable[str], limit: int = GROUP_SAMPLE_LIMIT) -> list[str]:
+    ordered_paths: list[str] = []
+    for path in paths:
+        normalized = normalize_path(path)
+        if normalized not in ordered_paths:
+            ordered_paths.append(normalized)
+    if len(ordered_paths) <= limit:
+        return ordered_paths
+
+    bucket_order: list[str] = []
+    buckets: dict[str, list[str]] = {}
+    for path in ordered_paths:
+        parent = sample_parent(path)
+        if parent not in buckets:
+            buckets[parent] = []
+            bucket_order.append(parent)
+        buckets[parent].append(path)
+
+    selected: list[str] = []
+    while len(selected) < limit:
+        progressed = False
+        for parent in bucket_order:
+            bucket = buckets[parent]
+            if not bucket:
+                continue
+            selected.append(bucket.pop(0))
+            progressed = True
+            if len(selected) >= limit:
+                break
+        if not progressed:
+            break
+
+    original_index = {path: index for index, path in enumerate(ordered_paths)}
+    return sorted(selected, key=original_index.__getitem__)
+
+
+def summarize_groups(groups: dict[str, list[str]]) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    for name, paths in groups.items():
+        sample_files = select_representative_files(paths)
+        result[name] = {
+            "count": len(paths),
+            "sample_files": sample_files,
+            "omitted_file_count": max(len(paths) - len(sample_files), 0),
+            "sample_strategy": "directory_round_robin",
+        }
+    return result
+
+
+def extract_issue_numbers(text: str | None) -> list[str]:
+    if not text:
+        return []
+    seen: list[str] = []
+    for match in ISSUE_REF_PATTERN.finditer(text):
+        number = match.group("number")
+        if number not in seen:
+            seen.append(number)
+    return seen
+
+
+def select_pr_template(repo_root: Path) -> dict[str, Any]:
+    default_candidates = [normalize_path(str(repo_root / path)) for path in DEFAULT_TEMPLATE_PATHS if (repo_root / path).is_file()]
+    named_candidates: list[str] = []
+    for pattern in NAMED_TEMPLATE_GLOBS:
+        named_candidates.extend(
+            normalize_path(str(path))
+            for path in sorted(repo_root.glob(pattern))
+            if path.is_file()
+        )
+    all_candidates = sorted(dict.fromkeys(default_candidates + named_candidates))
+    selected_path: str | None = None
+    status = "not_found"
+    if len(default_candidates) == 1 and not named_candidates:
+        selected_path = default_candidates[0]
+        status = "selected"
+    elif all_candidates:
+        status = "ambiguous"
+    sections = parse_markdown_headings(read_text_if_exists(Path(selected_path)) if selected_path else None)
+    fingerprint = json_fingerprint(read_text_if_exists(Path(selected_path)) or "") if selected_path else ""
+    return {
+        "status": status,
+        "selected_path": selected_path,
+        "default_candidates": default_candidates,
+        "named_template_candidates": named_candidates,
+        "all_candidates": all_candidates,
+        "sections": sections,
+        "fingerprint": fingerprint,
+    }
+
+
+def template_file_paths(repo_root: Path, template_selection: dict[str, Any]) -> dict[str, str]:
+    files = {
+        "pull_request_instructions": ".github/instructions/pull-request.instructions.md",
+        "commit_message_instructions": ".github/instructions/commit-message.instructions.md",
+        "contributing": "CONTRIBUTING.md",
+        "maintaining": "MAINTAINING.md",
+    }
+    result: dict[str, str] = {}
+    selected_template = template_selection.get("selected_path")
+    if selected_template:
+        result["pull_request_template"] = normalize_path(selected_template)
+    for key, rel_path in files.items():
+        path = repo_root / rel_path
+        if path.exists():
+            result[key] = normalize_path(str(path))
+    return result
+
+
+def first_heading_block(markdown_text: str | None, heading: str) -> str | None:
+    if not markdown_text:
+        return None
+    lines = markdown_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == heading:
+            start = index
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def load_open_prs_for_head(repo_root: Path, repo_slug: str | None, head_ref: str) -> list[dict[str, Any]]:
+    args = [
+        "gh",
+        "pr",
+        "list",
+        "--head",
+        head_ref,
+        "--state",
+        "open",
+        "--json",
+        "number,url,headRefName,baseRefName,title,body,isDraft,labels,assignees,reviewRequests,milestone,maintainerCanModify",
+    ]
+    if repo_slug:
+        args.extend(["--repo", repo_slug])
+    payload = json.loads(run_command(args, cwd=repo_root))
+    if not isinstance(payload, list):
+        raise RuntimeError("gh pr list did not return a JSON array")
+    return [dict(item) for item in payload if isinstance(item, dict)]
+
+
+def duplicate_check_summary(repo_root: Path, repo_slug: str | None, head_ref: str) -> dict[str, Any]:
+    matches = load_open_prs_for_head(repo_root, repo_slug, head_ref)
+    if not matches:
+        return normalize_duplicate_summary(
+            {
+                "status": "clear",
+                "matched_repo_slug": repo_slug,
+                "matched_head": head_ref,
+                "existing_pr_count": 0,
+            }
+        )
+    first = matches[0]
+    return normalize_duplicate_summary(
+        {
+            "status": "existing-open-pr",
+            "matched_repo_slug": repo_slug,
+            "matched_head": head_ref,
+            "existing_pr_number": first.get("number"),
+            "existing_pr_url": first.get("url"),
+            "existing_pr_count": len(matches),
+        }
+    )
+
+
+def build_context(
+    *,
+    repo_root: Path,
+    repo_slug: str | None = None,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+    reviewers: list[str] | None = None,
+    assignees: list[str] | None = None,
+    labels: list[str] | None = None,
+    milestone: str | None = None,
+    draft: bool = False,
+    no_maintainer_edit: bool = False,
+) -> dict[str, Any]:
+    resolved_repo_slug = repo_slug or infer_repo_slug(repo_root)
+    branch = current_branch(repo_root)
+    resolved_head = (head_ref or branch or "").strip() or None
+    resolved_base = resolve_base_ref(repo_root, resolved_repo_slug, branch, base_ref)
+    local_oid = local_head_oid(repo_root, resolved_head)
+    remote_oid = remote_head_oid(repo_root, resolved_head)
+    changed_files = load_changed_files_between(repo_root, resolved_base, resolved_head)
+    groups = classify_changed_files(changed_files)
+    diff_stat = load_diff_stat_between(repo_root, resolved_base, resolved_head)
+    commit_subjects = load_commit_subjects(repo_root, resolved_base, resolved_head)
+    template_selection = select_pr_template(repo_root)
+    rule_paths = template_file_paths(repo_root, template_selection)
+
+    template_text = read_text_if_exists(Path(template_selection["selected_path"])) if template_selection.get("selected_path") else None
+    instructions_text = read_text_if_exists(repo_root / ".github/instructions/pull-request.instructions.md")
+    commit_instructions_text = read_text_if_exists(repo_root / ".github/instructions/commit-message.instructions.md")
+    issue_hints = sorted(
+        {
+            *extract_issue_numbers(resolved_head),
+            *extract_issue_numbers(" ".join(commit_subjects)),
+        }
+    )
+
+    try:
+        duplicate_hint = (
+            duplicate_check_summary(repo_root, resolved_repo_slug, resolved_head)
+            if resolved_repo_slug and resolved_head
+            else normalize_duplicate_summary({"status": "repo-or-head-missing", "matched_repo_slug": resolved_repo_slug, "matched_head": resolved_head})
+        )
+    except Exception as exc:
+        duplicate_hint = normalize_duplicate_summary(
+            {
+                "status": "unavailable",
+                "matched_repo_slug": resolved_repo_slug,
+                "matched_head": resolved_head,
+                "existing_pr_count": 0,
+                "error": str(exc),
+            }
+        )
+
+    return {
+        "skill_name": "gh-create-pr",
+        "repo_root": str(repo_root),
+        "repo_slug": resolved_repo_slug,
+        "current_branch": branch,
+        "resolved_head": resolved_head,
+        "resolved_base": resolved_base,
+        "local_head_oid": local_oid,
+        "remote_head_oid": remote_oid,
+        "changed_files": changed_files,
+        "changed_files_fingerprint": json_fingerprint(changed_files),
+        "changed_file_groups": summarize_groups(groups),
+        "diff_stat": diff_stat,
+        "recent_commit_subjects": commit_subjects,
+        "rule_files": rule_paths,
+        "template_selection": template_selection,
+        "expected_template_sections": list(template_selection.get("sections") or []),
+        "instruction_snippets": {
+            "pull_request_title_rules_excerpt": first_heading_block(instructions_text, "## PR Title"),
+            "pull_request_template_sections": parse_markdown_headings(template_text),
+            "commit_types_excerpt": first_heading_block(commit_instructions_text, "## Types"),
+        },
+        "issue_reference_hints": {
+            "numbers": issue_hints,
+            "branch": resolved_head,
+            "commit_subjects": commit_subjects,
+        },
+        "testing_signal_candidates": {
+            "exact_commands": [],
+            "supports_positive_testing_claims": False,
+            "test_files_changed": int((summarize_groups(groups).get("tests") or {}).get("count", 0)) > 0,
+        },
+        "duplicate_check_hint": duplicate_hint,
+        "create_options": {
+            "reviewers": list(reviewers or []),
+            "assignees": list(assignees or []),
+            "labels": list(labels or []),
+            "milestone": milestone,
+            "draft": bool(draft),
+            "no_maintainer_edit": bool(no_maintainer_edit),
+        },
+        "checks": {
+            "repo_slug_resolved": bool(resolved_repo_slug),
+            "base_resolved": bool(resolved_base),
+            "remote_head_exists": bool(remote_oid),
+            "local_remote_match": bool(local_oid and remote_oid and local_oid == remote_oid),
+            "template_selected": template_selection.get("status") == "selected",
+            "duplicate_hint_status": duplicate_hint.get("status"),
+        },
+        "counts": {
+            "changed_files": len(changed_files),
+            "task_packet_count": 4,
+            "active_areas": sum(1 for value in summarize_groups(groups).values() if value.get("count", 0)),
+        },
+    }

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Smoke-test gh-create-pr with a temp repository and mocked gh."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+PR_BODY = "\n".join(
+    [
+        "## Why",
+        "Open a guarded PR from a pushed branch.",
+        "## What changed",
+        "- Added a validator-normalized `gh pr create` path.",
+        "- Re-check duplicate PR and template state before create.",
+        "## How",
+        "- Kept creation fail-closed on stale head/template snapshots.",
+        "## Risk / Rollback",
+        "- Re-run validation after refreshing the branch state.",
+        "## Testing",
+        "- Not run (synthetic smoke).",
+        "Refs: #42",
+    ]
+)
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def run_python(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        details = "\n".join(part for part in (result.stderr.strip(), result.stdout.strip()) if part)
+        raise RuntimeError(details or f"python {' '.join(args)} failed")
+    return result
+
+
+def run_git(repo_root: Path, args: list[str]) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def init_repo(repo_root: Path, origin_root: Path) -> None:
+    origin_root.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["git", "init", "--bare", str(origin_root)],
+        cwd=str(origin_root.parent),
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git init --bare failed")
+    run_git(repo_root, ["init", "-b", "main"])
+    run_git(repo_root, ["config", "user.name", "Smoke Test"])
+    run_git(repo_root, ["config", "user.email", "smoke@example.invalid"])
+    run_git(repo_root, ["remote", "add", "origin", str(origin_root)])
+
+    write_text(
+        repo_root / ".github" / "pull_request_template.md",
+        "\n".join(
+            [
+                "## Why",
+                "",
+                "## What changed",
+                "",
+                "## How",
+                "",
+                "## Risk / Rollback",
+                "",
+                "## Testing",
+                "",
+            ]
+        )
+        + "\n",
+    )
+    write_text(
+        repo_root / ".github" / "instructions" / "pull-request.instructions.md",
+        "\n".join(
+            [
+                "# PR Rules",
+                "",
+                "## PR Title",
+                "Use Conventional Commit style.",
+                "",
+                "## PR Body",
+                "Keep the PR body concise and evidence-backed.",
+            ]
+        )
+        + "\n",
+    )
+    write_text(
+        repo_root / ".github" / "instructions" / "commit-message.instructions.md",
+        "\n".join(
+            [
+                "# Commit Message Rules",
+                "",
+                "## Types",
+                "- feat",
+                "- fix",
+                "- docs",
+            ]
+        )
+        + "\n",
+    )
+    write_text(repo_root / "README.md", "# README\n")
+    write_text(repo_root / "src" / "creator.py", "VALUE = 1\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "Initial smoke fixture"])
+    run_git(repo_root, ["push", "-u", "origin", "main"])
+
+    run_git(repo_root, ["checkout", "-b", "feature/pr-create-guard"])
+    run_git(repo_root, ["config", "branch.feature/pr-create-guard.gh-merge-base", "main"])
+    write_text(repo_root / "src" / "creator.py", "VALUE = 2\n")
+    write_text(repo_root / "tests" / "test_creator.py", "def test_smoke_fixture():\n    assert True\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "feat(pr-create): add guarded creator #42"])
+    run_git(repo_root, ["push", "-u", "origin", "feature/pr-create-guard"])
+
+
+def install_gh_stub(target_dir: Path, repo_slug: str) -> Path:
+    state_path = target_dir / "gh_state.json"
+    write_json(
+        state_path,
+        {
+            "repo_slug": repo_slug,
+            "default_branch": "main",
+            "existing_prs": [],
+            "next_pr_number": 7,
+        },
+    )
+    return state_path
+
+
+def main() -> int:
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "gh-create-pr"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-") as tmp_dir_name:
+        tmp_dir = Path(tmp_dir_name)
+        repo_root = tmp_dir / "repo"
+        origin_root = tmp_dir / "origin.git"
+        repo_root.mkdir()
+        init_repo(repo_root, origin_root)
+
+        state_path = install_gh_stub(repo_root, "owner/repo")
+
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env["GH_CREATE_PR_GH_STUB_STATE"] = str(state_path)
+
+        context_path = tmp_dir / "context.json"
+        lint_path = tmp_dir / "lint.json"
+        build_result_path = tmp_dir / "build-result.json"
+        validation_path = tmp_dir / "validation.json"
+        dry_run_path = tmp_dir / "dry-run.json"
+        apply_result_path = tmp_dir / "apply.json"
+        body_path = tmp_dir / "body.md"
+        packet_dir = tmp_dir / "packets"
+
+        body_path.write_text(PR_BODY + "\n", encoding="utf-8")
+
+        run_python(
+            [
+                str(SCRIPT_DIR / "collect_pr_create_context.py"),
+                "--repo-root",
+                str(repo_root),
+                "--repo",
+                "owner/repo",
+                "--draft",
+                "--reviewer",
+                "alice",
+                "--assignee",
+                "bob",
+                "--label",
+                "automation",
+                "--output",
+                str(context_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "lint_pr_create.py"),
+                "--context",
+                str(context_path),
+                "--output",
+                str(lint_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "build_pr_create_packets.py"),
+                "--context",
+                str(context_path),
+                "--lint",
+                str(lint_path),
+                "--output-dir",
+                str(packet_dir),
+                "--result-output",
+                str(build_result_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "validate_pr_create.py"),
+                "--context",
+                str(context_path),
+                "--title",
+                "feat(pr-create): create guarded PRs",
+                "--body-file",
+                str(body_path),
+                "--output",
+                str(validation_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "apply_pr_create.py"),
+                "--validation",
+                str(validation_path),
+                "--dry-run",
+                "--result-output",
+                str(dry_run_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "apply_pr_create.py"),
+                "--validation",
+                str(validation_path),
+                "--result-output",
+                str(apply_result_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+
+        validation = read_json(validation_path)
+        dry_run = read_json(dry_run_path)
+        apply_result = read_json(apply_result_path)
+        state = read_json(state_path)
+        created = state["existing_prs"][0]
+        summary = {
+            "validation_valid": validation["valid"],
+            "dry_run_apply_succeeded": dry_run["apply_succeeded"],
+            "apply_succeeded": apply_result["apply_succeeded"],
+            "created_pr_url": created["url"],
+            "created_pr_number": created["number"],
+            "packet_metrics_path": str(packet_dir / "packet_metrics.json"),
+        }
+        print(json.dumps(summary, indent=2, ensure_ascii=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/validate_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/validate_pr_create.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Validate a candidate PR create request before guarded apply."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import lint_pr_create as lint_pr_create
+import pr_create_contract as contract
+import pr_create_tools as tools
+
+
+VALIDATION_ERROR_CODES = contract.VALIDATION_ERROR_CODES
+VALIDATION_WARNING_CODES = contract.VALIDATION_WARNING_CODES
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Path to JSON from collect_pr_create_context.py")
+    parser.add_argument("--title", required=True, help="Draft PR title")
+    parser.add_argument("--body-file", required=True, help="Path to draft PR body markdown")
+    parser.add_argument("--output", help="Optional output path for validation JSON")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return contract.load_json(path)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    contract.write_json(path, payload)
+
+
+def normalize_scalar(value: Any) -> str:
+    return contract.normalize_scalar(value)
+
+
+def push_issue(
+    bucket: list[str],
+    details: list[dict[str, Any]],
+    *,
+    code: str,
+    message: str,
+    field: str | None = None,
+    stop_category: str | None = None,
+) -> None:
+    bucket.append(message)
+    detail: dict[str, Any] = {"code": code, "message": message}
+    if field is not None:
+        detail["field"] = field
+    if stop_category is not None:
+        detail["stop_category"] = stop_category
+    details.append(detail)
+
+
+def normalize_handles(values: list[Any]) -> list[str]:
+    tokens: dict[str, str] = {}
+    for value in values:
+        for piece in str(value or "").split(","):
+            token = piece.strip().lower()
+            if token and token not in tokens:
+                tokens[token] = token
+    return sorted(tokens.values())
+
+
+def normalize_labels(values: list[Any]) -> list[str]:
+    tokens: dict[str, str] = {}
+    for value in values:
+        for piece in str(value or "").split(","):
+            token = piece.strip()
+            if token and token not in tokens:
+                tokens[token] = token
+    return sorted(tokens.values())
+
+
+def normalize_milestone(value: Any) -> str | None:
+    milestone = normalize_scalar(value)
+    return milestone or None
+
+
+def validate_context_contract(context: dict[str, Any]) -> list[tuple[str, str]]:
+    errors: list[tuple[str, str]] = []
+    if not normalize_scalar(context.get("repo_root")):
+        errors.append(("validator_mismatch", "Context is missing `repo_root`."))
+    if not normalize_scalar(context.get("resolved_head")):
+        errors.append(("validator_mismatch", "Context is missing `resolved_head`."))
+    if not normalize_scalar(context.get("repo_slug")):
+        errors.append(("repo_inference_failed", "Context could not resolve `repo_slug`."))
+    if not normalize_scalar(context.get("resolved_base")):
+        errors.append(("base_resolution_failed", "Context could not resolve `resolved_base`."))
+    template_selection = context.get("template_selection")
+    if not isinstance(template_selection, dict):
+        errors.append(("validator_mismatch", "Context is missing `template_selection`."))
+    if not isinstance(context.get("changed_files"), list):
+        errors.append(("validator_mismatch", "Context is missing `changed_files`."))
+    return errors
+
+
+def infer_review_mode(context: dict[str, Any]) -> str:
+    groups = context.get("changed_file_groups") or {}
+    active = [
+        name
+        for name in ("runtime", "automation", "docs", "tests", "config", "other")
+        if (groups.get(name) or {}).get("count", 0) > 0
+    ]
+    file_count = len(list(context.get("changed_files") or []))
+    if file_count <= contract.SMALL_FILE_LIMIT and len(active) <= contract.SMALL_GROUP_LIMIT:
+        return "local-only"
+    if file_count > contract.MEDIUM_FILE_LIMIT or len(active) >= contract.LARGE_GROUP_LIMIT:
+        return "broad-delegation"
+    return "targeted-delegation"
+
+
+def context_snapshot_subset(context: dict[str, Any]) -> dict[str, Any]:
+    template_selection = context.get("template_selection") or {}
+    return {
+        "local_head_oid": normalize_scalar(context.get("local_head_oid")),
+        "remote_head_oid": normalize_scalar(context.get("remote_head_oid")),
+        "repo_slug": normalize_scalar(context.get("repo_slug")),
+        "base_ref": normalize_scalar(context.get("resolved_base")),
+        "head_ref": normalize_scalar(context.get("resolved_head")),
+        "changed_files_fingerprint": normalize_scalar(context.get("changed_files_fingerprint")),
+        "template_path": normalize_scalar(template_selection.get("selected_path")).replace("\\", "/"),
+        "template_fingerprint": normalize_scalar(template_selection.get("fingerprint")),
+    }
+
+
+def live_state(context: dict[str, Any]) -> dict[str, Any]:
+    repo_root = Path(str(context.get("repo_root") or ".")).resolve()
+    repo_slug = normalize_scalar(context.get("repo_slug")) or None
+    head_ref = normalize_scalar(context.get("resolved_head"))
+    base_ref = normalize_scalar(context.get("resolved_base"))
+    template_selection = tools.select_pr_template(repo_root)
+    duplicate_summary = tools.duplicate_check_summary(repo_root, repo_slug, head_ref) if repo_slug and head_ref else {}
+    changed_files = tools.load_changed_files_between(repo_root, base_ref, head_ref)
+    return {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "head_ref": head_ref,
+        "base_ref": base_ref,
+        "local_head_oid": tools.local_head_oid(repo_root, head_ref),
+        "remote_head_oid": tools.remote_head_oid(repo_root, head_ref),
+        "changed_files": changed_files,
+        "changed_files_fingerprint": contract.json_fingerprint(changed_files),
+        "template_selection": template_selection,
+        "duplicate_check_summary": duplicate_summary,
+    }
+
+
+def subset_mismatches(expected: dict[str, Any], actual: dict[str, Any]) -> list[dict[str, Any]]:
+    mismatches: list[dict[str, Any]] = []
+    for field in contract.VALIDATED_SNAPSHOT_FIELDS:
+        if field == "duplicate_check_summary":
+            continue
+        expected_value = normalize_scalar(expected.get(field))
+        actual_value = normalize_scalar(actual.get(field))
+        if field == "template_path":
+            expected_value = expected_value.replace("\\", "/")
+            actual_value = actual_value.replace("\\", "/")
+        if expected_value != actual_value:
+            mismatches.append({"field": field, "expected": expected_value, "actual": actual_value})
+    return mismatches
+
+
+def validate_pr_create(context: dict[str, Any], title: str, body: str) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[dict[str, Any]] = []
+    warning_details: list[dict[str, Any]] = []
+    stop_reasons: list[str] = []
+    stale_fields: list[dict[str, Any]] = []
+
+    for stop_category, message in validate_context_contract(context):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["missing_context_field"],
+            message=message,
+            stop_category=stop_category,
+        )
+
+    if not title.strip():
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["missing_candidate_field"],
+            message="Candidate title is empty.",
+            field="title",
+            stop_category="invalid_title",
+        )
+    if not body.strip():
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["missing_candidate_field"],
+            message="Candidate body is empty.",
+            field="body",
+            stop_category="invalid_body",
+        )
+
+    template_selection = context.get("template_selection") or {}
+    template_status = normalize_scalar(template_selection.get("status"))
+    if template_status == "not_found":
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["template_not_found"],
+            message="No unique default PR template was found.",
+            stop_category="template_not_found",
+        )
+    elif template_status == "ambiguous":
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["template_ambiguous"],
+            message="Multiple PR template candidates were found; fail closed.",
+            stop_category="template_ambiguous",
+        )
+    if not normalize_scalar(context.get("remote_head_oid")):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["remote_head_missing"],
+            message="Resolved head branch does not exist on origin.",
+            stop_category="remote_head_missing",
+        )
+    elif normalize_scalar(context.get("local_head_oid")) != normalize_scalar(context.get("remote_head_oid")):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["head_oid_mismatch"],
+            message="Local and remote head OIDs differ.",
+            stop_category="head_oid_mismatch",
+        )
+
+    candidate_findings: dict[str, Any] = {"errors": [], "warnings": [], "info": [], "detected": {}}
+    if not errors:
+        candidate_findings = lint_pr_create.collect_candidate_findings(context, title.strip(), body)
+        for message in candidate_findings.get("warnings", []):
+            push_issue(
+                warnings,
+                warning_details,
+                code=VALIDATION_WARNING_CODES["candidate_warning"],
+                message=message,
+            )
+        detected = candidate_findings.get("detected", {})
+        for message in detected.get("title_errors", []):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["invalid_title"],
+                message=message,
+                stop_category="invalid_title",
+            )
+        for message in detected.get("body_errors", []):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["invalid_body"],
+                message=message,
+                stop_category="invalid_body",
+            )
+        for message in detected.get("unsupported_claims", []):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["unsupported_claim"],
+                message=message,
+                stop_category="unsupported_claim",
+            )
+
+    repo_root = Path(str(context.get("repo_root") or ".")).resolve()
+    repo_slug = normalize_scalar(context.get("repo_slug")) or None
+    head_ref = normalize_scalar(context.get("resolved_head"))
+    base_ref = normalize_scalar(context.get("resolved_base"))
+    validation_commands = [
+        "candidate lint",
+        "gh auth status",
+        f"git rev-parse {head_ref}",
+        f"git rev-parse refs/remotes/origin/{head_ref}",
+        f"git diff --name-only origin/{base_ref}..origin/{head_ref}",
+        "template selection recheck",
+        f"gh pr list --head {head_ref} --state open",
+    ]
+
+    fresh_state: dict[str, Any] | None = None
+    if not errors:
+        try:
+            tools.run_command(["gh", "auth", "status"], cwd=repo_root)
+        except Exception as exc:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_auth"],
+                message=str(exc),
+                stop_category="missing_auth",
+            )
+
+    if not errors:
+        try:
+            fresh_state = live_state(context)
+        except Exception as exc:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["live_snapshot_unavailable"],
+                message=str(exc),
+                stop_category="live_snapshot_unavailable",
+            )
+
+    if not errors and fresh_state is not None:
+        fresh_template = fresh_state.get("template_selection") or {}
+        fresh_template_status = normalize_scalar(fresh_template.get("status"))
+        if fresh_template_status == "not_found":
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["template_not_found"],
+                message="No unique default PR template was found during validation recheck.",
+                stop_category="template_not_found",
+            )
+        elif fresh_template_status == "ambiguous":
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["template_ambiguous"],
+                message="Multiple PR template candidates were found during validation recheck.",
+                stop_category="template_ambiguous",
+            )
+
+    if not errors and fresh_state is not None:
+        if not normalize_scalar(fresh_state.get("remote_head_oid")):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["remote_head_missing"],
+                message="Resolved head branch is missing on origin during validation recheck.",
+                stop_category="remote_head_missing",
+            )
+        elif normalize_scalar(fresh_state.get("local_head_oid")) != normalize_scalar(fresh_state.get("remote_head_oid")):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["head_oid_mismatch"],
+                message="Local and remote head OIDs differ during validation recheck.",
+                stop_category="head_oid_mismatch",
+            )
+
+    if not errors and fresh_state is not None:
+        duplicate_summary = fresh_state.get("duplicate_check_summary") or {}
+        if not contract.duplicate_summary_is_clear(duplicate_summary):
+            existing_url = duplicate_summary.get("existing_pr_url")
+            message = "A same-head open PR already exists."
+            if existing_url:
+                message += f" Existing PR: {existing_url}"
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["existing_open_pr"],
+                message=message,
+                stop_category="existing_open_pr",
+            )
+
+    if not errors and fresh_state is not None:
+        stale_fields = subset_mismatches(context_snapshot_subset(context), {
+            "local_head_oid": fresh_state.get("local_head_oid"),
+            "remote_head_oid": fresh_state.get("remote_head_oid"),
+            "repo_slug": fresh_state.get("repo_slug"),
+            "base_ref": fresh_state.get("base_ref"),
+            "head_ref": fresh_state.get("head_ref"),
+            "changed_files_fingerprint": fresh_state.get("changed_files_fingerprint"),
+            "template_path": (fresh_state.get("template_selection") or {}).get("selected_path"),
+            "template_fingerprint": (fresh_state.get("template_selection") or {}).get("fingerprint"),
+        })
+        if stale_fields:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["stale_snapshot"],
+                message="Collected context no longer matches the current branch/template snapshot.",
+                stop_category="stale_snapshot",
+            )
+
+    for detail in error_details:
+        category = detail.get("stop_category")
+        if isinstance(category, str) and category not in stop_reasons:
+            stop_reasons.append(category)
+
+    reviewers = normalize_handles(list((context.get("create_options") or {}).get("reviewers") or []))
+    assignees = normalize_handles(list((context.get("create_options") or {}).get("assignees") or []))
+    labels = normalize_labels(list((context.get("create_options") or {}).get("labels") or []))
+    milestone = normalize_milestone((context.get("create_options") or {}).get("milestone"))
+    draft = bool((context.get("create_options") or {}).get("draft"))
+    maintainer_can_modify = not bool((context.get("create_options") or {}).get("no_maintainer_edit"))
+
+    normalized_create_request = {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "base": base_ref,
+        "head": head_ref,
+        "title": title.strip(),
+        "body": body.rstrip(),
+        "draft": draft,
+        "reviewers": reviewers,
+        "assignees": assignees,
+        "labels": labels,
+        "milestone": milestone,
+        "maintainer_can_modify": maintainer_can_modify,
+        "validation_commands": validation_commands,
+        "review_mode": infer_review_mode(context),
+        "qa_gate": {
+            "required": False,
+            "reason": None,
+            "qa_clear": False,
+        },
+        "validated_snapshot": contract.build_validated_snapshot(
+            {
+                **context,
+                "repo_slug": fresh_state.get("repo_slug") if fresh_state else context.get("repo_slug"),
+                "resolved_base": fresh_state.get("base_ref") if fresh_state else context.get("resolved_base"),
+                "resolved_head": fresh_state.get("head_ref") if fresh_state else context.get("resolved_head"),
+                "local_head_oid": fresh_state.get("local_head_oid") if fresh_state else context.get("local_head_oid"),
+                "remote_head_oid": fresh_state.get("remote_head_oid") if fresh_state else context.get("remote_head_oid"),
+                "changed_files_fingerprint": fresh_state.get("changed_files_fingerprint") if fresh_state else context.get("changed_files_fingerprint"),
+                "template_selection": fresh_state.get("template_selection") if fresh_state else context.get("template_selection"),
+            },
+            fresh_state.get("duplicate_check_summary") if fresh_state else {},
+        ),
+    }
+    gate = contract.stop_status()
+    can_apply = not errors and not gate["uncovered_stop_categories"]
+    gate["status"] = "pass" if can_apply else "fail"
+    return {
+        "valid": not errors,
+        "can_apply": can_apply,
+        "errors": errors,
+        "warnings": warnings,
+        "error_details": error_details,
+        "warning_details": warning_details,
+        "stop_reasons": stop_reasons,
+        "candidate_findings": candidate_findings,
+        "validation_commands": validation_commands,
+        "stale_fields": stale_fields,
+        "review_mode": infer_review_mode(context),
+        "normalized_create_request": normalized_create_request,
+        "normalized_create_request_fingerprint": contract.json_fingerprint(normalized_create_request),
+        "context_file_fingerprint": contract.json_fingerprint(context),
+        "apply_gate_status": gate,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    body = Path(args.body_file).resolve().read_text(encoding="utf-8")
+    payload = validate_pr_create(context, args.title, body)
+    if args.output:
+        write_json(Path(args.output).resolve(), payload)
+    else:
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if payload.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/write_evaluation_log.py
@@ -1,0 +1,1011 @@
+﻿#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-create-pr":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        packet_metrics = result.get("packet_metrics")
+        if isinstance(packet_metrics, dict):
+            skill_specific = log.setdefault(
+                "skill_specific",
+                {"schema_name": log.get("skill", {}).get("name"), "schema_version": "1.0", "data": {}},
+            )
+            data = skill_specific.setdefault("data", {})
+            data["packet_metrics"] = packet_metrics
+            baseline = log.setdefault("baseline", {})
+            estimated_local_only_tokens = safe_int(
+                packet_metrics.get("estimated_local_only_tokens")
+            )
+            estimated_packet_tokens = safe_int(
+                packet_metrics.get("estimated_packet_tokens")
+            )
+            estimated_delegation_savings = safe_int(
+                packet_metrics.get("estimated_delegation_savings")
+            )
+            if estimated_local_only_tokens is not None:
+                baseline["estimated_local_only_tokens"] = estimated_local_only_tokens
+            if (
+                estimated_local_only_tokens is not None
+                and estimated_packet_tokens is not None
+            ):
+                baseline["estimated_token_savings"] = max(
+                    0, estimated_local_only_tokens - estimated_packet_tokens
+                )
+            if estimated_delegation_savings is not None:
+                baseline["estimated_delegation_savings"] = estimated_delegation_savings
+            baseline["method"] = "heuristic_local_only"
+            baseline["confidence"] = "estimated"
+            log.setdefault("measurement", {})["token_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_apply_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_apply_pr_create.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import apply_pr_create as apply_create  # noqa: E402
+import pr_create_contract as contract  # noqa: E402
+
+
+def request_payload(repo_root: Path) -> dict:
+    normalized = {
+        "repo_root": str(repo_root),
+        "repo_slug": "owner/repo",
+        "base": "main",
+        "head": "feature/pr-create",
+        "title": "feat(pr-create): create guarded PRs",
+        "body": "\n".join(
+            [
+                "## Why",
+                "Open a guarded PR from a pushed branch.",
+                "## What changed",
+                "- Added validator-normalized create flow.",
+                "- Re-check duplicate and template state before create.",
+                "## How",
+                "- Keep create fail-closed on stale snapshots.",
+                "## Risk / Rollback",
+                "- Refresh branch state and rerun validation.",
+                "## Testing",
+                "- Not run.",
+                "Refs: #42",
+            ]
+        ),
+        "draft": True,
+        "reviewers": ["alice"],
+        "assignees": ["bob"],
+        "labels": ["automation"],
+        "milestone": "v1",
+        "maintainer_can_modify": False,
+        "validation_commands": ["candidate lint", "gh auth status"],
+        "review_mode": "targeted-delegation",
+        "qa_gate": {"required": False, "reason": None, "qa_clear": False},
+        "validated_snapshot": {
+            "local_head_oid": "abc123",
+            "remote_head_oid": "abc123",
+            "repo_slug": "owner/repo",
+            "base_ref": "main",
+            "head_ref": "feature/pr-create",
+            "changed_files_fingerprint": contract.json_fingerprint(["src/creator.py"]),
+            "template_path": "C:/repo/.github/pull_request_template.md",
+            "template_fingerprint": contract.json_fingerprint("template"),
+            "duplicate_check_summary": {
+                "status": "clear",
+                "matched_repo_slug": "owner/repo",
+                "matched_head": "feature/pr-create",
+                "existing_pr_number": None,
+                "existing_pr_url": None,
+                "existing_pr_count": 0,
+            },
+        },
+    }
+    return {
+        "valid": True,
+        "can_apply": True,
+        "normalized_create_request": normalized,
+        "normalized_create_request_fingerprint": contract.json_fingerprint(normalized),
+        "apply_gate_status": contract.stop_status(),
+        "stop_reasons": [],
+    }
+
+
+class ApplyPrCreateTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def read_json(self, path: Path) -> dict:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_apply_rejects_tampered_validator_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation = request_payload(repo_root)
+            validation["normalized_create_request"]["title"] = "tampered"
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            self.write_json(validation_path, validation)
+
+            stdout = io.StringIO()
+            with mock.patch.object(
+                sys,
+                "argv",
+                ["apply_pr_create.py", "--validation", str(validation_path), "--result-output", str(result_path)],
+            ), redirect_stdout(stdout):
+                exit_code = apply_create.main()
+
+            self.assertEqual(exit_code, 1)
+            payload = self.read_json(result_path)
+            self.assertEqual(payload["stop_reason"], "fingerprint_mismatch")
+
+    def test_dry_run_reports_command_without_calling_gh_pr_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            self.write_json(validation_path, request_payload(repo_root))
+            recorded_calls: list[list[str]] = []
+
+            def fake_run_command(args: list[str], cwd: Path) -> str:
+                recorded_calls.append(args)
+                if args[:3] == ["gh", "auth", "status"]:
+                    return "Logged in to github.com"
+                raise AssertionError(f"Unexpected command: {args}")
+
+            with (
+                mock.patch.object(apply_create.tools, "run_command", side_effect=fake_run_command),
+                mock.patch.object(apply_create.tools, "local_head_oid", return_value="abc123"),
+                mock.patch.object(apply_create.tools, "remote_head_oid", return_value="abc123"),
+                mock.patch.object(apply_create.tools, "load_changed_files_between", return_value=["src/creator.py"]),
+                mock.patch.object(
+                    apply_create.tools,
+                    "select_pr_template",
+                    return_value={"selected_path": "C:/repo/.github/pull_request_template.md", "fingerprint": contract.json_fingerprint("template")},
+                ),
+                mock.patch.object(
+                    apply_create.tools,
+                    "duplicate_check_summary",
+                    return_value={
+                        "status": "clear",
+                        "matched_repo_slug": "owner/repo",
+                        "matched_head": "feature/pr-create",
+                        "existing_pr_count": 0,
+                    },
+                ),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["apply_pr_create.py", "--validation", str(validation_path), "--result-output", str(result_path), "--dry-run"],
+                ),
+            ):
+                exit_code = apply_create.main()
+
+            self.assertEqual(exit_code, 0)
+            payload = self.read_json(result_path)
+            self.assertTrue(payload["apply_succeeded"])
+            self.assertTrue(payload["dry_run"])
+            self.assertEqual(recorded_calls, [["gh", "auth", "status"]])
+
+    def test_apply_stops_when_duplicate_check_changes_after_validation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            self.write_json(validation_path, request_payload(repo_root))
+
+            with (
+                mock.patch.object(apply_create.tools, "run_command", return_value="Logged in to github.com"),
+                mock.patch.object(apply_create.tools, "local_head_oid", return_value="abc123"),
+                mock.patch.object(apply_create.tools, "remote_head_oid", return_value="abc123"),
+                mock.patch.object(apply_create.tools, "load_changed_files_between", return_value=["src/creator.py"]),
+                mock.patch.object(
+                    apply_create.tools,
+                    "select_pr_template",
+                    return_value={"selected_path": "C:/repo/.github/pull_request_template.md", "fingerprint": contract.json_fingerprint("template")},
+                ),
+                mock.patch.object(
+                    apply_create.tools,
+                    "duplicate_check_summary",
+                    return_value={
+                        "status": "existing-open-pr",
+                        "matched_repo_slug": "owner/repo",
+                        "matched_head": "feature/pr-create",
+                        "existing_pr_number": 9,
+                        "existing_pr_url": "https://example.invalid/pr/9",
+                        "existing_pr_count": 1,
+                    },
+                ),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["apply_pr_create.py", "--validation", str(validation_path), "--result-output", str(result_path)],
+                ),
+            ):
+                exit_code = apply_create.main()
+
+            self.assertEqual(exit_code, 1)
+            payload = self.read_json(result_path)
+            self.assertEqual(payload["stop_reason"], "stale_snapshot")
+
+    def test_apply_verifies_created_pr_matches_request(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            validation = request_payload(repo_root)
+            self.write_json(validation_path, validation)
+            command_calls: list[list[str]] = []
+
+            def fake_run_command(args: list[str], cwd: Path) -> str:
+                command_calls.append(args)
+                if args[:3] == ["gh", "auth", "status"]:
+                    return "Logged in to github.com"
+                if args[:3] == ["gh", "pr", "create"]:
+                    return "https://example.invalid/pr/10"
+                raise AssertionError(f"Unexpected command: {args}")
+
+            created_pr = {
+                "number": 10,
+                "url": "https://example.invalid/pr/10",
+                "title": validation["normalized_create_request"]["title"],
+                "body": validation["normalized_create_request"]["body"],
+                "headRefName": "feature/pr-create",
+                "baseRefName": "main",
+                "isDraft": True,
+                "labels": [{"name": "automation"}],
+                "assignees": [{"login": "bob"}],
+                "reviewRequests": [{"requestedReviewer": {"login": "alice"}}],
+                "milestone": {"title": "v1"},
+                "maintainerCanModify": False,
+            }
+
+            with (
+                mock.patch.object(apply_create.tools, "run_command", side_effect=fake_run_command),
+                mock.patch.object(apply_create.tools, "local_head_oid", return_value="abc123"),
+                mock.patch.object(apply_create.tools, "remote_head_oid", return_value="abc123"),
+                mock.patch.object(apply_create.tools, "load_changed_files_between", return_value=["src/creator.py"]),
+                mock.patch.object(
+                    apply_create.tools,
+                    "select_pr_template",
+                    return_value={"selected_path": "C:/repo/.github/pull_request_template.md", "fingerprint": contract.json_fingerprint("template")},
+                ),
+                mock.patch.object(
+                    apply_create.tools,
+                    "duplicate_check_summary",
+                    side_effect=[
+                        {
+                            "status": "clear",
+                            "matched_repo_slug": "owner/repo",
+                            "matched_head": "feature/pr-create",
+                            "existing_pr_count": 0,
+                        }
+                    ],
+                ),
+                mock.patch.object(apply_create.tools, "load_open_prs_for_head", return_value=[created_pr]),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["apply_pr_create.py", "--validation", str(validation_path), "--result-output", str(result_path)],
+                ),
+            ):
+                exit_code = apply_create.main()
+
+            self.assertEqual(exit_code, 0)
+            payload = self.read_json(result_path)
+            self.assertTrue(payload["apply_succeeded"])
+            self.assertEqual(payload["created_pr_number"], 10)
+            self.assertIn(["gh", "pr", "create"], [call[:3] for call in command_calls])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_build_pr_create_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_build_pr_create_packets.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import build_pr_create_packets as builder  # noqa: E402
+
+
+def collected_context() -> dict:
+    return {
+        "repo_root": str(Path.cwd()),
+        "repo_slug": "owner/repo",
+        "resolved_head": "feature/pr-create",
+        "resolved_base": "main",
+        "local_head_oid": "abc123",
+        "remote_head_oid": "abc123",
+        "changed_files": ["src/creator.py", "tests/test_creator.py"],
+        "changed_file_groups": {
+            "runtime": {"count": 1, "sample_files": ["src/creator.py"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 0, "sample_files": []},
+            "tests": {"count": 1, "sample_files": ["tests/test_creator.py"]},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "template_selection": {
+            "status": "selected",
+            "selected_path": "C:/repo/.github/pull_request_template.md",
+            "fingerprint": "sha256:template",
+        },
+        "expected_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "duplicate_check_hint": {"status": "clear", "matched_repo_slug": "owner/repo", "matched_head": "feature/pr-create"},
+        "issue_reference_hints": {"numbers": ["42"], "branch": "feature/pr-create", "commit_subjects": []},
+        "testing_signal_candidates": {"exact_commands": [], "supports_positive_testing_claims": False, "test_files_changed": True},
+        "create_options": {"reviewers": [], "assignees": [], "labels": [], "milestone": None, "draft": False, "no_maintainer_edit": False},
+        "diff_stat": " 2 files changed, 4 insertions(+), 1 deletion(-)",
+        "repo_profile_name": "default",
+        "repo_profile_path": "profiles/default/profile.json",
+        "repo_profile_summary": "Default profile",
+        "repo_profile": {"name": "default"},
+        "recent_commit_subjects": ["feat(pr-create): add guarded creator #42"],
+    }
+
+
+def lint_report() -> dict:
+    return {
+        "findings": {
+            "errors": [],
+            "warnings": [],
+            "override_signals": {
+                "high_churn": False,
+                "multi_group_core_files": False,
+                "generated_not_majority": False,
+            },
+        },
+        "drafting_basis": {
+            "active_rule_gates": ["title_pattern", "required_sections"],
+            "required_sections_status": {"required": ["Why", "What changed", "How", "Risk / Rollback", "Testing"]},
+            "supported_claims": [{"cluster": "runtime", "basis": "runtime files changed", "evidence_anchor": "src/creator.py"}],
+            "issue_reference_hints": {"numbers": ["42"]},
+            "testing_evidence_status": {"exact_commands": []},
+            "coverage_gaps": [],
+            "focused_packet_hint": "runtime_packet.json",
+        },
+    }
+
+
+class BuildPrCreatePacketsTests(unittest.TestCase):
+    def test_build_packet_payloads_emits_packet_heavy_outputs(self) -> None:
+        packets, build_result = builder.build_packet_payloads(collected_context(), lint_report())
+
+        self.assertIn("rules_packet.json", packets)
+        self.assertIn("runtime_packet.json", packets)
+        self.assertIn("testing_packet.json", packets)
+        self.assertIn("synthesis_packet.json", packets)
+        self.assertIn("orchestrator.json", packets)
+        self.assertIn("packet_metrics.json", packets)
+        self.assertEqual(build_result["shared_local_packet"], "synthesis_packet.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class CollectPrCreateContextTests(unittest.TestCase):
+    def test_import_resolves_builder_scripts_from_vendored_foundry_for_root_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            override_scripts_dir = repo_root / ".agents" / "skills" / "gh-create-pr" / "scripts"
+            builder_scripts_dir = (
+                repo_root
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / "builders"
+                / "packet-workflow"
+                / "scripts"
+            )
+
+            write_text(
+                override_scripts_dir / "collect_pr_create_context.py",
+                (SCRIPT_DIR / "collect_pr_create_context.py").read_text(encoding="utf-8"),
+            )
+            write_text(
+                override_scripts_dir / "pr_create_tools.py",
+                "def build_context(**_kwargs):\n"
+                "    return {\"builder_compatibility\": {\"status\": \"current\"}}\n",
+            )
+            write_text(
+                builder_scripts_dir / "packet_workflow_versioning.py",
+                "def classify_builder_compatibility(**_kwargs):\n"
+                "    return {\"status\": \"current\"}\n\n"
+                "def extract_profile_versioning(_value):\n"
+                "    return None\n\n"
+                "def extract_skill_builder_versioning(_value):\n"
+                "    return None\n\n"
+                "def format_runtime_warning(_value):\n"
+                "    return \"warning\"\n\n"
+                "def load_builder_versioning():\n"
+                "    return {\"builder_family\": \"packet-workflow\", \"builder_semver\": \"1.0.0\"}\n\n"
+                "def load_json_document(_path):\n"
+                "    return {}\n",
+            )
+
+            module_name = "temp_collect_pr_create_context"
+            original_sys_path = list(sys.path)
+            try:
+                sys.path.insert(0, str(override_scripts_dir))
+                spec = importlib.util.spec_from_file_location(
+                    module_name,
+                    override_scripts_dir / "collect_pr_create_context.py",
+                )
+                self.assertIsNotNone(spec)
+                self.assertIsNotNone(spec.loader)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+            finally:
+                sys.path[:] = original_sys_path
+                sys.modules.pop(module_name, None)
+
+        self.assertEqual(module.BUILDER_SCRIPTS_DIR, builder_scripts_dir.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import lint_pr_create as lint  # noqa: E402
+
+
+def collected_context() -> dict:
+    return {
+        "repo_root": str(Path.cwd()),
+        "repo_slug": "owner/repo",
+        "resolved_head": "feature/pr-create",
+        "resolved_base": "main",
+        "local_head_oid": "abc123",
+        "remote_head_oid": "abc123",
+        "changed_files": ["src/creator.py", "tests/test_creator.py"],
+        "changed_files_fingerprint": "sha256:changed",
+        "changed_file_groups": {
+            "runtime": {"count": 1, "sample_files": ["src/creator.py"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 0, "sample_files": []},
+            "tests": {"count": 1, "sample_files": ["tests/test_creator.py"]},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "diff_stat": " 2 files changed, 4 insertions(+), 1 deletion(-)",
+        "template_selection": {
+            "status": "selected",
+            "selected_path": "C:/repo/.github/pull_request_template.md",
+            "fingerprint": "sha256:template",
+        },
+        "expected_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "duplicate_check_hint": {"status": "clear", "matched_repo_slug": "owner/repo", "matched_head": "feature/pr-create"},
+        "checks": {
+            "repo_slug_resolved": True,
+            "base_resolved": True,
+            "remote_head_exists": True,
+            "local_remote_match": True,
+            "template_selected": True,
+        },
+        "issue_reference_hints": {
+            "numbers": ["42"],
+            "branch": "feature/pr-create",
+            "commit_subjects": ["feat(pr-create): add guarded creator #42"],
+        },
+        "testing_signal_candidates": {
+            "exact_commands": [],
+            "supports_positive_testing_claims": False,
+            "test_files_changed": True,
+        },
+        "instruction_snippets": {},
+    }
+
+
+class LintPrCreateTests(unittest.TestCase):
+    def test_context_findings_flag_missing_default_template(self) -> None:
+        context = collected_context()
+        context["template_selection"] = {"status": "not_found", "selected_path": None, "fingerprint": ""}
+        context["checks"]["template_selected"] = False
+
+        findings = lint.collect_context_findings(context)
+
+        self.assertIn("No unique default PR template was found.", findings["errors"])
+
+    def test_candidate_findings_block_positive_testing_claim_without_external_command(self) -> None:
+        findings = lint.collect_candidate_findings(
+            collected_context(),
+            "feat(pr-create): create guarded PRs",
+            "\n".join(
+                [
+                    "## Why",
+                    "Open a guarded PR.",
+                    "## What changed",
+                    "- Added validator/apply gates.",
+                    "## How",
+                    "- Keep create fail-closed.",
+                    "## Risk / Rollback",
+                    "- Re-run validation.",
+                    "## Testing",
+                    "- Ran `python -m pytest`.",
+                    "Refs: #42",
+                ]
+            ),
+        )
+
+        self.assertIn("Positive testing claims cite commands that are not grounded in the testing packet.", findings["detected"]["unsupported_claims"])
+
+    def test_candidate_findings_allow_no_behavior_change_when_runtime_packet_is_empty(self) -> None:
+        context = collected_context()
+        context["changed_file_groups"]["runtime"]["count"] = 0
+        context["changed_file_groups"]["runtime"]["sample_files"] = []
+        context["changed_files"] = ["README.md"]
+
+        findings = lint.collect_candidate_findings(
+            context,
+            "docs(pr-create): document guarded create flow",
+            "\n".join(
+                [
+                    "## Why",
+                    "Document the create flow.",
+                    "## What changed",
+                    "- Updated docs only.",
+                    "## How",
+                    "- No behavior change.",
+                    "## Risk / Rollback",
+                    "- Revert the docs text.",
+                    "## Testing",
+                    "- Not run.",
+                    "Refs: #42",
+                ]
+            ),
+        )
+
+        self.assertEqual(findings["detected"]["unsupported_claims"], [])
+
+    def test_candidate_findings_block_issue_reference_without_hint(self) -> None:
+        context = collected_context()
+        context["issue_reference_hints"]["numbers"] = []
+
+        findings = lint.collect_candidate_findings(
+            context,
+            "feat(pr-create): create guarded PRs",
+            "\n".join(
+                [
+                    "## Why",
+                    "Open a guarded PR.",
+                    "## What changed",
+                    "- Added validator/apply gates.",
+                    "## How",
+                    "- Keep create fail-closed.",
+                    "## Risk / Rollback",
+                    "- Re-run validation.",
+                    "## Testing",
+                    "- Not run.",
+                    "Refs: #42",
+                ]
+            ),
+        )
+
+        self.assertIn("Issue references are present without matching issue hints from the process packet.", findings["detected"]["unsupported_claims"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import pr_create_tools as tools  # noqa: E402
+
+
+def run_git(repo_root: Path, args: list[str]) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def init_repo(repo_root: Path, origin_root: Path) -> None:
+    origin_root.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["git", "init", "--bare", str(origin_root)],
+        cwd=str(origin_root.parent),
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git init --bare failed")
+    run_git(repo_root, ["init", "-b", "main"])
+    run_git(repo_root, ["config", "user.name", "Tests"])
+    run_git(repo_root, ["config", "user.email", "tests@example.invalid"])
+    run_git(repo_root, ["remote", "add", "origin", str(origin_root)])
+
+    write_text(
+        repo_root / ".github" / "pull_request_template.md",
+        "## Why\n\n## What changed\n\n## How\n\n## Risk / Rollback\n\n## Testing\n",
+    )
+    write_text(
+        repo_root / ".github" / "instructions" / "pull-request.instructions.md",
+        "# Rules\n\n## PR Title\nUse Conventional Commit style.\n",
+    )
+    write_text(
+        repo_root / ".github" / "instructions" / "commit-message.instructions.md",
+        "# Commit Rules\n\n## Types\n- feat\n- fix\n",
+    )
+    write_text(repo_root / "README.md", "# Repo\n")
+    write_text(repo_root / "src" / "feature.py", "VALUE = 1\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "Initial commit"])
+    run_git(repo_root, ["push", "-u", "origin", "main"])
+
+    run_git(repo_root, ["checkout", "-b", "release"])
+    run_git(repo_root, ["push", "-u", "origin", "release"])
+
+    run_git(repo_root, ["checkout", "main"])
+    run_git(repo_root, ["checkout", "-b", "feature/pr-create"])
+    run_git(repo_root, ["config", "branch.feature/pr-create.gh-merge-base", "main"])
+    write_text(repo_root / "src" / "feature.py", "VALUE = 2\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "feat(pr-create): add guarded creator #42"])
+    run_git(repo_root, ["push", "-u", "origin", "feature/pr-create"])
+
+
+class PrCreateToolsTests(unittest.TestCase):
+    def test_infer_repo_slug_accepts_dotted_repo_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            run_git(repo_root, ["init", "-b", "main"])
+            run_git(repo_root, ["remote", "add", "origin", "git@github.com:owner/my.repo.git"])
+
+            self.assertEqual(tools.infer_repo_slug(repo_root), "owner/my.repo")
+
+    def test_build_context_resolves_defaults_from_branch_and_profiled_repo_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            context = tools.build_context(repo_root=repo_root, repo_slug="owner/repo")
+
+            self.assertEqual(context["resolved_head"], "feature/pr-create")
+            self.assertEqual(context["resolved_base"], "main")
+            self.assertEqual(context["repo_slug"], "owner/repo")
+            self.assertEqual(context["template_selection"]["status"], "selected")
+            self.assertTrue(context["changed_files"])
+            self.assertEqual(context["duplicate_check_hint"]["status"], "unavailable")
+
+    def test_build_context_respects_explicit_base_and_head_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            context = tools.build_context(
+                repo_root=repo_root,
+                repo_slug="owner/repo",
+                base_ref="release",
+                head_ref="feature/pr-create",
+            )
+
+            self.assertEqual(context["resolved_base"], "release")
+            self.assertEqual(context["resolved_head"], "feature/pr-create")
+
+    def test_select_pr_template_fails_closed_when_multiple_candidates_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            write_text(repo_root / ".github" / "pull_request_template.md", "## Why\n")
+            write_text(repo_root / ".github" / "PULL_REQUEST_TEMPLATE" / "alt.md", "## Why\n")
+
+            selection = tools.select_pr_template(repo_root)
+
+            self.assertEqual(selection["status"], "ambiguous")
+            self.assertGreaterEqual(len(selection["all_candidates"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_validate_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_validate_pr_create.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import pr_create_contract as contract  # noqa: E402
+import validate_pr_create as validator  # noqa: E402
+
+
+def collected_context(repo_root: Path, *, repo_slug: str = "owner/repo") -> dict:
+    return {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "resolved_head": "feature/pr-create",
+        "resolved_base": "main",
+        "local_head_oid": "abc123",
+        "remote_head_oid": "abc123",
+        "changed_files": ["src/creator.py", "tests/test_creator.py"],
+        "changed_files_fingerprint": contract.json_fingerprint(["src/creator.py", "tests/test_creator.py"]),
+        "changed_file_groups": {
+            "runtime": {"count": 1, "sample_files": ["src/creator.py"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 0, "sample_files": []},
+            "tests": {"count": 1, "sample_files": ["tests/test_creator.py"]},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "template_selection": {
+            "status": "selected",
+            "selected_path": "C:/repo/.github/pull_request_template.md",
+            "fingerprint": contract.json_fingerprint("template"),
+        },
+        "expected_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "issue_reference_hints": {"numbers": ["42"], "branch": "feature/pr-create", "commit_subjects": []},
+        "testing_signal_candidates": {"exact_commands": [], "supports_positive_testing_claims": False, "test_files_changed": True},
+        "create_options": {
+            "reviewers": ["Alice", "alice", "bob, alice"],
+            "assignees": ["Carol", "carol"],
+            "labels": ["automation", "automation", "docs"],
+            "milestone": "v1",
+            "draft": True,
+            "no_maintainer_edit": True,
+        },
+        "checks": {
+            "repo_slug_resolved": bool(repo_slug),
+            "base_resolved": True,
+            "remote_head_exists": True,
+            "local_remote_match": True,
+            "template_selected": True,
+        },
+        "duplicate_check_hint": {"status": "clear", "matched_repo_slug": repo_slug, "matched_head": "feature/pr-create"},
+        "diff_stat": " 2 files changed, 4 insertions(+), 1 deletion(-)",
+    }
+
+
+def valid_body() -> str:
+    return "\n".join(
+        [
+            "## Why",
+            "Open a guarded PR from a pushed branch.",
+            "## What changed",
+            "- Added validator-normalized create flow.",
+            "- Re-check duplicate and template state before create.",
+            "## How",
+            "- Keep create fail-closed on stale snapshots.",
+            "## Risk / Rollback",
+            "- Refresh branch state and rerun validation.",
+            "## Testing",
+            "- Not run.",
+            "Refs: #42",
+        ]
+    )
+
+
+class ValidatePrCreateTests(unittest.TestCase):
+    def test_validator_rejects_repo_inference_failure_before_gh_calls(self) -> None:
+        context = collected_context(Path.cwd(), repo_slug="")
+        with mock.patch.object(
+            validator.tools,
+            "run_command",
+            side_effect=AssertionError("gh command should not run when repo inference already failed"),
+        ):
+            payload = validator.validate_pr_create(
+                context,
+                "feat(pr-create): create guarded PRs",
+                valid_body(),
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("repo_inference_failed", payload["stop_reasons"])
+
+    def test_validator_rejects_invalid_title_before_gh_calls(self) -> None:
+        context = collected_context(Path.cwd())
+        with mock.patch.object(
+            validator.tools,
+            "run_command",
+            side_effect=AssertionError("gh command should not run for invalid candidate lint"),
+        ):
+            payload = validator.validate_pr_create(context, "bad title", valid_body())
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("invalid_title", payload["stop_reasons"])
+
+    def test_validator_flags_unsupported_claims(self) -> None:
+        context = collected_context(Path.cwd())
+        body = valid_body().replace("- Not run.", "- Ran `python -m pytest`.")
+        with mock.patch.object(
+            validator.tools,
+            "run_command",
+            side_effect=AssertionError("gh command should not run once unsupported claims are detected"),
+        ):
+            payload = validator.validate_pr_create(
+                context,
+                "feat(pr-create): create guarded PRs",
+                body,
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("unsupported_claim", payload["stop_reasons"])
+
+    def test_validator_rejects_existing_open_pr_on_live_duplicate_check(self) -> None:
+        context = collected_context(Path.cwd())
+        with (
+            mock.patch.object(validator.tools, "run_command", return_value="Logged in to github.com"),
+            mock.patch.object(validator.tools, "local_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "remote_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "load_changed_files_between", return_value=context["changed_files"]),
+            mock.patch.object(validator.tools, "select_pr_template", return_value=context["template_selection"]),
+            mock.patch.object(
+                validator.tools,
+                "duplicate_check_summary",
+                return_value={
+                    "status": "existing-open-pr",
+                    "matched_repo_slug": "owner/repo",
+                    "matched_head": "feature/pr-create",
+                    "existing_pr_number": 9,
+                    "existing_pr_url": "https://example.invalid/pr/9",
+                    "existing_pr_count": 1,
+                },
+            ),
+        ):
+            payload = validator.validate_pr_create(
+                context,
+                "feat(pr-create): create guarded PRs",
+                valid_body(),
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("existing_open_pr", payload["stop_reasons"])
+
+    def test_validator_emits_normalized_create_request_when_candidate_is_apply_safe(self) -> None:
+        context = collected_context(Path.cwd())
+        with (
+            mock.patch.object(validator.tools, "run_command", return_value="Logged in to github.com"),
+            mock.patch.object(validator.tools, "local_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "remote_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "load_changed_files_between", return_value=context["changed_files"]),
+            mock.patch.object(validator.tools, "select_pr_template", return_value=context["template_selection"]),
+            mock.patch.object(
+                validator.tools,
+                "duplicate_check_summary",
+                return_value={
+                    "status": "clear",
+                    "matched_repo_slug": "owner/repo",
+                    "matched_head": "feature/pr-create",
+                    "existing_pr_count": 0,
+                },
+            ),
+        ):
+            payload = validator.validate_pr_create(
+                context,
+                "feat(pr-create): create guarded PRs",
+                valid_body(),
+            )
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["can_apply"])
+        normalized = payload["normalized_create_request"]
+        self.assertEqual(normalized["reviewers"], ["alice", "bob"])
+        self.assertEqual(normalized["assignees"], ["carol"])
+        self.assertEqual(normalized["labels"], ["automation", "docs"])
+        self.assertEqual(normalized["milestone"], "v1")
+        self.assertFalse(normalized["maintainer_can_modify"])
+        self.assertEqual(
+            sorted(normalized["validated_snapshot"].keys()),
+            sorted(
+                [
+                    "local_head_oid",
+                    "remote_head_oid",
+                    "repo_slug",
+                    "base_ref",
+                    "head_ref",
+                    "changed_files_fingerprint",
+                    "template_path",
+                    "template_fingerprint",
+                    "duplicate_check_summary",
+                ]
+            ),
+        )
+
+    def test_validator_rejects_stale_snapshot_when_changed_files_drift(self) -> None:
+        context = collected_context(Path.cwd())
+        with (
+            mock.patch.object(validator.tools, "run_command", return_value="Logged in to github.com"),
+            mock.patch.object(validator.tools, "local_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "remote_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "load_changed_files_between", return_value=context["changed_files"] + ["README.md"]),
+            mock.patch.object(validator.tools, "select_pr_template", return_value=context["template_selection"]),
+            mock.patch.object(
+                validator.tools,
+                "duplicate_check_summary",
+                return_value={
+                    "status": "clear",
+                    "matched_repo_slug": "owner/repo",
+                    "matched_head": "feature/pr-create",
+                    "existing_pr_count": 0,
+                },
+            ),
+        ):
+            payload = validator.validate_pr_create(
+                context,
+                "feat(pr-create): create guarded PRs",
+                valid_body(),
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("stale_snapshot", payload["stop_reasons"])
+        self.assertEqual(payload["stale_fields"][0]["field"], "changed_files_fingerprint")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/SKILL.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: gh-fix-pr-writeup
+description: Verify and repair a GitHub pull request title and body when the user gives a PR number or asks to audit, rewrite, or fix PR text. Use when Codex must compare a PR's current writeup against repository PR instructions/templates and the actual code changes, then update it with gh CLI if the title/body are missing, truncated, generic, misleading, or unsupported by the diff.
+---
+
+# PR Writeup Repair
+
+Use this skill to check whether a specific PR's title and body match repository PR rules and the real change set, then fix the PR with `gh` only when the replacement is materially better.
+
+This is a packet-heavy orchestrator skill with local final synthesis:
+- keep GitHub auth, context collection, final judgment, final title/body drafting, validator gating, and guarded PR mutation local
+- keep worker outputs proposal-grade and `generic / flat`
+- keep `rules_packet.json` authoritative for hard rules and `synthesis_packet.json` limited to run-specific drafting basis
+- keep token-efficiency metrics out of runtime packets; record them in `packet_metrics.json` and the evaluation log instead
+
+Boundary:
+- Keep reusable packet-workflow semantics in `references/core-contract.md`.
+- Keep default repo bindings and review-doc ownership in `profiles/default/profile.json`.
+- Keep vendored repo overrides data-only in `.codex/project/profiles/`.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/gh-fix-pr-writeup/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/gh-fix-pr-writeup/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/gh-fix-pr-writeup/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Verify GitHub access first.
+- Run `gh auth status`.
+- If authentication fails, stop and tell the user to run `gh auth login`.
+
+2. Collect, lint, and build packets before broad rereads.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_pr_context.py <pr-number> --repo-root <repo-root> --output <context-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/lint_pr_writeup.py --context <context-json> --output <lint-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_pr_review_packets.py --context <context-json> --lint <lint-json> --output-dir <packet-dir> --result-output <packet-dir>/build-result.json`.
+- Run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --lint <lint-json> --output <eval-log-json>`.
+- Read `<packet-dir>/orchestrator.json` first.
+- Read `<packet-dir>/rules_packet.json` locally before drafting any replacement title/body.
+- Keep common-path local drafting on `rules_packet.json + synthesis_packet.json + <= 1 focused packet`.
+
+3. Follow the review mode and packet contract.
+- `local-only`
+  - use no workers
+  - keep drafting on `rules_packet.json`, `synthesis_packet.json`, and one focused packet at most
+- `targeted-delegation`
+  - use 1-2 narrow workers on focused packets
+- `broad-delegation`
+  - use 3-4 narrow workers
+  - QA is still a rare exception, not the common path
+- Treat packet file lists as representative slices, not a complete inventory.
+- Raw reread is allowed only for `sample_omission`, `worker_conflict`, `claim_dispute`, or `validator_blocker`.
+- `packet_insufficiency` is a failure, not an allowed reread reason.
+
+4. Keep the critical path local.
+- `rules_packet.json` is the only authority source for hard rules.
+- `synthesis_packet.json` is the run-specific decision packet for this PR; it must not duplicate the full rules prose.
+- Draft the final title/body locally even when workers were used.
+- Workers may suggest bullets or evidence, but they must not emit embedded edit code or take over the PR mutation step.
+- Run `<python-bin> -B <skill-dir>/scripts/validate_pr_writeup_edit.py --context <context-json> --title "<title>" --body-file <body-file> [--qa-result <qa-json>] --output <packet-dir>/validation.json` before any mutation.
+- `validate_pr_writeup_edit.py` re-runs `gh auth status`, compares the live PR snapshot and changed-file list against the collected context, computes `qa_required`, and fails closed on stale context, invalid replacement text, unsupported claims, or missing QA clear when QA is required.
+- Run `<python-bin> -B <skill-dir>/scripts/apply_pr_writeup.py --validation <packet-dir>/validation.json [--dry-run] [--result-output <packet-dir>/apply-result.json>` for the guarded apply step.
+- `apply_pr_writeup.py` consumes validator output only, re-checks the live snapshot against the validated snapshot, and fails closed if `qa_required` is still true without QA clear.
+
+5. Judge the title and body conservatively.
+- Use the repository's PR guidance and template order exactly.
+- Title the primary shipped behavior or workflow change, not the noisiest file.
+- Keep bullets concise and supported by the diff or by commands you actually ran.
+- Do not claim tests, defaults, reload/restart requirements, migration impact, or mitigation steps unless you can verify them.
+
+## Packet Contract
+
+- `orchestrator_profile=packet-heavy-orchestrator`
+- `decision_ready_packets=false`
+- `worker_return_contract=generic`
+- `worker_output_shape=flat`
+- `shared_local_packet=synthesis_packet.json`
+- `common_path_contract=rules + synthesis + <=1 focused`
+- `packet_worker_map` is the routing authority for delegated packet analysis.
+- `packet_metrics.json` is evaluation-only and must not be used as runtime routing data.
+
+## Delegation Rules
+
+- Never ask workers to rediscover the whole repo rules or raw diff from scratch.
+- Pass `global_packet.json`, one focused packet, and only the explicit file slice needed for grounding.
+- `rules_packet.json` is local-first. A rules worker is a cross-check, not a replacement for local verification.
+- Prefer these roles:
+  - `docs_verifier` for the optional `rules_packet.json` cross-check
+  - `evidence_summarizer` for `testing_packet.json`
+  - `packet_explorer` for `runtime_packet.json` and `process_packet.json`
+  - `large_diff_auditor` or explicit `gpt-5.4-mini` for the rare QA pass
+- Require every normal worker to return:
+  - `primary outcome`
+  - `evidence files`
+  - `unsupported claims`
+  - `suggested PR bullets`
+- Require the optional QA worker to return:
+  - `keep_or_revise`
+  - `rule violations`
+  - `coverage gaps`
+  - `unsupported claims`
+- Read `references/delegation-playbook.md` only when `review_mode` is not `local-only`.
+
+## Scripts
+
+- `scripts/collect_pr_context.py`
+  - Collect PR metadata, changed-file groups, diff stat, template headings, rule-file paths, and instruction snippets.
+- `scripts/lint_pr_writeup.py`
+  - Flag deterministic problems and emit structured drafting basis for the synthesis packet.
+- `scripts/build_pr_review_packets.py`
+  - Emit lean runtime packets, `synthesis_packet.json`, `packet_metrics.json`, and build-result metadata.
+- `scripts/validate_pr_writeup_edit.py`
+  - Validate candidate replacements against the collected context, candidate lint checks, QA gate, and the live PR snapshot before apply.
+- `scripts/apply_pr_writeup.py`
+  - Consume validator output only and apply `gh pr edit` only when the validated snapshot still matches live PR state.
+- `scripts/smoke_gh_fix_pr_writeup.py`
+  - Run the temp-repo smoke path with stubbed `gh` responses.
+- `scripts/write_evaluation_log.py`
+  - Record the shared evaluation log for efficiency, quality, and safety tracking.
+
+## Evaluation
+
+- After build, run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase build --result <packet-dir>/build-result.json`.
+- After lint, run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase lint --result <lint-json>`.
+- After validation, merge `validation.json` with the `validate` phase.
+- After guarded apply or dry-run, merge `apply-result.json` with the `apply` phase.
+- `packet_metrics.json` and build-result metadata should drive token-efficiency and common-path regression tracking.
+- Runtime packets must stay lean and must not embed packet-size or token counters.
+- Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
+
+## Output
+
+- Tell the user whether the PR already matched the rules or what changed.
+- Include the final PR URL.
+- Mention the validation commands that actually ran.
+- If blocked, name the blocker precisely: missing `gh` auth, stale PR snapshot, invalid replacement text, missing QA clear, or insufficient diff support.

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/agents/openai.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: "Fix PR Writeup"
+  short_description: "Audit and repair PR title/body"
+  default_prompt: >-
+    Use $gh-fix-pr-writeup to verify a PR title and body against repository
+    PR rules and the actual change set, then rewrite it only if the new text
+    is materially better. Keep rules_packet.json in view before editing the
+    PR, run validate_pr_writeup_edit.py before any mutation, and use
+    apply_pr_writeup.py only with validator output.

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/builder-spec.json
@@ -1,0 +1,115 @@
+{
+  "skill_name": "gh-fix-pr-writeup",
+  "description": "Verify and repair a GitHub pull request title and body when the user gives a PR number or asks to audit, rewrite, or fix PR text. Use when Codex must compare a PR's current writeup against repository PR instructions/templates and the actual code changes, then update it with gh CLI if the title/body are missing, truncated, generic, misleading, or unsupported by the diff.",
+  "domain_slug": "pr_writeup",
+  "workflow_family": "github-review",
+  "archetype": "audit-and-apply",
+  "primary_goal": "repair PR title and body against repo rules and diff-supported evidence with packet-heavy local synthesis",
+  "trigger_phrases": [
+    "fix PR writeup",
+    "rewrite pull request description",
+    "audit PR title and body",
+    "repair PR body"
+  ],
+  "task_packet_names": [
+    "rules",
+    "runtime",
+    "process",
+    "testing"
+  ],
+  "orchestrator_profile": "packet-heavy-orchestrator",
+  "needs_lint": true,
+  "needs_validate": true,
+  "needs_apply": true,
+  "decision_ready_packets": false,
+  "worker_return_contract": "generic",
+  "worker_output_shape": "flat",
+  "packet_worker_map": {
+    "rules": [
+      "docs_verifier"
+    ],
+    "runtime": [
+      "packet_explorer"
+    ],
+    "process": [
+      "packet_explorer"
+    ],
+    "testing": [
+      "evidence_summarizer"
+    ]
+  },
+  "repo_profile": {
+    "name": "default",
+    "summary": "Default reusable profile scaffold for PR writeup repair. Replace with project-local PR guidance bindings, review-doc lists, and repo-specific lint toggles when vendored.",
+    "repo_match": {
+      "root_markers": [
+        ".git",
+        "README.md"
+      ],
+      "remote_patterns": []
+    },
+    "bindings": {
+      "primary_readme_path": "README.md",
+      "settings_source_path": null,
+      "publish_config_path": null
+    },
+    "packet_defaults": {
+      "review_docs": {
+        "rules": [
+          ".github/pull_request_template.md",
+          "CONTRIBUTING.md",
+          "MAINTAINING.md"
+        ],
+        "runtime": [
+          "README.md"
+        ],
+        "process": [
+          ".github/pull_request_template.md",
+          "CONTRIBUTING.md",
+          "MAINTAINING.md"
+        ],
+        "testing": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ]
+      },
+      "source_path_globs": {
+        "rules": [
+          ".github/**",
+          "*.md"
+        ],
+        "runtime": [
+          "src/**",
+          "lib/**",
+          "app/**",
+          "server/**",
+          "client/**"
+        ],
+        "process": [
+          ".github/**",
+          "*.md",
+          "docs/**"
+        ],
+        "testing": [
+          "tests/**",
+          "**/*test*.*"
+        ]
+      }
+    },
+    "lint_rules": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "notes": [
+      "Keep template order, PR guidance locations, and repo-specific rule files in project-local profile data.",
+      "Do not place title/body drafting policy, QA gates, or validator/apply rules in the profile."
+    ]
+  },
+  "builder_versioning": {
+    "builder_family": "packet-workflow",
+    "builder_semver": "0.1.0",
+    "compatibility_epoch": 1,
+    "builder_spec_schema_version": 1,
+    "repo_profile_schema_version": 1
+  }
+}

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/migration-worksheet.md
@@ -1,0 +1,58 @@
+# Migration Worksheet: gh-fix-pr-writeup
+
+## Workflow Snapshot
+- `workflow_family`: `github-review`
+- Current runtime shape: `packet-heavy-orchestrator`, `generic`, `flat`
+- Primary packets: `global_packet`, `rules_packet`, `synthesis_packet`, focused runtime/process/testing packets
+- Current authoritative files:
+  - references: `pr-writeup-contract.md`, `gh-fix-pr-writeup-evaluation-contract.md`
+  - scripts: `collect_pr_context.py`, `lint_pr_writeup.py`, `build_pr_review_packets.py`, `validate_pr_writeup_edit.py`, `apply_pr_writeup.py`
+  - tests: lint/build/validate/apply/smoke coverage exists
+
+## Repo-Specific Inputs Seen In Legacy Skill
+- PR template paths and repo instruction files
+- repo-specific changed-file grouping and core-area hints
+- review-doc sets used by rules/runtime/process/testing packets
+
+## Migration Classification
+- `core`
+  - packet-heavy common-path semantics
+  - validator-normalized apply boundary
+  - worker-family semantics and packet-routing authority
+- `profiles/default/profile.json`
+  - PR guidance paths and review-doc lists
+  - source-path globs for focused packet hints
+  - lint toggles that stay declarative
+- Skill-local
+  - PR writeup contract and QA trigger policy
+  - title/body validation logic
+  - guarded `gh pr edit` apply flow
+
+## Legacy Inventory Mapping
+- references kept as domain-local: `pr-writeup-contract.md`
+- new retained interface additions: `builder-spec.json`, `references/core-contract.md`, `profiles/default/profile.json`
+- scripts to update for profile metadata wiring: `collect_pr_context.py`, `build_pr_review_packets.py`
+
+## Retained vs Consumer-Local 판정
+- Data-only profile로 표현 가능한 repo-specific 차이:
+  - PR template file paths
+  - repo instruction file bindings
+  - review-doc sets and source globs
+- 실행 의미/정책/행동 계약까지 건드리는 차이:
+  - 없음. QA gating and validator/apply behavior remain reusable skill-local contracts.
+- Decision: `retained`
+
+## Core 승격 기준
+- 반복 shared gap 여부:
+  - profile loading and profile metadata propagation repeat across multiple retained skills
+  - packet-heavy common-path documentation already belongs in core and builder
+- 일회성 우회 여부:
+  - PR title/body QA policy and writeup validation are local to this skill
+- Decision:
+  - shared profile-loading contract should be treated as foundry-wide
+  - PR writeup QA behavior stays skill-local
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/profiles/default/profile.json
@@ -1,0 +1,76 @@
+{
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "publish_config_path": null,
+    "settings_source_path": null
+  },
+  "lint_rules": {
+    "missing_review_docs_are_errors": false,
+    "require_readme_settings_table": false
+  },
+  "name": "default",
+  "notes": [
+    "Keep template order, PR guidance locations, and repo-specific rule files in project-local profile data.",
+    "Do not place title/body drafting policy, QA gates, or validator/apply rules in the profile."
+  ],
+  "packet_defaults": {
+    "review_docs": {
+      "process": [
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "rules": [
+        ".github/pull_request_template.md",
+        "CONTRIBUTING.md",
+        "MAINTAINING.md"
+      ],
+      "runtime": [
+        "README.md"
+      ],
+      "testing": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ]
+    },
+    "source_path_globs": {
+      "process": [
+        ".github/**",
+        "*.md",
+        "docs/**"
+      ],
+      "rules": [
+        ".github/**",
+        "*.md"
+      ],
+      "runtime": [
+        "src/**",
+        "lib/**",
+        "app/**",
+        "server/**",
+        "client/**"
+      ],
+      "testing": [
+        "tests/**",
+        "**/*test*.*"
+      ]
+    }
+  },
+  "profile_path": "profiles/default/profile.json",
+  "repo_match": {
+    "remote_patterns": [],
+    "root_markers": [
+      ".git",
+      "README.md"
+    ]
+  },
+  "summary": "Default reusable profile scaffold for PR writeup repair. Replace with project-local PR guidance bindings, review-doc lists, and repo-specific lint toggles when vendored.",
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/core-contract.md
@@ -1,0 +1,144 @@
+# Gh Fix Pr Writeup Core Contract
+
+This file captures the reusable packet-workflow core for the generated `gh-fix-pr-writeup` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+
+## Core Metadata
+
+- `workflow_family`: `github-review`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `packet-heavy-orchestrator`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `rules.json`
+- `runtime.json`
+- `process.json`
+- `testing.json`
+- Additional runtime packet:
+  - `synthesis_packet.json` for common-path local drafting and synthesis.
+
+Review mode overrides inherited by default:
+- diff churn exceeds a configured threshold
+- core runtime, config, or process files span multiple groups
+- generated files are present but are not the majority of the change
+
+Authority order:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+## Generic Worker Contract
+
+## Generic Adjudication Structure
+
+- This scaffold uses the `generic` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Generic flat mode does not require hierarchical `candidates[]` plus `footer` worker output.
+
+## Worker Families
+
+- The builder keeps worker-family structure generic and reusable across packet-driven workflows.
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+
+- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:
+- `repo_mapper`
+- `packet_explorer`
+- `docs_verifier`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `rules`
+  - `docs_verifier`
+- `runtime`
+  - `packet_explorer`
+- `process`
+  - `packet_explorer`
+- `testing`
+  - `evidence_summarizer`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Summary: Default reusable profile scaffold for PR writeup repair. Replace with project-local PR guidance bindings, review-doc lists, and repo-specific lint toggles when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `rules`
+    - `.github/pull_request_template.md`
+    - `CONTRIBUTING.md`
+    - `MAINTAINING.md`
+  - `runtime`
+    - `README.md`
+  - `process`
+    - `.github/pull_request_template.md`
+    - `CONTRIBUTING.md`
+    - `MAINTAINING.md`
+  - `testing`
+    - `README.md`
+    - `CONTRIBUTING.md`
+- source path globs:
+  - `rules`
+    - `.github/**`
+    - `*.md`
+  - `runtime`
+    - `src/**`
+    - `lib/**`
+    - `app/**`
+    - `server/**`
+    - `client/**`
+  - `process`
+    - `.github/**`
+    - `*.md`
+    - `docs/**`
+  - `testing`
+    - `tests/**`
+    - `**/*test*.*`
+- Default lint rules:
+- `require_readme_settings_table`: false
+- `missing_review_docs_are_errors`: false
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes
+
+- Optional local helpers remain non-authoritative even when collected.
+- Final plan confidence is recomputed locally even when worker confidence signals are present.

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/core-contract.md
@@ -135,6 +135,7 @@ Stop conditions:
 
 - Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/delegation-playbook.md
@@ -1,0 +1,85 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`
+  - no workers
+- `targeted-delegation`
+  - 1-2 workers
+- `broad-delegation`
+  - 3-4 workers
+- Optional QA worker
+  - only when `qa_required` is true or an explicit claim conflict triggers it
+
+## Local Gates
+
+- Read `rules_packet.json` locally before drafting any replacement title/body.
+- Read `synthesis_packet.json` locally before final drafting.
+- Keep common-path drafting on `rules_packet.json + synthesis_packet.json + <=1 focused packet`.
+- Re-check the final draft against `rules_packet.json` locally before `validate_pr_writeup_edit.py`.
+- Run `apply_pr_writeup.py` only from validator output.
+- Treat `packet_insufficiency` as failure, not as permission to compensate with raw reread.
+- Treat `packet_worker_map` as the routing authority for delegated packet analysis.
+
+## Shared Packet Discipline
+
+Every worker reads `global_packet.json` first.
+
+Then give the worker only:
+- one focused packet or one narrow slice from a focused packet
+- any explicitly referenced file slice only when the packet cannot carry the required evidence
+
+Do not ask workers to:
+- rediscover the whole repo state from scratch
+- reread long raw diffs without an explicit allowed reread reason
+- draft the final user-facing PR text
+- emit embedded edit code or take over the guarded `apply_pr_writeup.py` step
+
+## Worker Roles
+
+Prefer these roles:
+- `packet_explorer`
+  - `runtime_packet.json` and `process_packet.json`
+- `evidence_summarizer`
+  - `testing_packet.json`
+- optional `docs_verifier`
+  - `rules_packet.json` cross-check when the local gate still leaves ambiguity
+- optional `large_diff_auditor`
+  - QA cross-check only when `qa_required` is true
+
+## Worker Output Contract
+
+Require each worker to return exactly:
+- `primary outcome`
+- `evidence files`
+- `unsupported claims`
+- `suggested PR bullets`
+
+For the optional QA worker, require:
+- `keep_or_revise`
+- `rule violations`
+- `coverage gaps`
+- `unsupported claims`
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $gh-fix-pr-writeup at <skill-path> to analyze one PR packet.
+
+Read only:
+- <global-packet>
+- <packet-file>
+- <specific changed files if needed>
+
+Return exactly:
+- primary outcome
+- evidence files
+- unsupported claims
+- suggested PR bullets
+```
+
+Keep each worker narrow. Do not ask one worker to cover multiple packets unless `orchestrator.json` explicitly recommends a smaller split.

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as build, lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/gh-fix-pr-writeup-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/gh-fix-pr-writeup-evaluation-contract.md
@@ -1,0 +1,54 @@
+# PR Writeup Evaluation Contract
+
+Use the shared envelope in [`evaluation-log-contract.md`](evaluation-log-contract.md) and keep PR-writeup-specific metrics under `skill_specific.data`.
+
+## Required Skill-Specific Fields
+
+- `review_mode`
+- `packet_count`
+- `worker_count`
+- `rewrite_strategy`
+- `qa_required`
+- `qa_reason`
+- `qa_ran`
+- `validation_commands`
+- `edited_pr_url`
+- `common_path_sufficient`
+- `raw_reread_count`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+- `unsupported_claim_categories`
+- `evidence_gap_categories`
+
+## Build-Phase Metrics
+
+Build-phase merge should populate:
+- `packet_count`
+- `rewrite_strategy`
+- `qa_required`
+- `qa_reason`
+- `common_path_sufficient`
+- `raw_reread_count`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+
+It should also update baseline byte-proxy fields when `packet_metrics.json` is available:
+- `baseline.estimated_local_only_tokens`
+- `baseline.estimated_token_savings`
+- `baseline.estimated_delegation_savings`
+
+## Validation / Apply Signals
+
+- `validation_commands`
+  - concrete checks that actually ran before guarded mutation
+- `qa_ran`
+  - true only when a QA-required draft was actually cleared or reviewed
+- `edited_pr_url`
+  - final PR URL after a successful edit or dry-run confirmation path
+
+## Logging Rules
+
+- Keep packet bodies out of the evaluation log.
+- Keep runtime routing metadata separate from packet-size and token-efficiency metrics.
+- Prefer enums, counts, booleans, and short reason strings over free-form summaries.
+- Treat token-efficiency numbers as estimated byte-proxy regression metrics, not runtime routing inputs.

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/pr-writeup-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/references/pr-writeup-contract.md
@@ -1,0 +1,153 @@
+# PR Writeup Contract
+
+This file defines the packet, worker, validator, and apply contract for `gh-fix-pr-writeup`.
+
+## Builder Metadata
+
+- `workflow_family`: `github-review`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `packet-heavy-orchestrator`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Runtime vs Evaluation Split
+
+- `orchestrator.json` is a lean runtime contract.
+- `packet_metrics.json` is evaluation/regression metadata only.
+- Runtime packets must not carry token-efficiency counters.
+- Build-phase metrics are merged into the evaluation log from `build-result.json` / `packet_metrics.json`, not read from runtime routing metadata.
+
+## Required Packet Outputs
+
+- `orchestrator.json`
+- `global_packet.json`
+- `rules_packet.json`
+- `runtime_packet.json` when runtime evidence is active
+- `process_packet.json` when workflow/docs/config evidence is active
+- `testing_packet.json`
+- `synthesis_packet.json`
+- `packet_metrics.json`
+
+## Packet Semantics
+
+### `rules_packet.json`
+
+This is the authoritative hard-rule source.
+
+Keep only:
+- title pattern
+- required section order
+- disallowed claim categories
+- issue-ref policy
+- repo instruction excerpts
+- local gate reminders
+
+Do not put run-specific failures or drafting decisions here.
+
+### `synthesis_packet.json`
+
+This is the run-specific drafting decision packet.
+
+It must not duplicate the full rule prose from `rules_packet.json`.
+
+It must contain:
+- `rewrite_strategy`
+- `qa_required`
+- `qa_reason`
+- `active_rule_gates`
+- `current_failures`
+- `title_direction`
+- `required_sections_status`
+- `section_rewrite_requirements`
+- `supported_claims`
+- `unsupported_claim_risks`
+- `testing_evidence_status`
+- `issue_ref_status`
+- `coverage_gaps`
+- `focused_packet_hint`
+
+## Common Path Contract
+
+Common-path local drafting must close with:
+- `rules_packet.json`
+- `synthesis_packet.json`
+- at most one focused packet
+
+Rules:
+- `packet_insufficiency` is failure, not an allowed reread reason
+- raw reread is allowed only for:
+  - `sample_omission`
+  - `worker_conflict`
+  - `claim_dispute`
+  - `validator_blocker`
+
+## Worker Routing Metadata
+
+- `packet_worker_map`
+  - `runtime_packet.json -> packet_explorer`
+  - `process_packet.json -> packet_explorer`
+  - `testing_packet.json -> evidence_summarizer`
+- optional rules cross-check
+  - `rules_packet.json -> docs_verifier`
+- optional QA pass
+  - `large_diff_auditor`
+
+Rules:
+- `packet_worker_map` is the routing authority
+- `worker_selection_guidance` is explanatory only
+- `rules_packet.json` remains local-first even when a rules verifier is available
+
+## QA Trigger Policy
+
+`qa_required` must stay a rare exception.
+
+It becomes `true` only when:
+- `rewrite_strategy == full-rewrite` and `review_mode == broad-delegation`
+- worker/local findings conflict on the same claim cluster
+- raw reread reason is `worker_conflict` or `claim_dispute`
+
+It must remain `false` for:
+- `full_rewrite_likely` alone
+- small PR full rewrites without conflicting claim evidence
+
+## Validate/Apply Boundary
+
+- Final title/body synthesis stays local.
+- `validate_pr_writeup_edit.py` is the required validator.
+- `apply_pr_writeup.py` is the only supported mutation helper.
+- Apply consumes validator output only.
+- `--dry-run` follows the same validated-input path.
+- Validator output must expose:
+  - `valid`
+  - `can_apply`
+  - `errors`
+  - `warnings`
+  - `stop_reasons`
+  - `normalized_edit`
+  - `normalized_edit_fingerprint`
+  - `apply_gate_status`
+- `normalized_edit` must include:
+  - replacement title/body
+  - minimal validated snapshot
+  - validation commands
+  - review mode
+  - QA gate state
+- The minimal validated snapshot is limited to apply recheck fields:
+  - `title`
+  - `body`
+  - `url`
+  - `headRefName`
+  - `headRefOid`
+  - `baseRefName`
+  - `changed_files`
+- A `qa_required` draft must not become apply-safe without QA clear.
+- Apply must fail closed when live snapshot state changes after validation.
+
+## Final Output Shape
+
+The final user-visible result must:
+- say whether the PR already matched the rules or what changed
+- include the final PR URL
+- mention the validation commands that actually ran
+- call out blockers precisely when safe repair was not possible

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/apply_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/apply_pr_writeup.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Apply a PR title/body update only from validator output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pr_writeup_contract as contract
+import pr_writeup_tools as tools
+from validate_pr_writeup_edit import (
+    json_fingerprint,
+    load_json,
+    normalize_paths,
+    normalize_scalar,
+    stale_snapshot_fields,
+    write_json,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--validation", required=True, help="Validator output JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the planned gh command without editing the PR.")
+    parser.add_argument("--result-output", help="Optional machine-readable apply result JSON.")
+    return parser.parse_args()
+
+
+def fail(payload: dict[str, Any], result_output: Path | None, reason: str, message: str, **extra: Any) -> int:
+    payload.update(extra)
+    payload["apply_succeeded"] = False
+    payload["stop_reason"] = reason
+    payload["stop_reasons"] = [reason]
+    if result_output is not None:
+        write_json(result_output, payload)
+    print(f"apply_pr_writeup.py: {message}", file=sys.stderr)
+    return 1
+
+
+def normalized_edit_from_validation(validation: dict[str, Any]) -> dict[str, Any]:
+    normalized_edit = validation.get("normalized_edit")
+    if not isinstance(normalized_edit, dict):
+        raise RuntimeError("validator output is missing `normalized_edit`")
+    expected_fingerprint = str(validation.get("normalized_edit_fingerprint") or "").strip()
+    if not expected_fingerprint:
+        raise RuntimeError("validator output is missing `normalized_edit_fingerprint`")
+    if json_fingerprint(normalized_edit) != expected_fingerprint:
+        raise RuntimeError("validator mismatch: normalized-edit fingerprint changed")
+    if not validation.get("valid"):
+        raise RuntimeError("refusing to apply validator output marked invalid")
+    if not validation.get("can_apply"):
+        raise RuntimeError("refusing to apply validator output marked not apply-safe")
+    apply_gate_status = validation.get("apply_gate_status") or {}
+    if apply_gate_status.get("uncovered_stop_categories"):
+        raise RuntimeError("refusing to apply while applicable stop categories remain uncovered")
+    qa_gate = normalized_edit.get("qa_gate") or {}
+    if qa_gate.get("required") and not qa_gate.get("qa_clear"):
+        raise RuntimeError("refusing to apply while QA-required draft lacks QA clear signal")
+    return normalized_edit
+
+
+def main() -> int:
+    args = parse_args()
+    validation = load_json(Path(args.validation).resolve())
+    result_output = Path(args.result_output).resolve() if args.result_output else None
+    payload: dict[str, Any] = {
+        "dry_run": args.dry_run,
+        "validation_source": "validator_normalized_edit",
+        "mutation_type": "gh_pr_edit",
+        "command": None,
+    }
+
+    try:
+        normalized_edit = normalized_edit_from_validation(validation)
+    except Exception as exc:
+        return fail(payload, result_output, "validator_mismatch", str(exc))
+
+    repo_root = Path(str(normalized_edit.get("repo_root") or ".")).resolve()
+    repo_slug = normalized_edit.get("repo_slug")
+    pr_number = int(normalized_edit["pr_number"])
+    title = normalize_scalar(normalized_edit.get("title"))
+    body = str(normalized_edit.get("body") or "")
+    validated_snapshot = dict(normalized_edit.get("validated_snapshot") or {})
+
+    payload.update(
+        {
+            "pr_number": pr_number,
+            "repo_slug": repo_slug,
+            "validation_commands": list(normalized_edit.get("validation_commands") or []),
+            "normalized_edit_fingerprint": str(validation.get("normalized_edit_fingerprint") or ""),
+            "current_pr_url": normalize_scalar(validated_snapshot.get("url")),
+            "qa_required": bool((normalized_edit.get("qa_gate") or {}).get("required")),
+            "qa_clear": bool((normalized_edit.get("qa_gate") or {}).get("qa_clear")),
+        }
+    )
+
+    try:
+        tools.run_command(["gh", "auth", "status"], cwd=repo_root)
+    except Exception as exc:
+        return fail(payload, result_output, "missing_auth", str(exc))
+
+    try:
+        live_pr = tools.load_pr_metadata(pr_number, repo_root, repo_slug)
+        live_changed_files = tools.load_pr_changed_files(pr_number, repo_root, repo_slug)
+    except Exception as exc:
+        return fail(payload, result_output, "live_snapshot_unavailable", str(exc))
+
+    stale_fields = stale_snapshot_fields(validated_snapshot, live_pr, live_changed_files)
+    if stale_fields:
+        return fail(
+            payload,
+            result_output,
+            "stale_context",
+            "the live PR snapshot changed after validation; rerun validation before editing",
+            stale_fields=stale_fields,
+        )
+
+    qa_gate = normalized_edit.get("qa_gate") or {}
+    if qa_gate.get("required") and not qa_gate.get("qa_clear"):
+        return fail(
+            payload,
+            result_output,
+            "qa_required",
+            "the draft still requires QA clearance before apply",
+            apply_gate_status=contract.stop_status(),
+        )
+
+    temp_root = repo_root / ".codex" / "tmp" / "packet-workflow" / "gh-fix-pr-writeup"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        suffix=".md",
+        dir=temp_root,
+        delete=False,
+    ) as temp_file:
+        temp_file.write(body)
+        temp_path = Path(temp_file.name)
+    try:
+        command = ["gh", "pr", "edit", str(pr_number), "--title", title, "--body-file", str(temp_path)]
+        if repo_slug:
+            command.extend(["--repo", str(repo_slug)])
+        payload["command"] = command
+
+        if args.dry_run:
+            payload["apply_succeeded"] = True
+            if result_output is not None:
+                write_json(result_output, payload)
+            print(json.dumps(payload, indent=2, ensure_ascii=True))
+            return 0
+
+        try:
+            tools.run_command(command, cwd=repo_root)
+            confirmed = tools.load_pr_metadata(pr_number, repo_root, repo_slug)
+        except Exception as exc:
+            return fail(payload, result_output, "apply_failed", str(exc))
+
+        if normalize_scalar(confirmed.get("title")) != title or normalize_scalar(confirmed.get("body")) != body.strip():
+            return fail(
+                payload,
+                result_output,
+                "apply_verification_failed",
+                "gh pr edit returned, but the confirmed PR title/body do not match the requested replacement",
+                confirmed_pr_url=normalize_scalar(confirmed.get("url")),
+            )
+
+        payload["current_pr_url"] = normalize_scalar(confirmed.get("url"))
+        payload["apply_succeeded"] = True
+        if result_output is not None:
+            write_json(result_output, payload)
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+        return 0
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/build_pr_review_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/build_pr_review_packets.py
@@ -1,0 +1,713 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import lint_pr_writeup as lint_tools
+import pr_writeup_contract as contract
+
+
+SMALL_FILE_LIMIT = contract.SMALL_FILE_LIMIT
+MEDIUM_FILE_LIMIT = contract.MEDIUM_FILE_LIMIT
+SMALL_GROUP_LIMIT = contract.SMALL_GROUP_LIMIT
+LARGE_GROUP_LIMIT = contract.LARGE_GROUP_LIMIT
+LARGE_CHURN_LIMIT = 1500
+VERY_LARGE_CHURN_LIMIT = 3000
+MEANINGFUL_GENERATED_FILE_MIN_COUNT = 3
+MEANINGFUL_GENERATED_FILE_MIN_RATIO = 0.2
+GENERATED_FILE_PATTERNS = (
+    re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
+    re.compile(r"\.(g|generated)\.[^.]+$"),
+    re.compile(r"\.designer\.[^.]+$"),
+    re.compile(r"(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|cargo\.lock)$"),
+    re.compile(r"\.min\.(js|css)$"),
+)
+
+STANDARD_RETURN_CONTRACT = contract.STANDARD_RETURN_CONTRACT
+QA_REQUIRED_INPUTS = contract.QA_REQUIRED_INPUTS
+QA_RETURN_CONTRACT = contract.QA_RETURN_CONTRACT
+PREFERRED_WORKER_FAMILIES = contract.PREFERRED_WORKER_FAMILIES
+PACKET_WORKER_MAP = contract.PACKET_WORKER_MAP
+WORKER_SELECTION_GUIDANCE = contract.WORKER_SELECTION_GUIDANCE
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return contract.load_json(path)
+
+
+def active_groups(group_summary: dict[str, dict[str, object]]) -> list[str]:
+    ordered_names = ("runtime", "automation", "docs", "tests", "config", "other")
+    return [name for name in ordered_names if (group_summary.get(name) or {}).get("count", 0) > 0]
+
+
+def parse_diff_totals(diff_stat: str | None) -> dict[str, int] | None:
+    if not diff_stat:
+        return None
+    last_line = diff_stat.strip().splitlines()[-1]
+    files_match = re.search(r"(?P<files>\d+) files? changed", last_line)
+    insertions_match = re.search(r"(?P<insertions>\d+) insertions?\(\+\)", last_line)
+    deletions_match = re.search(r"(?P<deletions>\d+) deletions?\(-\)", last_line)
+    if not files_match and not insertions_match and not deletions_match:
+        return None
+    files_changed = int(files_match.group("files")) if files_match else 0
+    insertions = int(insertions_match.group("insertions")) if insertions_match else 0
+    deletions = int(deletions_match.group("deletions")) if deletions_match else 0
+    return {
+        "files_changed": files_changed,
+        "insertions": insertions,
+        "deletions": deletions,
+        "churn": insertions + deletions,
+    }
+
+
+def is_generated_file(path: str) -> bool:
+    lowered = path.replace("\\", "/").lower()
+    return any(pattern.search(lowered) for pattern in GENERATED_FILE_PATTERNS)
+
+
+def core_area_for_path(path: str) -> str | None:
+    lowered = path.replace("\\", "/").lower()
+    runtime_prefixes = (
+        "src/",
+        "lib/",
+        "app/",
+        "server/",
+        "client/",
+    )
+    runtime_files: set[str] = set()
+    process_prefixes = (
+        ".github/workflows/",
+        ".github/scripts/",
+        ".github/issue_template/",
+        ".github/instructions/",
+    )
+    process_files = {
+        ".github/pull_request_template.md",
+        "contributing.md",
+        "maintaining.md",
+    }
+    config_suffixes = (".csproj", ".props", ".targets")
+    config_files = {
+        "pyproject.toml",
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "poetry.lock",
+    }
+    if lowered.startswith(runtime_prefixes) or lowered in runtime_files:
+        return "runtime"
+    if lowered.startswith(process_prefixes) or lowered in process_files:
+        return "process"
+    if lowered.endswith(config_suffixes) or lowered in config_files:
+        return "config"
+    return None
+
+
+def testing_findings(findings: dict[str, Any]) -> list[str]:
+    messages = list(findings.get("errors", [])) + list(findings.get("warnings", []))
+    return [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("testing", "tested", "command", "verification"))
+    ]
+
+
+def full_rewrite_likely(body: str, findings: dict[str, Any]) -> bool:
+    if not body.strip():
+        return True
+    rewrite_signals = (
+        "missing template sections",
+        "template order",
+        "placeholder",
+        "template guidance text",
+        "blank nested bullet",
+        "empty bullet",
+    )
+    for message in findings.get("errors", []):
+        lowered = message.lower()
+        if any(signal in lowered for signal in rewrite_signals):
+            return True
+    return False
+
+
+def determine_review_mode(
+    *,
+    file_count: int,
+    group_count: int,
+    diff_totals: dict[str, int] | None,
+    runtime_active: bool,
+    process_active: bool,
+    testing_relevant: bool,
+    override_signals: list[dict[str, object]],
+) -> tuple[str, int]:
+    churn = (diff_totals or {}).get("churn", 0)
+    if file_count <= SMALL_FILE_LIMIT and group_count <= SMALL_GROUP_LIMIT:
+        review_mode = "local-only"
+    elif file_count > MEDIUM_FILE_LIMIT or group_count >= LARGE_GROUP_LIMIT:
+        review_mode = "broad-delegation"
+    else:
+        review_mode = "targeted-delegation"
+
+    if override_signals and review_mode == "local-only":
+        review_mode = "targeted-delegation"
+    elif override_signals and review_mode == "targeted-delegation":
+        review_mode = "broad-delegation"
+
+    if review_mode == "local-only":
+        return review_mode, 0
+    if review_mode == "targeted-delegation":
+        return review_mode, 2
+
+    worker_count = 3
+    if (
+        (runtime_active and process_active and testing_relevant)
+        or churn >= VERY_LARGE_CHURN_LIMIT
+        or group_count >= 5
+        or bool(override_signals)
+    ):
+        worker_count = 4
+    return review_mode, worker_count
+
+
+def focus_packet_name(groups: dict[str, dict[str, Any]], findings: dict[str, Any]) -> str | None:
+    testing_group = (groups.get("tests") or {}).get("count", 0)
+    runtime_group = (groups.get("runtime") or {}).get("count", 0)
+    process_group = sum((groups.get(name) or {}).get("count", 0) for name in ("automation", "docs", "config"))
+    if testing_group or testing_findings(findings):
+        return "testing_packet.json"
+    if runtime_group:
+        return "runtime_packet.json"
+    if process_group:
+        return "process_packet.json"
+    return None
+
+
+def default_review_overrides(
+    *,
+    context: dict[str, Any],
+    diff_totals: dict[str, int] | None,
+    core_areas_touched: list[str],
+    generated_file_count: int,
+    generated_file_ratio: float,
+) -> list[dict[str, str]]:
+    changed_files = list(context.get("changed_files", []))
+    overrides: list[dict[str, str]] = []
+    if (diff_totals or {}).get("churn", 0) >= LARGE_CHURN_LIMIT:
+        overrides.append(
+            {
+                "reason": "diff_stat_threshold",
+                "detail": f"Diff churn reached {(diff_totals or {}).get('churn', 0)} lines (threshold {LARGE_CHURN_LIMIT}).",
+            }
+        )
+    if len(core_areas_touched) >= 2:
+        overrides.append(
+            {
+                "reason": "core_files_across_groups",
+                "detail": "Core runtime/config/process files were touched across multiple groups: "
+                + ", ".join(core_areas_touched),
+            }
+        )
+    if (
+        generated_file_count >= MEANINGFUL_GENERATED_FILE_MIN_COUNT
+        and MEANINGFUL_GENERATED_FILE_MIN_RATIO <= generated_file_ratio < 0.5
+    ):
+        overrides.append(
+            {
+                "reason": "generated_files_meaningful_minor_slice",
+                "detail": "Generated files are a meaningful minority slice "
+                f"({generated_file_count}/{len(changed_files)}); increase review depth so hand-authored changes are not crowded out.",
+            }
+        )
+    return overrides
+
+
+def build_rules_packet(context: dict[str, Any]) -> dict[str, Any]:
+    snippets = context.get("instruction_snippets") or {}
+    return {
+        "purpose": "Authoritative hard-rule source for PR title/body drafting.",
+        "authoritative": True,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "title_pattern": "<type>(<scope>): <summary>",
+        "required_sections": list(context.get("expected_template_sections") or []),
+        "disallowed_claim_categories": [
+            "unsupported testing or manual verification claims",
+            "unsupported issue references",
+            "unsupported defaults or threshold claims",
+            "unsupported reload/restart claims",
+            "unsupported migration or compatibility claims",
+        ],
+        "issue_ref_policy": "Only cite linked issues that are present in PR metadata or already verifiable in the repo state.",
+        "repo_instruction_excerpts": {
+            "pull_request_title_rules_excerpt": snippets.get("pull_request_title_rules_excerpt"),
+            "pull_request_template_sections": snippets.get("pull_request_template_sections"),
+            "commit_types_excerpt": snippets.get("commit_types_excerpt"),
+        },
+        "rule_files": context.get("rule_files", {}),
+        "local_gate": [
+            "Read this packet locally before drafting any replacement title/body.",
+            "Treat this packet as the authority source for hard rules; synthesis_packet only carries rule application results for this PR.",
+            "Re-check the final draft against this packet before validation.",
+        ],
+    }
+
+
+def build_global_packet(
+    context: dict[str, Any],
+    *,
+    review_mode: str,
+    override_signals: list[dict[str, str]],
+    focused_packet_hint: str | None,
+) -> dict[str, Any]:
+    pr = context.get("pr") or {}
+    return {
+        "purpose": "Shared runtime context for local orchestration and narrow delegated packet analysis.",
+        "workflow_family": contract.WORKFLOW_FAMILY,
+        "archetype": contract.ARCHETYPE,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "repo_profile": context.get("repo_profile"),
+        "pr": {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "url": pr.get("url"),
+            "linked_issues": pr.get("closingIssuesReferences") or [],
+        },
+        "review_mode": review_mode,
+        "authority_order": [
+            "rules_packet.json",
+            "synthesis_packet.json",
+            "focused packet evidence",
+            "explicit local reread only for allowed reasons",
+        ],
+        "packet_worker_map": contract.PACKET_WORKER_MAP,
+        "preferred_worker_families": contract.PREFERRED_WORKER_FAMILIES,
+        "worker_selection_guidance": contract.WORKER_SELECTION_GUIDANCE,
+        "raw_reread_policy": {
+            "allowed_reasons": contract.RAW_REREAD_ALLOWED_REASONS,
+            "packet_insufficiency_is_failure": True,
+            "common_path_expected": True,
+        },
+        "qa_policy": contract.QA_TRIGGER_POLICY,
+        "focused_packet_hint": focused_packet_hint,
+        "review_overrides": override_signals,
+        "local_gate_reminders": [
+            "Keep final title/body synthesis local.",
+            "Use rules_packet.json as the only authority source for hard constraints.",
+            "Use synthesis_packet.json as the run-specific decision packet.",
+            "Treat raw reread as exceptional, not compensatory.",
+        ],
+    }
+
+
+def build_runtime_packet(context: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    groups = context.get("changed_file_groups") or {}
+    runtime_group = groups.get("runtime") or {"count": 0, "sample_files": []}
+    return {
+        "purpose": "Runtime behavior and shipped-impact evidence slice.",
+        "ownership_summary": "Use this packet for runtime behavior, settings impact, reload/restart risk, and runtime claim anchoring.",
+        "github_evidence_slice": {
+            "changed_files": list(runtime_group.get("sample_files", [])),
+            "diff_stat": context.get("diff_stat"),
+        },
+        "claim_basis": {
+            "supported_claims": [
+                item for item in drafting_basis.get("supported_claims", []) if item.get("cluster") == "runtime"
+            ],
+            "coverage_gaps": list(drafting_basis.get("coverage_gaps", [])),
+        },
+    }
+
+
+def build_process_packet(context: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    groups = context.get("changed_file_groups") or {}
+    selected_files: list[str] = []
+    process_groups: dict[str, Any] = {}
+    for group_name in ("automation", "docs", "config"):
+        packet_group = groups.get(group_name) or {"count": 0, "sample_files": []}
+        process_groups[group_name] = packet_group
+        selected_files.extend(list(packet_group.get("sample_files", [])))
+    return {
+        "purpose": "Workflow, configuration, and documentation evidence slice.",
+        "ownership_summary": "Use this packet for workflow/config/docs changes that influence PR wording or risk framing.",
+        "github_evidence_slice": {
+            "changed_files": selected_files,
+            "diff_stat": context.get("diff_stat"),
+        },
+        "claim_basis": {
+            "supported_claims": [
+                item for item in drafting_basis.get("supported_claims", []) if item.get("cluster") == "process"
+            ],
+            "coverage_gaps": list(drafting_basis.get("coverage_gaps", [])),
+            "process_groups": process_groups,
+        },
+    }
+
+
+def build_testing_packet(context: dict[str, Any], lint_report: dict[str, Any], drafting_basis: dict[str, Any]) -> dict[str, Any]:
+    groups = context.get("changed_file_groups") or {}
+    findings = lint_report.get("findings", {})
+    return {
+        "purpose": "Testing-claims evidence slice.",
+        "ownership_summary": "Use this packet for testing commands, unsupported verification risks, and coverage gaps tied to validation language.",
+        "github_evidence_slice": {
+            "changed_test_files": list((groups.get("tests") or {}).get("sample_files", [])),
+            "diff_stat": context.get("diff_stat"),
+        },
+        "testing_evidence_status": drafting_basis.get("testing_evidence_status"),
+        "lint_testing_findings": testing_findings(findings),
+        "unsupported_claim_risks": list(drafting_basis.get("unsupported_claim_risks", [])),
+    }
+
+
+def build_synthesis_packet(
+    context: dict[str, Any],
+    *,
+    review_mode: str,
+    drafting_basis: dict[str, Any],
+    focused_packet_hint: str | None,
+) -> dict[str, Any]:
+    rewrite_strategy = str(drafting_basis.get("rewrite_strategy") or "targeted-touch-up")
+    qa_required, qa_reason = contract.should_require_qa(
+        rewrite_strategy=rewrite_strategy,
+        review_mode=review_mode,
+    )
+    return {
+        "purpose": "Run-specific drafting decision packet for local final PR title/body synthesis.",
+        "local_only": True,
+        "rewrite_strategy": rewrite_strategy,
+        "qa_required": qa_required,
+        "qa_reason": qa_reason,
+        "active_rule_gates": list(drafting_basis.get("active_rule_gates", [])),
+        "current_failures": drafting_basis.get("current_failures", {}),
+        "title_direction": drafting_basis.get("title_direction"),
+        "required_sections_status": drafting_basis.get("required_sections_status"),
+        "section_rewrite_requirements": list(drafting_basis.get("section_rewrite_requirements", [])),
+        "supported_claims": list(drafting_basis.get("supported_claims", [])),
+        "unsupported_claim_risks": list(drafting_basis.get("unsupported_claim_risks", [])),
+        "testing_evidence_status": drafting_basis.get("testing_evidence_status"),
+        "issue_ref_status": drafting_basis.get("issue_ref_status"),
+        "coverage_gaps": list(drafting_basis.get("coverage_gaps", [])),
+        "focused_packet_hint": focused_packet_hint,
+        "common_path_contract": {
+            "required_packets": contract.COMMON_PATH_REQUIRED_PACKETS,
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "sufficient_for_local_final_drafting": True,
+            "packet_insufficiency_is_failure": True,
+            "raw_reread_allowed_reasons": contract.RAW_REREAD_ALLOWED_REASONS,
+        },
+        "pr_identity": {
+            "number": context.get("pr", {}).get("number"),
+            "url": context.get("pr", {}).get("url"),
+        },
+    }
+
+
+def raw_local_bundle(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "context": context,
+        "lint_findings": lint_report.get("findings"),
+        "drafting_basis": lint_report.get("drafting_basis"),
+    }
+
+
+def build_worker_specs(
+    *,
+    review_mode: str,
+    worker_count: int,
+    runtime_active: bool,
+    process_active: bool,
+    testing_relevant: bool,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    recommended: list[dict[str, Any]] = []
+    optional: list[dict[str, Any]] = []
+
+    delegated_packets: list[tuple[str, str, str, str, str | None]] = []
+    if runtime_active:
+        delegated_packets.append(
+            (
+                "runtime",
+                "packet_explorer",
+                "runtime_packet.json",
+                "Summarize shipped runtime behavior and settings impact.",
+                "gpt-5.4-mini",
+            )
+        )
+    if process_active:
+        delegated_packets.append(
+            (
+                "process",
+                "packet_explorer",
+                "process_packet.json",
+                "Summarize automation, docs, and config changes worth mentioning.",
+                "gpt-5.4-mini",
+            )
+        )
+    if testing_relevant:
+        delegated_packets.append(
+            (
+                "testing",
+                "evidence_summarizer",
+                "testing_packet.json",
+                "Check testing claims and unsupported evidence.",
+                None,
+            )
+        )
+
+    for name, agent_type, packet_name, responsibility, model in delegated_packets[:worker_count]:
+        worker: dict[str, Any] = {
+            "name": name,
+            "agent_type": agent_type,
+            "packets": ["global_packet.json", packet_name],
+            "responsibility": responsibility,
+            "reasoning_effort": "medium" if agent_type != "evidence_summarizer" else "low",
+            "return_contract": contract.STANDARD_RETURN_CONTRACT,
+        }
+        if model:
+            worker["model"] = model
+        recommended.append(worker)
+
+    optional.append(
+        {
+            "name": "rules-cross-check",
+            "agent_type": "docs_verifier",
+            "packets": ["global_packet.json", "rules_packet.json"],
+            "responsibility": "Cross-check the local rules gate when the final draft still has template or claim ambiguity.",
+            "reasoning_effort": "medium",
+            "when": "Only add this pass when direct local inspection of rules_packet.json still leaves ambiguity.",
+            "return_contract": contract.STANDARD_RETURN_CONTRACT,
+        }
+    )
+    optional.append(
+        {
+            "name": "qa",
+            "agent_type": "large_diff_auditor",
+            "packets": ["global_packet.json", "rules_packet.json"],
+            "responsibility": "Compare the drafted replacement title/body against the diff coverage and template requirements.",
+            "reasoning_effort": "medium",
+            "when": "Only add this pass when qa_required is true or a claim conflict explicitly triggers QA.",
+            "required_inputs": contract.QA_REQUIRED_INPUTS,
+            "return_contract": contract.QA_RETURN_CONTRACT,
+        }
+    )
+    return recommended, optional
+
+
+def build_packet_payloads(context: dict[str, Any], lint_report: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    findings = lint_report.get("findings", {})
+    body = str((context.get("pr") or {}).get("body") or "")
+    groups = context.get("changed_file_groups") or {}
+    active_group_names = active_groups(groups)
+    changed_files = list(context.get("changed_files", []))
+    file_count = len(changed_files)
+    group_count = len(active_group_names)
+    diff_totals = parse_diff_totals(context.get("diff_stat"))
+    generated_file_count = sum(1 for path in changed_files if is_generated_file(path))
+    generated_file_ratio = (generated_file_count / file_count) if file_count else 0.0
+    core_areas_touched = sorted(
+        {
+            area
+            for path in changed_files
+            if (area := core_area_for_path(path)) is not None
+        }
+    )
+
+    runtime_active = (groups.get("runtime") or {}).get("count", 0) > 0
+    process_active = any((groups.get(name) or {}).get("count", 0) > 0 for name in ("automation", "docs", "config"))
+    testing_relevant = (
+        (groups.get("tests") or {}).get("count", 0) > 0
+        or bool(testing_findings(findings))
+        or bool(lint_tools.section_text(context, "Testing"))
+    )
+
+    override_signals = default_review_overrides(
+        context=context,
+        diff_totals=diff_totals,
+        core_areas_touched=core_areas_touched,
+        generated_file_count=generated_file_count,
+        generated_file_ratio=generated_file_ratio,
+    )
+    review_mode, worker_count = determine_review_mode(
+        file_count=file_count,
+        group_count=group_count,
+        diff_totals=diff_totals,
+        runtime_active=runtime_active,
+        process_active=process_active,
+        testing_relevant=testing_relevant,
+        override_signals=override_signals,
+    )
+
+    drafting_basis = lint_report.get("drafting_basis") or lint_tools.build_drafting_basis(
+        context,
+        findings,
+        rewrite_hint=full_rewrite_likely(body, findings),
+    )
+    focused_packet_hint = focus_packet_name(groups, findings)
+
+    runtime_packet = build_runtime_packet(context, drafting_basis) if runtime_active else None
+    process_packet = build_process_packet(context, drafting_basis) if process_active else None
+    testing_packet = build_testing_packet(context, lint_report, drafting_basis)
+    synthesis_packet = build_synthesis_packet(
+        context,
+        review_mode=review_mode,
+        drafting_basis=drafting_basis,
+        focused_packet_hint=focused_packet_hint,
+    )
+    common_path_packets = ["rules_packet.json", "synthesis_packet.json"]
+    if focused_packet_hint:
+        common_path_packets.append(focused_packet_hint)
+
+    packet_payloads: dict[str, Any] = {
+        "global_packet.json": build_global_packet(
+            context,
+            review_mode=review_mode,
+            override_signals=override_signals,
+            focused_packet_hint=focused_packet_hint,
+        ),
+        "rules_packet.json": build_rules_packet(context),
+        "testing_packet.json": testing_packet,
+        "synthesis_packet.json": synthesis_packet,
+    }
+    if runtime_packet is not None:
+        packet_payloads["runtime_packet.json"] = runtime_packet
+    if process_packet is not None:
+        packet_payloads["process_packet.json"] = process_packet
+
+    recommended_workers, optional_workers = build_worker_specs(
+        review_mode=review_mode,
+        worker_count=worker_count,
+        runtime_active=runtime_active,
+        process_active=process_active,
+        testing_relevant=testing_relevant,
+    )
+
+    packet_metrics = contract.compute_packet_metrics(
+        packet_payloads,
+        common_path_packet_names=common_path_packets,
+        raw_local_payload=raw_local_bundle(context, lint_report),
+    )
+    packet_metrics["raw_reread_allowed_reasons"] = contract.RAW_REREAD_ALLOWED_REASONS
+    packet_metrics["common_path_packets"] = common_path_packets
+    packet_metrics["common_path_sufficient"] = True
+    packet_metrics["raw_reread_count"] = 0
+    packet_metrics["packet_insufficiency_is_failure"] = True
+
+    packet_files = list(packet_payloads.keys()) + ["orchestrator.json"]
+    build_result = {
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "optional_worker_count": len(optional_workers),
+        "packet_files": packet_files,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "shared_local_packet": contract.SHARED_LOCAL_PACKET,
+        "common_path_contract": {
+            "required_packets": contract.COMMON_PATH_REQUIRED_PACKETS,
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "packet_insufficiency_is_failure": True,
+        },
+        "rewrite_strategy": synthesis_packet["rewrite_strategy"],
+        "qa_required": synthesis_packet["qa_required"],
+        "qa_reason": synthesis_packet["qa_reason"],
+        "raw_reread_count": 0,
+        "common_path_sufficient": True,
+        "packet_metrics": packet_metrics,
+    }
+
+    orchestrator = {
+        "workflow_family": contract.WORKFLOW_FAMILY,
+        "archetype": contract.ARCHETYPE,
+        "orchestrator_profile": contract.ORCHESTRATOR_PROFILE,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "optional_worker_count": len(optional_workers),
+        "shared_packet": "global_packet.json",
+        "shared_local_packet": contract.SHARED_LOCAL_PACKET,
+        "decision_ready_packets": contract.DECISION_READY_PACKETS,
+        "worker_return_contract": contract.WORKER_RETURN_CONTRACT,
+        "worker_output_shape": contract.WORKER_OUTPUT_SHAPE,
+        "preferred_worker_families": contract.PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": contract.PACKET_WORKER_MAP,
+        "worker_selection_guidance": contract.WORKER_SELECTION_GUIDANCE,
+        "review_overrides": override_signals,
+        "raw_reread_allowed_reasons": contract.RAW_REREAD_ALLOWED_REASONS,
+        "common_path_contract": {
+            "required_packets": contract.COMMON_PATH_REQUIRED_PACKETS,
+            "max_additional_focused_packets": contract.COMMON_PATH_MAX_FOCUSED_PACKETS,
+            "packet_insufficiency_is_failure": True,
+            "raw_reread_should_be_exceptional": True,
+        },
+        "qa_policy": contract.QA_TRIGGER_POLICY,
+        "local_responsibilities": [
+            "Read rules_packet.json locally before drafting any replacement title/body.",
+            "Read synthesis_packet.json locally before final drafting and keep common-path drafting on those packets plus at most one focused packet.",
+            "Treat packet insufficiency as failure, not as permission to compensate with raw reread.",
+            "Draft the final title/body locally.",
+            "Run validate_pr_writeup_edit.py before any mutation.",
+            "Run apply_pr_writeup.py only from validator output.",
+        ],
+        "packet_files": packet_files,
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+        "current_writeup": {
+            "title_matches_conventional_commit": context.get("checks", {}).get("title_matches_conventional_commit"),
+            "body_has_template_sections": context.get("checks", {}).get("body_has_template_sections"),
+            "lint_error_count": len(findings.get("errors", [])),
+            "lint_warning_count": len(findings.get("warnings", [])),
+            "full_rewrite_likely": full_rewrite_likely(body, findings),
+            "rewrite_strategy": synthesis_packet["rewrite_strategy"],
+            "qa_required": synthesis_packet["qa_required"],
+        },
+    }
+    packet_payloads["orchestrator.json"] = orchestrator
+    packet_payloads["packet_metrics.json"] = packet_metrics
+    return packet_payloads, build_result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build packet-heavy PR review packets with lean runtime metadata."
+    )
+    parser.add_argument("--context", required=True, help="Path to JSON from collect_pr_context.py")
+    parser.add_argument("--lint", required=True, help="Path to JSON from lint_pr_writeup.py")
+    parser.add_argument("--output-dir", required=True, help="Directory for generated packets")
+    parser.add_argument("--result-output", help="Optional output path for build result JSON")
+    args = parser.parse_args()
+
+    context = load_json(Path(args.context))
+    lint_report = load_json(Path(args.lint))
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    packets, build_result = build_packet_payloads(context, lint_report)
+    for file_name, payload in packets.items():
+        contract.write_json(output_dir / file_name, payload)
+    if args.result_output:
+        contract.write_json(Path(args.result_output), build_result)
+
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output_dir),
+                "review_mode": build_result["review_mode"],
+                "packet_files": build_result["packet_files"],
+                "recommended_worker_count": build_result["recommended_worker_count"],
+                "packet_metrics_file": str(output_dir / "packet_metrics.json"),
+                "estimated_delegation_savings": build_result["packet_metrics"]["estimated_delegation_savings"],
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/collect_pr_context.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/collect_pr_context.py
@@ -1,0 +1,181 @@
+﻿from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+from pr_writeup_tools import build_context
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise SystemExit(f"[ERROR] Missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise SystemExit("[ERROR] Repo profile must be a JSON object.")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect structured context for auditing a GitHub PR writeup."
+    )
+    parser.add_argument("pr_number", type=int, help="Pull request number")
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root containing .git and PR guidance files",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Optional GitHub repo slug such as owner/name",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional output file path. Prints JSON to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    profile_path = resolve_profile_path(args.profile, repo_root)
+    repo_profile = load_repo_profile(profile_path)
+    try:
+        context = build_context(
+            pr_number=args.pr_number,
+            repo_root=repo_root,
+            repo_slug=args.repo,
+        )
+    except RuntimeError as exc:
+        print(f"collect_pr_context.py: {exc}", file=sys.stderr)
+        return 1
+    context["repo_profile_name"] = repo_profile.get("name")
+    context["repo_profile_path"] = profile_path.as_posix()
+    context["repo_profile_summary"] = repo_profile.get("summary")
+    context["repo_profile"] = repo_profile
+    context["builder_compatibility"] = build_builder_compatibility(repo_profile)
+    payload = json.dumps(context, indent=2, ensure_ascii=True)
+
+    if context["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(context["builder_compatibility"]), file=sys.stderr)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/lint_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/lint_pr_writeup.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from pr_writeup_tools import PR_TITLE_RE, build_context
+
+
+PLACEHOLDER_PATTERNS = [
+    (re.compile(r"^- $", re.MULTILINE), "Template contains an empty bullet (`- `)."),
+    (
+        re.compile(r"Refs:\s*#$", re.MULTILINE),
+        "Template still contains the placeholder `Refs: #`.",
+    ),
+    (
+        re.compile(r"Note any important defaults, thresholds, reload/restart requirements, or", re.MULTILINE),
+        "Template guidance text is still present in `How`.",
+    ),
+    (
+        re.compile(r"^\s*-\s*$", re.MULTILINE),
+        "Body contains a blank nested bullet.",
+    ),
+    (
+        re.compile(r"If not tested, state why\.", re.MULTILINE),
+        "Template reminder `If not tested, state why.` was not replaced.",
+    ),
+]
+ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
+CANDIDATE_CLAIM_PATTERNS = (
+    (
+        re.compile(r"\b(restart|reload)\b", re.IGNORECASE),
+        "Candidate writeup introduces restart or reload claims that need direct verification.",
+    ),
+    (
+        re.compile(r"\bmigration\b", re.IGNORECASE),
+        "Candidate writeup introduces migration claims that need direct verification.",
+    ),
+    (
+        re.compile(r"\b(default|defaults|threshold|thresholds)\b", re.IGNORECASE),
+        "Candidate writeup introduces default or threshold claims that need direct verification.",
+    ),
+)
+
+
+def section_bodies(markdown_text: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                result[current] = "\n".join(buffer).strip()
+            current = line[3:].strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        result[current] = "\n".join(buffer).strip()
+    return result
+
+
+def ordered_subset(expected: list[str], actual: list[str]) -> bool:
+    position = 0
+    for heading in expected:
+        while position < len(actual) and actual[position] != heading:
+            position += 1
+        if position >= len(actual):
+            return False
+        position += 1
+    return True
+
+
+def section_text(context: dict, heading: str) -> str:
+    body = context.get("pr", {}).get("body") or ""
+    return section_bodies(body).get(heading, "")
+
+
+def referenced_issue_numbers(body: str) -> set[str]:
+    refs_line = next((line for line in body.splitlines() if line.lower().startswith("refs:")), "")
+    return {match.group("number") for match in ISSUE_REF_PATTERN.finditer(refs_line)}
+
+
+def support_corpus(context: dict) -> str:
+    pr = context.get("pr") or {}
+    parts = [
+        str(pr.get("title") or ""),
+        str(pr.get("body") or ""),
+        str(context.get("diff_stat") or ""),
+        " ".join(str(path) for path in context.get("changed_files", []) if str(path).strip()),
+    ]
+    return "\n".join(parts).lower()
+
+
+def candidate_claim_findings(candidate_context: dict, original_context: dict) -> list[str]:
+    body = str(candidate_context.get("pr", {}).get("body") or "")
+    original_corpus = support_corpus(original_context)
+    findings: list[str] = []
+    for pattern, message in CANDIDATE_CLAIM_PATTERNS:
+        if pattern.search(body) and not pattern.search(original_corpus):
+            findings.append(message)
+    testing = section_text(candidate_context, "Testing")
+    if testing and re.search(r"\b(verified|validated|manual(?:ly)?|tested)\b", testing, flags=re.IGNORECASE):
+        if not re.search(r"`[^`]+`", testing):
+            findings.append(
+                "Candidate `Testing` claims verification without citing an exact command or concrete step."
+            )
+    return findings
+
+
+def full_rewrite_relative_to_original(candidate_context: dict, original_context: dict) -> bool:
+    candidate_sections = section_bodies(str(candidate_context.get("pr", {}).get("body") or ""))
+    original_sections = section_bodies(str(original_context.get("pr", {}).get("body") or ""))
+    shared_sections = [name for name in candidate_sections if name in original_sections]
+    if not shared_sections:
+        return False
+    changed_sections = 0
+    for section in shared_sections:
+        if candidate_sections.get(section, "").strip() != original_sections.get(section, "").strip():
+            changed_sections += 1
+    if len(shared_sections) >= 4 and changed_sections >= max(4, len(shared_sections) - 1):
+        return True
+    candidate_title = str(candidate_context.get("pr", {}).get("title") or "").strip()
+    original_title = str(original_context.get("pr", {}).get("title") or "").strip()
+    return candidate_title != original_title and changed_sections == len(shared_sections)
+
+
+def rewrite_strategy_for_findings(context: dict, findings: dict, *, rewrite_hint: bool | None = None) -> str:
+    if rewrite_hint is True:
+        return "full-rewrite"
+    if rewrite_hint is False:
+        pass
+    if not (context.get("pr", {}).get("body") or "").strip():
+        return "full-rewrite"
+    error_messages = [str(item).lower() for item in findings.get("errors", [])]
+    if any(
+        token in message
+        for message in error_messages
+        for token in (
+            "missing template sections",
+            "template order",
+            "placeholder",
+            "template guidance text",
+            "blank nested bullet",
+            "empty bullet",
+        )
+    ):
+        return "full-rewrite"
+    if error_messages:
+        return "section-rewrite"
+    if findings.get("warnings"):
+        return "targeted-touch-up"
+    return "keep"
+
+
+def risky_claim_categories(body: str) -> list[str]:
+    categories: list[str] = []
+    lowered = body.lower()
+    if re.search(r"\b(restart|reload)\b", lowered):
+        categories.append("reload_restart")
+    if re.search(r"\bmigration\b", lowered):
+        categories.append("migration")
+    if re.search(r"\b(default|defaults|threshold|thresholds)\b", lowered):
+        categories.append("defaults_thresholds")
+    return categories
+
+
+def testing_status(context: dict) -> dict[str, object]:
+    testing = section_text(context, "Testing")
+    has_command = bool(re.search(r"`[^`]+`", testing))
+    return {
+        "present": bool(testing.strip()),
+        "has_exact_command": has_command,
+        "status": "supported" if testing.strip() and has_command else ("missing" if not testing.strip() else "needs-recheck"),
+    }
+
+
+def issue_ref_status(context: dict) -> dict[str, object]:
+    body = str(context.get("pr", {}).get("body") or "")
+    metadata_refs = {
+        str(item.get("number"))
+        for item in (context.get("pr", {}).get("closingIssuesReferences") or [])
+        if str(item.get("number") or "").strip()
+    }
+    body_refs = referenced_issue_numbers(body)
+    matched = sorted(metadata_refs & body_refs)
+    return {
+        "metadata_refs": sorted(metadata_refs),
+        "body_refs": sorted(body_refs),
+        "matched_refs": matched,
+        "status": (
+            "aligned"
+            if matched or (not metadata_refs and not body_refs)
+            else ("missing-body-ref" if metadata_refs and not body_refs else "needs-recheck")
+        ),
+    }
+
+
+def supported_claims(context: dict) -> list[dict[str, str]]:
+    groups = context.get("changed_file_groups") or {}
+    claims: list[dict[str, str]] = []
+    if (groups.get("runtime") or {}).get("count", 0) > 0:
+        claims.append(
+            {
+                "cluster": "runtime",
+                "basis": "runtime files changed",
+                "evidence_anchor": ", ".join(list((groups.get("runtime") or {}).get("sample_files", []))[:2]),
+            }
+        )
+    process_files: list[str] = []
+    for name in ("automation", "docs", "config"):
+        process_files.extend(list((groups.get(name) or {}).get("sample_files", []))[:1])
+    if process_files:
+        claims.append(
+            {
+                "cluster": "process",
+                "basis": "workflow/docs/config files changed",
+                "evidence_anchor": ", ".join(process_files[:2]),
+            }
+        )
+    if testing_status(context)["present"]:
+        claims.append(
+            {
+                "cluster": "testing",
+                "basis": "testing section is present",
+                "evidence_anchor": "Testing",
+            }
+        )
+    return claims
+
+
+def coverage_gaps(context: dict, findings: dict) -> list[str]:
+    gaps: list[str] = []
+    groups = context.get("changed_file_groups") or {}
+    if (groups.get("runtime") or {}).get("count", 0) > 0 and "What changed" not in section_bodies(str(context.get("pr", {}).get("body") or "")):
+        gaps.append("runtime changes exist but the writeup lacks a `What changed` section.")
+    if not testing_status(context)["has_exact_command"]:
+        gaps.append("testing claims need an exact command or concrete verification step.")
+    if issue_ref_status(context)["status"] == "missing-body-ref":
+        gaps.append("linked issue metadata exists but the body does not cite it in `Refs:`.")
+    for message in findings.get("warnings", []):
+        lowered = message.lower()
+        if "testing" in lowered or "evidence" in lowered:
+            gaps.append(message)
+    deduped: list[str] = []
+    for gap in gaps:
+        if gap not in deduped:
+            deduped.append(gap)
+    return deduped
+
+
+def section_rewrite_requirements(context: dict, findings: dict) -> list[dict[str, str]]:
+    expected = list(context.get("expected_template_sections") or [])
+    actual = list(context.get("current_body_sections") or [])
+    missing = [section for section in expected if section not in actual]
+    requirements: list[dict[str, str]] = [
+        {"section": section, "reason": "missing template section"}
+        for section in missing
+    ]
+    if expected and actual and not ordered_subset(expected, actual) and not missing:
+        requirements.append({"section": "all", "reason": "template order must match repository guidance"})
+    for pattern, message in PLACEHOLDER_PATTERNS:
+        if pattern.search(str(context.get("pr", {}).get("body") or "")):
+            requirements.append({"section": "body", "reason": message})
+    testing = testing_status(context)
+    if testing["present"] and not testing["has_exact_command"]:
+        requirements.append({"section": "Testing", "reason": "cite an exact command or concrete verification step"})
+    return requirements
+
+
+def build_drafting_basis(context: dict, findings: dict, *, rewrite_hint: bool | None = None) -> dict[str, object]:
+    expected = list(context.get("expected_template_sections") or [])
+    actual = list(context.get("current_body_sections") or [])
+    issue_status = issue_ref_status(context)
+    testing = testing_status(context)
+    active_rule_gates = [
+        "title_pattern",
+        "required_sections",
+        "section_order",
+        "testing_evidence",
+        "issue_ref_alignment",
+        "unsupported_claim_screen",
+    ]
+    current_failures = {
+        "errors": list(findings.get("errors", [])),
+        "warnings": list(findings.get("warnings", [])),
+    }
+    title = str(context.get("pr", {}).get("title") or "").strip()
+    return {
+        "rewrite_strategy": rewrite_strategy_for_findings(context, findings, rewrite_hint=rewrite_hint),
+        "active_rule_gates": active_rule_gates,
+        "current_failures": current_failures,
+        "title_direction": {
+            "status": "rewrite" if not PR_TITLE_RE.match(title) else "keep-or-tighten",
+            "current_title": title,
+            "constraint": "<type>(<scope>): <summary>",
+        },
+        "required_sections_status": {
+            "required": expected,
+            "present": [section for section in expected if section in actual],
+            "missing": [section for section in expected if section not in actual],
+            "ordered": ordered_subset(expected, actual) if expected else True,
+        },
+        "section_rewrite_requirements": section_rewrite_requirements(context, findings),
+        "supported_claims": supported_claims(context),
+        "unsupported_claim_risks": risky_claim_categories(str(context.get("pr", {}).get("body") or "")),
+        "testing_evidence_status": testing,
+        "issue_ref_status": issue_status,
+        "coverage_gaps": coverage_gaps(context, findings),
+        "focused_packet_hint": None,
+    }
+
+
+def collect_findings(context: dict, *, original_context: dict | None = None) -> dict:
+    title = (context["pr"].get("title") or "").strip()
+    body = context["pr"].get("body") or ""
+    expected_sections = context.get("expected_template_sections") or []
+    actual_sections = context.get("current_body_sections") or []
+    bodies = section_bodies(body)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    info: list[str] = []
+
+    if not PR_TITLE_RE.match(title):
+        errors.append(
+            "Title does not match the repository Conventional Commit pattern `<type>(<scope>): <summary>`."
+        )
+
+    if len(title) > 72:
+        warnings.append("Title is longer than the PR instruction limit of 72 characters.")
+
+    missing_sections = [section for section in expected_sections if section not in actual_sections]
+    if missing_sections:
+        errors.append(
+            "Body is missing template sections: " + ", ".join(missing_sections) + "."
+        )
+    elif not ordered_subset(expected_sections, actual_sections):
+        errors.append("Body sections do not follow the repository template order.")
+
+    for pattern, message in PLACEHOLDER_PATTERNS:
+        if pattern.search(body):
+            errors.append(message)
+
+    what_changed = bodies.get("What changed", "")
+    what_changed_bullets = [
+        line for line in what_changed.splitlines() if line.lstrip().startswith("- ")
+    ]
+    if what_changed and not (2 <= len(what_changed_bullets) <= 6):
+        warnings.append("`What changed` should usually contain 2-6 bullets.")
+
+    testing = bodies.get("Testing", "")
+    if testing:
+        has_command = bool(re.search(r"`[^`]+`", testing))
+        if not has_command:
+            warnings.append(
+                "`Testing` does not cite any exact command or concrete verification step."
+            )
+
+    classification = bodies.get("PR Classification (optional)", "")
+    checked_labels = re.findall(r"- \[x\] ([^\n]+)", classification, flags=re.IGNORECASE)
+    justification_match = re.search(r"\nJustification:\s*(.*)$", body, flags=re.DOTALL)
+    justification_text = justification_match.group(1).strip() if justification_match else ""
+    if len(checked_labels) > 1:
+        warnings.append("More than one PR classification label is checked.")
+    if checked_labels and not justification_text:
+        errors.append("A PR classification is checked but `Justification:` is empty.")
+
+    if original_context is not None:
+        closing_refs = {
+            str(item.get("number"))
+            for item in (original_context.get("pr", {}).get("closingIssuesReferences") or [])
+            if str(item.get("number") or "").strip()
+        }
+        body_refs = referenced_issue_numbers(body)
+        if closing_refs and body_refs and closing_refs.isdisjoint(body_refs):
+            errors.append(
+                "Candidate `Refs:` line does not match any issue linked from the PR metadata."
+            )
+        errors.extend(candidate_claim_findings(context, original_context))
+
+    groups = context.get("changed_file_groups") or {}
+    high_signal_groups = [
+        name for name in ("runtime", "automation", "docs", "tests", "config")
+        if (groups.get(name) or {}).get("count", 0) > 0
+    ]
+    info.append("Changed areas: " + ", ".join(high_signal_groups) if high_signal_groups else "Changed areas: none detected")
+
+    rewrite_hint = full_rewrite_relative_to_original(context, original_context) if original_context is not None else None
+    result = {
+        "errors": errors,
+        "warnings": warnings,
+        "info": info,
+        "detected": {
+            "expected_sections": expected_sections,
+            "actual_sections": actual_sections,
+            "checked_classification_labels": checked_labels,
+            "changed_file_groups": groups,
+        },
+    }
+    result["drafting_basis"] = build_drafting_basis(context, result, rewrite_hint=rewrite_hint)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic checks against a PR title/body and template."
+    )
+    parser.add_argument("pr_number", type=int, nargs="?", help="Pull request number")
+    parser.add_argument(
+        "--context",
+        default=None,
+        help="Existing JSON file generated by collect_pr_context.py",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root containing .git and PR guidance files",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Optional GitHub repo slug such as owner/name",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional output file path. Prints JSON to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--candidate-title",
+        default=None,
+        help="Optional replacement title to lint against the collected context.",
+    )
+    parser.add_argument(
+        "--candidate-body-file",
+        default=None,
+        help="Optional replacement body markdown file to lint against the collected context.",
+    )
+    args = parser.parse_args()
+
+    if args.context:
+        context = json.loads(Path(args.context).read_text(encoding="utf-8"))
+    else:
+        if args.pr_number is None:
+            parser.error("Provide either <pr_number> or --context.")
+        context = build_context(
+            pr_number=args.pr_number,
+            repo_root=Path(args.repo_root).resolve(),
+            repo_slug=args.repo,
+        )
+
+    lint_context = context
+    original_context = None
+    if args.candidate_title is not None or args.candidate_body_file is not None:
+        candidate_title = args.candidate_title if args.candidate_title is not None else str(context["pr"].get("title") or "")
+        candidate_body = (
+            Path(args.candidate_body_file).read_text(encoding="utf-8")
+            if args.candidate_body_file
+            else str(context["pr"].get("body") or "")
+        )
+        lint_context = {
+            **context,
+            "pr": {
+                **context["pr"],
+                "title": candidate_title,
+                "body": candidate_body,
+            },
+            "current_body_sections": list(section_bodies(candidate_body).keys()),
+        }
+        original_context = context
+
+    findings = collect_findings(lint_context, original_context=original_context)
+    report = {
+        "pr_number": lint_context["pr"]["number"],
+        "title": lint_context["pr"]["title"],
+        "url": lint_context["pr"]["url"],
+        "mode": "candidate" if original_context is not None else "current",
+        "findings": findings,
+        "drafting_basis": findings.get("drafting_basis"),
+    }
+    payload = json.dumps(report, indent=2, ensure_ascii=True)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/pr_writeup_contract.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/pr_writeup_contract.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Shared contracts and helpers for gh-fix-pr-writeup."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+
+WORKFLOW_FAMILY = "github-review"
+ARCHETYPE = "audit-and-apply"
+ORCHESTRATOR_PROFILE = "packet-heavy-orchestrator"
+DECISION_READY_PACKETS = False
+WORKER_RETURN_CONTRACT = "generic"
+WORKER_OUTPUT_SHAPE = "flat"
+
+COMMON_PATH_REQUIRED_PACKETS = ["rules_packet.json", "synthesis_packet.json"]
+COMMON_PATH_MAX_FOCUSED_PACKETS = 1
+SHARED_LOCAL_PACKET = "synthesis_packet.json"
+
+PACKET_NAMES = [
+    "global_packet.json",
+    "rules_packet.json",
+    "runtime_packet.json",
+    "process_packet.json",
+    "testing_packet.json",
+    "synthesis_packet.json",
+]
+
+SMALL_FILE_LIMIT = 8
+MEDIUM_FILE_LIMIT = 20
+SMALL_GROUP_LIMIT = 2
+LARGE_GROUP_LIMIT = 4
+
+PACKET_WORKER_MAP = {
+    "runtime_packet.json": ["packet_explorer"],
+    "process_packet.json": ["packet_explorer"],
+    "testing_packet.json": ["evidence_summarizer"],
+}
+
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["packet_explorer", "docs_verifier"],
+    "candidate_producers": ["evidence_summarizer", "large_diff_auditor"],
+    "verifiers": ["docs_verifier"],
+}
+
+WORKER_SELECTION_GUIDANCE = {
+    "routing_authority": "packet_worker_map",
+    "notes": [
+        "Treat packet_worker_map as the concrete routing source for delegated runtime, process, and testing packets.",
+        "Keep rules_packet.json as a local-only authority source for rule text and hard constraints.",
+        "Use the optional QA pass only when qa_required is true or a local conflict explicitly triggers it.",
+    ],
+    "agent_type_guidance": {
+        "packet_explorer": "Use for one focused runtime or process packet plus only the explicitly referenced file slices needed to ground a narrow summary.",
+        "docs_verifier": "Use only as a narrow rules cross-check when the local gate still leaves ambiguity.",
+        "evidence_summarizer": "Use for testing claims, commands, and unsupported evidence.",
+        "large_diff_auditor": "Use only for the optional QA pass after a local draft exists.",
+    },
+}
+
+STANDARD_RETURN_CONTRACT = [
+    "primary outcome",
+    "evidence files",
+    "unsupported claims",
+    "suggested PR bullets",
+]
+
+QA_REQUIRED_INPUTS = [
+    "global_packet.json",
+    "rules_packet.json",
+    "draft title",
+    "draft body",
+    "conflicting worker findings or specific changed files being re-checked",
+]
+
+QA_RETURN_CONTRACT = [
+    "keep_or_revise",
+    "rule violations",
+    "coverage gaps",
+    "unsupported claims",
+]
+
+RAW_REREAD_ALLOWED_REASONS = [
+    "sample_omission",
+    "worker_conflict",
+    "claim_dispute",
+    "validator_blocker",
+]
+
+QA_TRIGGER_POLICY = {
+    "rare_exception_expected": True,
+    "required_when": [
+        "rewrite_strategy == full-rewrite and review_mode == broad-delegation",
+        "worker/local findings conflict on the same claim cluster",
+        "raw reread reason is worker_conflict or claim_dispute",
+    ],
+    "not_required_when": [
+        "full_rewrite_likely alone",
+        "small PR rewrite without conflicting claim evidence",
+    ],
+}
+
+VALIDATION_ERROR_CODES = {
+    "missing_context_field": "E_EDIT_CONTEXT_MISSING_FIELD",
+    "missing_candidate_field": "E_EDIT_CANDIDATE_MISSING_FIELD",
+    "candidate_lint_failed": "E_EDIT_CANDIDATE_LINT_FAILED",
+    "unsupported_claims": "E_EDIT_UNSUPPORTED_CLAIMS",
+    "missing_auth": "E_EDIT_MISSING_AUTH",
+    "live_snapshot_unavailable": "E_EDIT_LIVE_SNAPSHOT_UNAVAILABLE",
+    "stale_context": "E_EDIT_STALE_CONTEXT",
+    "qa_clear_required": "E_EDIT_QA_CLEAR_REQUIRED",
+    "qa_rejected": "E_EDIT_QA_REJECTED",
+}
+
+VALIDATION_WARNING_CODES = {
+    "candidate_warning": "W_EDIT_CANDIDATE_WARNING",
+}
+
+CORE_STOP_CATEGORIES = [
+    "stale_context",
+    "ambiguous_routing",
+    "missing_required_evidence",
+    "validator_mismatch",
+    "missing_auth",
+    "unresolved_stop_reason",
+]
+
+APPLICABLE_STOP_CATEGORIES = [
+    "stale_context",
+    "validator_mismatch",
+    "missing_auth",
+    "unresolved_stop_reason",
+]
+
+LOCAL_STOP_CATEGORIES = [
+    "invalid_candidate",
+    "live_snapshot_unavailable",
+    "unsupported_claims_detected",
+    "qa_required",
+]
+
+VALIDATED_SNAPSHOT_FIELDS = [
+    "title",
+    "body",
+    "url",
+    "headRefName",
+    "headRefOid",
+    "baseRefName",
+]
+
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+
+LOCAL_ONLY_PACKETS = {"synthesis_packet.json", "orchestrator.json"}
+RUNTIME_PACKET_EXCLUSIONS = {"packet_metrics.json"}
+
+
+def load_json(path: Any) -> dict[str, Any]:
+    from pathlib import Path
+
+    return json.loads(Path(path).read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Any, payload: dict[str, Any]) -> None:
+    from pathlib import Path
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def json_fingerprint(payload: Any) -> str:
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def json_bytes(payload: Any) -> int:
+    return len((json.dumps(payload, indent=2, ensure_ascii=True) + "\n").encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return int(math.ceil(byte_count / 4.0))
+
+
+def compute_packet_metrics(
+    packet_payloads: dict[str, Any],
+    *,
+    common_path_packet_names: list[str],
+    raw_local_payload: Any,
+) -> dict[str, Any]:
+    packet_sizes = {name: json_bytes(payload) for name, payload in packet_payloads.items()}
+    total_packet_bytes = sum(packet_sizes.values())
+    sorted_sizes = sorted(packet_sizes.values(), reverse=True)
+    common_path_bytes = sum(packet_sizes.get(name, 0) for name in common_path_packet_names)
+    raw_local_bytes = json_bytes(raw_local_payload)
+    return {
+        "packet_count": len(packet_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "packet_size_by_file": packet_sizes,
+        "largest_packet_bytes": sorted_sizes[0] if sorted_sizes else 0,
+        "largest_two_packets_bytes": sum(sorted_sizes[:2]),
+        "common_path_packet_bytes": common_path_bytes,
+        "raw_local_source_bytes": raw_local_bytes,
+        "estimated_local_only_tokens": estimate_tokens_from_bytes(raw_local_bytes),
+        "estimated_packet_tokens": estimate_tokens_from_bytes(common_path_bytes),
+        "estimated_delegation_savings": max(
+            0,
+            estimate_tokens_from_bytes(raw_local_bytes) - estimate_tokens_from_bytes(common_path_bytes),
+        ),
+    }
+
+
+def stop_status() -> dict[str, Any]:
+    return {
+        "status": "pass",
+        "applicable_stop_categories": APPLICABLE_STOP_CATEGORIES.copy(),
+        "covered_stop_categories": APPLICABLE_STOP_CATEGORIES.copy(),
+        "uncovered_stop_categories": [],
+        "not_applicable_stop_categories": ["ambiguous_routing", "missing_required_evidence"],
+        "local_stop_categories": LOCAL_STOP_CATEGORIES.copy(),
+    }
+
+
+def should_require_qa(
+    *,
+    rewrite_strategy: str,
+    review_mode: str,
+    worker_conflict: bool = False,
+    raw_reread_reasons: list[str] | None = None,
+) -> tuple[bool, str | None]:
+    reasons = list(raw_reread_reasons or [])
+    if worker_conflict:
+        return True, "worker-local claim conflict"
+    if any(reason in {"worker_conflict", "claim_dispute"} for reason in reasons):
+        return True, "claim conflict requires QA cross-check"
+    if rewrite_strategy == "full-rewrite" and review_mode == "broad-delegation":
+        return True, "broad-delegation full rewrite requires QA cross-check"
+    return False, None
+
+
+def minimal_validated_snapshot(pr_payload: dict[str, Any], changed_files: list[str]) -> dict[str, Any]:
+    snapshot = {field: str(pr_payload.get(field) or "").strip() for field in VALIDATED_SNAPSHOT_FIELDS}
+    snapshot["changed_files"] = [str(path).replace("\\", "/") for path in changed_files]
+    return snapshot

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/pr_writeup_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/pr_writeup_tools.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+
+PR_TITLE_RE = re.compile(
+    r"^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)"
+    r"\([a-z0-9][a-z0-9-]*\): .+$"
+)
+GROUP_SAMPLE_LIMIT = 16
+GH_STUB_STATE_ENV = "GH_FIX_PR_WRITEUP_GH_STUB_STATE"
+
+
+def maybe_run_stubbed_gh(args: list[str]) -> str | None:
+    if not args or args[0] != "gh":
+        return None
+    state_path = os.environ.get(GH_STUB_STATE_ENV)
+    if not state_path:
+        return None
+    state = json.loads(Path(state_path).read_text(encoding="utf-8"))
+    command = args[1:]
+    if command[:2] == ["auth", "status"]:
+        return "Logged in to github.com\n"
+    if command[:2] == ["pr", "view"]:
+        return json.dumps(state["pr"])
+    if command[:2] == ["pr", "diff"] and "--name-only" in command:
+        return "\n".join(state.get("changed_files", []))
+    if command[:2] == ["pr", "edit"]:
+        title = command[command.index("--title") + 1]
+        body_file = command[command.index("--body-file") + 1]
+        state["pr"]["title"] = title
+        state["pr"]["body"] = Path(body_file).read_text(encoding="utf-8")
+        Path(state_path).write_text(json.dumps(state, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        return ""
+    raise subprocess.CalledProcessError(returncode=1, cmd=args, output="", stderr="unsupported stubbed gh command")
+
+
+def run_command(args: list[str], cwd: Path) -> str:
+    stubbed = maybe_run_stubbed_gh(args)
+    if stubbed is not None:
+        return stubbed
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd),
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError as exc:
+        command_name = args[0] if args else "command"
+        raise RuntimeError(f"{command_name} executable not found") from exc
+    return completed.stdout
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def infer_repo_slug(repo_root: Path) -> str | None:
+    try:
+        remote = run_command(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=repo_root,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return None
+
+    if not remote:
+        return None
+
+    match = re.search(r"github\.com[:/](?P<slug>[^/]+/[^/]+?)(?:\.git)?$", remote)
+    return match.group("slug") if match else None
+
+
+def parse_markdown_headings(markdown_text: str | None) -> list[str]:
+    if not markdown_text:
+        return []
+    headings: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            headings.append(line[3:].strip())
+    return headings
+
+
+def classify_changed_files(paths: Iterable[str]) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = {
+        "runtime": [],
+        "automation": [],
+        "docs": [],
+        "tests": [],
+        "config": [],
+        "other": [],
+    }
+    for path in paths:
+        normalized = path.replace("\\", "/")
+        lower = normalized.lower()
+        if (
+            "/tests/" in lower
+            or lower.endswith("_test.py")
+            or lower.endswith(".tests.cs")
+            or lower.startswith(".github/scripts/tests/")
+        ):
+            groups["tests"].append(normalized)
+            continue
+        if (
+            lower.startswith(".github/workflows/")
+            or lower.startswith(".github/scripts/")
+            or lower.startswith(".github/issue_template/")
+        ):
+            groups["automation"].append(normalized)
+        elif lower.endswith(".md"):
+            groups["docs"].append(normalized)
+        elif (
+            lower.endswith(".yml")
+            or lower.endswith(".yaml")
+            or lower.endswith(".toml")
+            or lower.endswith(".json")
+            or lower.endswith(".csproj")
+            or lower.endswith(".props")
+            or lower.endswith(".targets")
+        ):
+            groups["config"].append(normalized)
+        elif lower.endswith(".cs") or lower.endswith(".dll"):
+            groups["runtime"].append(normalized)
+        else:
+            groups["other"].append(normalized)
+    return groups
+
+
+def sample_parent(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    return normalized.rsplit("/", 1)[0] if "/" in normalized else "."
+
+
+def select_representative_files(paths: Iterable[str], limit: int = GROUP_SAMPLE_LIMIT) -> list[str]:
+    ordered_paths: list[str] = []
+    for path in paths:
+        normalized = path.replace("\\", "/")
+        if normalized not in ordered_paths:
+            ordered_paths.append(normalized)
+
+    if len(ordered_paths) <= limit:
+        return ordered_paths
+
+    bucket_order: list[str] = []
+    buckets: dict[str, list[str]] = {}
+    for path in ordered_paths:
+        parent = sample_parent(path)
+        if parent not in buckets:
+            buckets[parent] = []
+            bucket_order.append(parent)
+        buckets[parent].append(path)
+
+    selected: list[str] = []
+    while len(selected) < limit:
+        progressed = False
+        for parent in bucket_order:
+            bucket = buckets[parent]
+            if not bucket:
+                continue
+            selected.append(bucket.pop(0))
+            progressed = True
+            if len(selected) >= limit:
+                break
+        if not progressed:
+            break
+
+    original_index = {path: index for index, path in enumerate(ordered_paths)}
+    return sorted(selected, key=original_index.__getitem__)
+
+
+def summarize_groups(groups: dict[str, list[str]]) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    for name, paths in groups.items():
+        sample_files = select_representative_files(paths)
+        result[name] = {
+            "count": len(paths),
+            "sample_files": sample_files,
+            "omitted_file_count": max(len(paths) - len(sample_files), 0),
+            "sample_strategy": "directory_round_robin",
+        }
+    return result
+
+
+def load_pr_metadata(pr_number: int, repo_root: Path, repo_slug: str | None) -> dict:
+    args = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--json",
+        "number,title,body,headRefName,headRefOid,baseRefName,url,closingIssuesReferences",
+    ]
+    if repo_slug:
+        args.extend(["--repo", repo_slug])
+    return json.loads(run_command(args, cwd=repo_root))
+
+
+def parse_changed_files_output(output: str) -> list[str]:
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def is_diff_too_large_error(exc: subprocess.CalledProcessError) -> bool:
+    detail = "\n".join(
+        part
+        for part in (
+            str(exc),
+            (exc.stderr or "").strip(),
+            (exc.output or "").strip(),
+        )
+        if part
+    )
+    return "PullRequest.diff too_large" in detail or "maximum number of lines" in detail
+
+
+def load_pr_changed_files_via_api(pr_number: int, repo_root: Path, repo_slug: str) -> list[str]:
+    output = run_command(
+        [
+            "gh",
+            "api",
+            f"repos/{repo_slug}/pulls/{pr_number}/files",
+            "--paginate",
+            "--jq",
+            ".[].filename",
+        ],
+        cwd=repo_root,
+    )
+    return parse_changed_files_output(output)
+
+
+def load_pr_changed_files(pr_number: int, repo_root: Path, repo_slug: str | None) -> list[str]:
+    args = ["gh", "pr", "diff", str(pr_number), "--name-only"]
+    if repo_slug:
+        args.extend(["--repo", repo_slug])
+    try:
+        output = run_command(args, cwd=repo_root)
+    except subprocess.CalledProcessError as exc:
+        if not repo_slug or not is_diff_too_large_error(exc):
+            raise
+        return load_pr_changed_files_via_api(pr_number, repo_root, repo_slug)
+    return parse_changed_files_output(output)
+
+
+def load_local_diff_stat(repo_root: Path, base_ref: str | None, head_ref: str | None) -> str | None:
+    if not base_ref or not head_ref:
+        return None
+
+    candidates = [
+        f"{base_ref}..{head_ref}",
+        f"origin/{base_ref}..{head_ref}",
+        f"{base_ref}..origin/{head_ref}",
+        f"origin/{base_ref}..origin/{head_ref}",
+    ]
+    for revision_range in candidates:
+        try:
+            output = run_command(
+                ["git", "diff", "--stat", revision_range],
+                cwd=repo_root,
+            ).strip()
+        except subprocess.CalledProcessError:
+            continue
+        if output:
+            return output
+    return None
+
+
+def template_file_paths(repo_root: Path) -> dict[str, str]:
+    files = {
+        "pull_request_instructions": ".github/instructions/pull-request.instructions.md",
+        "pull_request_template": ".github/pull_request_template.md",
+        "commit_message_instructions": ".github/instructions/commit-message.instructions.md",
+        "contributing": "CONTRIBUTING.md",
+        "maintaining": "MAINTAINING.md",
+    }
+    result: dict[str, str] = {}
+    for key, rel_path in files.items():
+        path = repo_root / rel_path
+        if path.exists():
+            result[key] = str(path)
+    return result
+
+
+def build_context(pr_number: int, repo_root: Path, repo_slug: str | None = None) -> dict:
+    resolved_repo_slug = repo_slug or infer_repo_slug(repo_root)
+    metadata = load_pr_metadata(pr_number, repo_root, resolved_repo_slug)
+    changed_files = load_pr_changed_files(pr_number, repo_root, resolved_repo_slug)
+    groups = classify_changed_files(changed_files)
+    rule_paths = template_file_paths(repo_root)
+    diff_stat = load_local_diff_stat(
+        repo_root,
+        metadata.get("baseRefName"),
+        metadata.get("headRefName"),
+    )
+
+    template_text = read_text_if_exists(repo_root / ".github/pull_request_template.md")
+    instructions_text = read_text_if_exists(
+        repo_root / ".github/instructions/pull-request.instructions.md"
+    )
+    commit_instructions_text = read_text_if_exists(
+        repo_root / ".github/instructions/commit-message.instructions.md"
+    )
+
+    return {
+        "repo_root": str(repo_root),
+        "repo_slug": resolved_repo_slug,
+        "pr": metadata,
+        "changed_files": changed_files,
+        "changed_file_groups": summarize_groups(groups),
+        "diff_stat": diff_stat,
+        "rule_files": rule_paths,
+        "expected_template_sections": parse_markdown_headings(template_text),
+        "current_body_sections": parse_markdown_headings(metadata.get("body") or ""),
+        "checks": {
+            "title_matches_conventional_commit": bool(
+                PR_TITLE_RE.match((metadata.get("title") or "").strip())
+            ),
+            "title_length": len((metadata.get("title") or "").strip()),
+            "body_has_template_sections": bool(parse_markdown_headings(metadata.get("body") or "")),
+            "has_issue_refs": bool(metadata.get("closingIssuesReferences")),
+        },
+        "instruction_snippets": {
+            "pull_request_title_rules_excerpt": first_heading_block(
+                instructions_text,
+                "## PR Title",
+            ),
+            "pull_request_template_sections": parse_markdown_headings(template_text),
+            "commit_types_excerpt": first_heading_block(
+                commit_instructions_text,
+                "## Types",
+            ),
+        },
+    }
+
+
+def first_heading_block(markdown_text: str | None, heading: str) -> str | None:
+    if not markdown_text:
+        return None
+    lines = markdown_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == heading:
+            start = index
+            break
+    if start is None:
+        return None
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].startswith("## "):
+            end = index
+            break
+    return "\n".join(lines[start:end]).strip()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/smoke_gh_fix_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/smoke_gh_fix_pr_writeup.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Smoke-test gh-fix-pr-writeup with a temp repository and mocked gh."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+CURRENT_PR_BODY = "\n".join(
+    [
+        "## Why",
+        "The current writeup is too vague.",
+        "## What changed",
+        "- Reworked the PR body structure.",
+        "## How",
+        "Note any important defaults, thresholds, reload/restart requirements, or",
+        "## Risk / Rollback",
+        "Minimal risk.",
+        "## Testing",
+        "Not run.",
+    ]
+)
+
+
+REPLACEMENT_BODY = "\n".join(
+    [
+        "## Why",
+        "Clarify the shipped behavior and tighten the PR guardrails.",
+        "## What changed",
+        "- Added a guarded validate/apply flow for PR text updates.",
+        "- Kept the final writeup aligned with the inspected diff and local rules gate.",
+        "## How",
+        "- Re-fetched the live PR snapshot before the guarded mutation.",
+        "## Risk / Rollback",
+        "- Revert the PR text if the replacement proves inaccurate.",
+        "## Testing",
+        "- Ran `python -m unittest discover tests`.",
+        "Refs: #42",
+    ]
+)
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def run_python(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        details = "\n".join(part for part in (result.stderr.strip(), result.stdout.strip()) if part)
+        raise RuntimeError(details or f"python {' '.join(args)} failed")
+    return result
+
+
+def run_git(repo_root: Path, args: list[str]) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_root),
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def init_repo(repo_root: Path) -> None:
+    run_git(repo_root, ["init"])
+    run_git(repo_root, ["config", "user.name", "Smoke Test"])
+    run_git(repo_root, ["config", "user.email", "smoke@example.invalid"])
+
+    write_text(
+        repo_root / ".github" / "pull_request_template.md",
+        "\n".join(
+            [
+                "## Why",
+                "",
+                "## What changed",
+                "",
+                "## How",
+                "",
+                "## Risk / Rollback",
+                "",
+                "## Testing",
+                "",
+            ]
+        )
+        + "\n",
+    )
+    write_text(
+        repo_root / ".github" / "instructions" / "pull-request.instructions.md",
+        "\n".join(
+            [
+                "# PR Rules",
+                "",
+                "## PR Title",
+                "Use Conventional Commit style.",
+                "",
+                "## PR Body",
+                "Keep the PR body concise and evidence-backed.",
+            ]
+        )
+        + "\n",
+    )
+    write_text(
+        repo_root / ".github" / "instructions" / "commit-message.instructions.md",
+        "\n".join(
+            [
+                "# Commit Message Rules",
+                "",
+                "## Types",
+                "- feat",
+                "- fix",
+                "- docs",
+            ]
+        )
+        + "\n",
+    )
+    write_text(repo_root / "README.md", "# README\n",)
+    write_text(repo_root / "ExampleProduct" / "Systems" / "OfficeDemandDiagnosticsSystem.cs", "namespace Smoke;\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "Initial smoke fixture"])
+
+
+def install_gh_stub(target_dir: Path, repo_slug: str) -> Path:
+    state_path = target_dir / "gh_state.json"
+    write_json(
+        state_path,
+        {
+            "repo_slug": repo_slug,
+            "pr": {
+                "number": 7,
+                "title": "docs(pr-writeup): polish guard rails",
+                "body": CURRENT_PR_BODY,
+                "headRefName": "codex/writeup-guard",
+                "headRefOid": "abc123def456",
+                "baseRefName": "main",
+                "url": "https://example.invalid/pr/7",
+                "closingIssuesReferences": [{"number": 42}],
+            },
+            "changed_files": [
+                "README.md",
+                "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+            ],
+        },
+    )
+    return state_path
+
+
+def main() -> int:
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "gh-fix-pr-writeup"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-") as tmp_dir_name:
+        tmp_dir = Path(tmp_dir_name)
+        repo_root = tmp_dir / "repo"
+        repo_root.mkdir()
+        init_repo(repo_root)
+
+        state_path = install_gh_stub(repo_root, "owner/repo")
+
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env["GH_FIX_PR_WRITEUP_GH_STUB_STATE"] = str(state_path)
+
+        context_path = tmp_dir / "context.json"
+        lint_path = tmp_dir / "lint.json"
+        build_result_path = tmp_dir / "build-result.json"
+        validation_path = tmp_dir / "validation.json"
+        apply_result_path = tmp_dir / "apply.json"
+        eval_log_path = tmp_dir / "evaluation.json"
+        body_path = tmp_dir / "replacement.md"
+        packet_dir = tmp_dir / "packets"
+
+        body_path.write_text(REPLACEMENT_BODY + "\n", encoding="utf-8")
+
+        run_python(
+            [
+                str(SCRIPT_DIR / "collect_pr_context.py"),
+                "7",
+                "--repo-root",
+                str(repo_root),
+                "--repo",
+                "owner/repo",
+                "--output",
+                str(context_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "lint_pr_writeup.py"),
+                "--context",
+                str(context_path),
+                "--output",
+                str(lint_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "build_pr_review_packets.py"),
+                "--context",
+                str(context_path),
+                "--lint",
+                str(lint_path),
+                "--output-dir",
+                str(packet_dir),
+                "--result-output",
+                str(build_result_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "validate_pr_writeup_edit.py"),
+                "--context",
+                str(context_path),
+                "--title",
+                "docs(pr-writeup): tighten guard rails",
+                "--body-file",
+                str(body_path),
+                "--output",
+                str(validation_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "apply_pr_writeup.py"),
+                "--validation",
+                str(validation_path),
+                "--dry-run",
+                "--result-output",
+                str(apply_result_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "init",
+                "--context",
+                str(context_path),
+                "--orchestrator",
+                str(packet_dir / "orchestrator.json"),
+                "--lint",
+                str(lint_path),
+                "--output",
+                str(eval_log_path),
+            ],
+            cwd=repo_root,
+            env=env,
+        )
+        for phase, result_path in (
+            ("build", build_result_path),
+            ("validate", validation_path),
+            ("apply", apply_result_path),
+        ):
+            run_python(
+                [
+                    str(SCRIPT_DIR / "write_evaluation_log.py"),
+                    "phase",
+                    "--log",
+                    str(eval_log_path),
+                    "--phase",
+                    phase,
+                    "--result",
+                    str(result_path),
+                ],
+                cwd=repo_root,
+                env=env,
+            )
+
+        build_result = read_json(build_result_path)
+        validation = read_json(validation_path)
+        apply_result = read_json(apply_result_path)
+        packet_metrics = read_json(packet_dir / "packet_metrics.json")
+        eval_log = read_json(eval_log_path)
+        orchestrator = read_json(packet_dir / "orchestrator.json")
+
+        assert build_result["qa_required"] is False
+        assert build_result["raw_reread_count"] == 0
+        assert build_result["common_path_sufficient"] is True
+        assert validation["qa_required"] is False
+        assert apply_result["apply_succeeded"] is True
+        assert packet_metrics["estimated_packet_tokens"] < packet_metrics["estimated_local_only_tokens"]
+        assert packet_metrics["estimated_delegation_savings"] > 0
+        assert "estimated_packet_tokens" not in orchestrator
+        assert eval_log["skill_specific"]["data"]["common_path_sufficient"] is True
+        assert eval_log["skill_specific"]["data"]["raw_reread_count"] == 0
+
+        print(
+            json.dumps(
+                {
+                    "smoke": "passed",
+                    "qa_required": build_result["qa_required"],
+                    "raw_reread_count": build_result["raw_reread_count"],
+                    "common_path_sufficient": build_result["common_path_sufficient"],
+                    "estimated_local_only_tokens": packet_metrics["estimated_local_only_tokens"],
+                    "estimated_packet_tokens": packet_metrics["estimated_packet_tokens"],
+                    "estimated_delegation_savings": packet_metrics["estimated_delegation_savings"],
+                },
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/validate_pr_writeup_edit.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/validate_pr_writeup_edit.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Validate a candidate PR title/body update before guarded apply."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import lint_pr_writeup as lint_pr_writeup
+import pr_writeup_contract as contract
+import pr_writeup_tools as tools
+
+
+VALIDATION_ERROR_CODES = contract.VALIDATION_ERROR_CODES
+VALIDATION_WARNING_CODES = contract.VALIDATION_WARNING_CODES
+APPLICABLE_STOP_CATEGORIES = contract.APPLICABLE_STOP_CATEGORIES
+LOCAL_STOP_CATEGORIES = contract.LOCAL_STOP_CATEGORIES
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Path to JSON from collect_pr_context.py")
+    parser.add_argument("--title", required=True, help="Replacement PR title")
+    parser.add_argument("--body-file", required=True, help="Path to replacement PR body markdown")
+    parser.add_argument("--qa-result", help="Optional QA result JSON.")
+    parser.add_argument(
+        "--worker-claim-conflict",
+        action="store_true",
+        help="Require QA because worker and local claim findings conflict.",
+    )
+    parser.add_argument(
+        "--raw-reread-reason",
+        action="append",
+        choices=contract.RAW_REREAD_ALLOWED_REASONS,
+        help="Optional explicit reread reason that can trigger QA.",
+    )
+    parser.add_argument("--output", help="Optional output path for validation JSON")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return contract.load_json(path)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    contract.write_json(path, payload)
+
+
+def json_fingerprint(payload: dict[str, Any]) -> str:
+    return contract.json_fingerprint(payload)
+
+
+def normalize_scalar(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalize_paths(paths: list[Any]) -> list[str]:
+    return [str(path).replace("\\", "/") for path in paths]
+
+
+def push_issue(
+    bucket: list[str],
+    details: list[dict[str, Any]],
+    *,
+    code: str,
+    message: str,
+    field: str | None = None,
+    stop_category: str | None = None,
+) -> None:
+    bucket.append(message)
+    detail = {"code": code, "message": message}
+    if field is not None:
+        detail["field"] = field
+    if stop_category is not None:
+        detail["stop_category"] = stop_category
+    details.append(detail)
+
+
+def validate_context_contract(context: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not normalize_scalar(context.get("repo_root")):
+        errors.append("Context is missing `repo_root`.")
+    pr = context.get("pr")
+    if not isinstance(pr, dict):
+        errors.append("Context is missing `pr` metadata.")
+        return errors
+    for field in ("number", "title", "body", "url", "headRefName", "headRefOid", "baseRefName"):
+        if field == "number":
+            if pr.get(field) in {None, ""}:
+                errors.append("Context is missing `pr.number`.")
+        elif not normalize_scalar(pr.get(field)):
+            errors.append(f"Context is missing `pr.{field}`.")
+    if not isinstance(context.get("changed_files"), list):
+        errors.append("Context is missing `changed_files`.")
+    return errors
+
+
+def build_candidate_context(context: dict[str, Any], title: str, body: str) -> dict[str, Any]:
+    updated = deepcopy(context)
+    updated["pr"] = {**dict(context.get("pr") or {}), "title": title, "body": body}
+    updated["current_body_sections"] = list(lint_pr_writeup.section_bodies(body).keys())
+    checks = dict(updated.get("checks") or {})
+    checks["title_matches_conventional_commit"] = bool(tools.PR_TITLE_RE.match(title))
+    checks["title_length"] = len(title)
+    checks["body_has_template_sections"] = bool(updated["current_body_sections"])
+    updated["checks"] = checks
+    return updated
+
+
+def stale_snapshot_fields(
+    context_snapshot: dict[str, Any],
+    live_pr: dict[str, Any],
+    live_changed_files: list[str],
+) -> list[dict[str, Any]]:
+    mismatches: list[dict[str, Any]] = []
+    for field in contract.VALIDATED_SNAPSHOT_FIELDS:
+        expected = normalize_scalar(context_snapshot.get(field))
+        actual = normalize_scalar(live_pr.get(field))
+        if expected != actual:
+            mismatches.append({"field": field, "expected": expected, "actual": actual})
+    expected_files = normalize_paths(list(context_snapshot.get("changed_files") or []))
+    actual_files = normalize_paths(live_changed_files)
+    if expected_files != actual_files:
+        mismatches.append({"field": "changed_files", "expected": expected_files, "actual": actual_files})
+    return mismatches
+
+
+def infer_review_mode(context: dict[str, Any]) -> str:
+    file_count = len(list(context.get("changed_files") or []))
+    groups = context.get("changed_file_groups") or {}
+    active = [
+        name for name in ("runtime", "automation", "docs", "tests", "config", "other")
+        if (groups.get(name) or {}).get("count", 0) > 0
+    ]
+    if file_count <= contract.SMALL_FILE_LIMIT and len(active) <= contract.SMALL_GROUP_LIMIT:
+        return "local-only"
+    if file_count > contract.MEDIUM_FILE_LIMIT or len(active) >= contract.LARGE_GROUP_LIMIT:
+        return "broad-delegation"
+    return "targeted-delegation"
+
+
+def qa_summary(qa_result: dict[str, Any] | None) -> dict[str, Any]:
+    payload = qa_result if isinstance(qa_result, dict) else {}
+    keep_or_revise = normalize_scalar(payload.get("keep_or_revise")).lower()
+    return {
+        "keep_or_revise": keep_or_revise or None,
+        "rule_violations": [str(item) for item in payload.get("rule_violations", []) if str(item).strip()],
+        "coverage_gaps": [str(item) for item in payload.get("coverage_gaps", []) if str(item).strip()],
+        "unsupported_claims": [str(item) for item in payload.get("unsupported_claims", []) if str(item).strip()],
+    }
+
+
+def qa_is_clear(qa_result: dict[str, Any] | None) -> tuple[bool, str | None]:
+    if not isinstance(qa_result, dict):
+        return False, "QA clear result is required but was not provided."
+    summary = qa_summary(qa_result)
+    if summary["keep_or_revise"] not in {"keep", "accept"}:
+        return False, "QA result did not clear the draft for keep/apply."
+    for key in ("rule_violations", "coverage_gaps", "unsupported_claims"):
+        if summary[key]:
+            return False, f"QA result reported {key.replace('_', ' ')}."
+    return True, None
+
+
+def stop_status() -> dict[str, Any]:
+    return contract.stop_status()
+
+
+def validate_pr_writeup_edit(
+    context: dict[str, Any],
+    title: str,
+    body: str,
+    *,
+    qa_result: dict[str, Any] | None = None,
+    worker_claim_conflict: bool = False,
+    raw_reread_reasons: list[str] | None = None,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[dict[str, Any]] = []
+    warning_details: list[dict[str, Any]] = []
+    stop_reasons: list[str] = []
+
+    context_errors = validate_context_contract(context)
+    for message in context_errors:
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["missing_context_field"],
+            message=message,
+            stop_category="validator_mismatch",
+        )
+    if not title.strip():
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["missing_candidate_field"],
+            message="Candidate title is empty.",
+            field="title",
+            stop_category="invalid_candidate",
+        )
+    if not body.strip():
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["missing_candidate_field"],
+            message="Candidate body is empty.",
+            field="body",
+            stop_category="invalid_candidate",
+        )
+
+    candidate_findings: dict[str, Any] = {"errors": [], "warnings": [], "info": [], "detected": {}}
+    repo_root = Path(str(context.get("repo_root", "."))).resolve()
+    repo_slug = context.get("repo_slug")
+    pr = context.get("pr") or {}
+    pr_number = int(pr.get("number") or 0) if str(pr.get("number") or "").strip() else 0
+    validation_commands: list[str] = [
+        "candidate lint",
+        "gh auth status",
+        f"gh pr view {pr_number} --json number,title,body,headRefName,headRefOid,baseRefName,url,closingIssuesReferences",
+        f"gh pr diff {pr_number} --name-only",
+    ] if pr_number else ["candidate lint", "gh auth status"]
+    if qa_result is not None:
+        validation_commands.append("qa result review")
+
+    live_pr: dict[str, Any] | None = None
+    live_changed_files: list[str] = []
+    stale_fields: list[dict[str, Any]] = []
+
+    if not errors:
+        candidate_context = build_candidate_context(context, title.strip(), body)
+        candidate_findings = lint_pr_writeup.collect_findings(candidate_context, original_context=context)
+        for message in candidate_findings.get("warnings", []):
+            push_issue(
+                warnings,
+                warning_details,
+                code=VALIDATION_WARNING_CODES["candidate_warning"],
+                message=message,
+            )
+        unsupported_claim_messages = [
+            message
+            for message in candidate_findings.get("errors", [])
+            if "direct verification" in message.lower() or "claims verification" in message.lower()
+        ]
+        non_claim_errors = [
+            message for message in candidate_findings.get("errors", []) if message not in unsupported_claim_messages
+        ]
+        for message in non_claim_errors:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["candidate_lint_failed"],
+                message=message,
+                stop_category="invalid_candidate",
+            )
+        for message in unsupported_claim_messages:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["unsupported_claims"],
+                message=message,
+                stop_category="unsupported_claims_detected",
+            )
+
+    if not errors:
+        try:
+            tools.run_command(["gh", "auth", "status"], cwd=repo_root)
+        except Exception as exc:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_auth"],
+                message=str(exc),
+                stop_category="missing_auth",
+            )
+
+    if not errors:
+        try:
+            live_pr = tools.load_pr_metadata(pr_number, repo_root, repo_slug)
+            live_changed_files = tools.load_pr_changed_files(pr_number, repo_root, repo_slug)
+        except Exception as exc:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["live_snapshot_unavailable"],
+                message=str(exc),
+                stop_category="live_snapshot_unavailable",
+            )
+
+    if not errors and live_pr is not None:
+        context_snapshot = contract.minimal_validated_snapshot(pr, list(context.get("changed_files") or []))
+        stale_fields = stale_snapshot_fields(context_snapshot, live_pr, live_changed_files)
+        if stale_fields:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["stale_context"],
+                message="The live PR snapshot changed after collection; refresh collect -> lint -> packet build before editing.",
+                stop_category="stale_context",
+            )
+
+    review_mode = infer_review_mode(context)
+    drafting_basis = candidate_findings.get("drafting_basis") or {}
+    qa_required, qa_reason = contract.should_require_qa(
+        rewrite_strategy=str(drafting_basis.get("rewrite_strategy") or "targeted-touch-up"),
+        review_mode=review_mode,
+        worker_conflict=worker_claim_conflict,
+        raw_reread_reasons=list(raw_reread_reasons or []),
+    )
+    qa_clear, qa_block_reason = qa_is_clear(qa_result) if qa_required else (False, None)
+    if not errors and qa_required and not qa_clear:
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["qa_clear_required"] if qa_result is None else VALIDATION_ERROR_CODES["qa_rejected"],
+            message=qa_block_reason or "QA review is required before apply-safe validation.",
+            stop_category="qa_required",
+        )
+
+    for detail in error_details:
+        category = detail.get("stop_category")
+        if isinstance(category, str) and category not in stop_reasons:
+            stop_reasons.append(category)
+
+    validated_snapshot = contract.minimal_validated_snapshot(
+        live_pr or pr,
+        live_changed_files or list(context.get("changed_files") or []),
+    )
+    normalized_edit = {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_slug,
+        "pr_number": pr_number,
+        "title": title.strip(),
+        "body": body,
+        "validated_snapshot": validated_snapshot,
+        "validation_commands": validation_commands,
+        "review_mode": review_mode,
+        "qa_gate": {
+            "required": qa_required,
+            "reason": qa_reason,
+            "qa_clear": qa_clear if qa_required else False,
+            "worker_claim_conflict": worker_claim_conflict,
+            "raw_reread_reasons": list(raw_reread_reasons or []),
+            "qa_summary": qa_summary(qa_result) if qa_result is not None else None,
+        },
+    }
+    gate = stop_status()
+    can_apply = not errors and not gate["uncovered_stop_categories"]
+    gate["status"] = "pass" if can_apply else "fail"
+    return {
+        "valid": not errors,
+        "can_apply": can_apply,
+        "errors": errors,
+        "warnings": warnings,
+        "error_details": error_details,
+        "warning_details": warning_details,
+        "stop_reasons": stop_reasons,
+        "candidate_findings": candidate_findings,
+        "validation_commands": validation_commands,
+        "stale_fields": stale_fields,
+        "review_mode": review_mode,
+        "qa_required": qa_required,
+        "qa_reason": qa_reason,
+        "qa_clear": qa_clear if qa_required else False,
+        "normalized_edit": normalized_edit,
+        "normalized_edit_fingerprint": json_fingerprint(normalized_edit),
+        "context_file_fingerprint": json_fingerprint(context),
+        "apply_gate_status": gate,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    body = Path(args.body_file).resolve().read_text(encoding="utf-8")
+    qa_result = load_json(Path(args.qa_result).resolve()) if args.qa_result else None
+    payload = validate_pr_writeup_edit(
+        context,
+        args.title,
+        body,
+        qa_result=qa_result,
+        worker_claim_conflict=args.worker_claim_conflict,
+        raw_reread_reasons=list(args.raw_reread_reason or []),
+    )
+    if args.output:
+        write_json(Path(args.output).resolve(), payload)
+    else:
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if payload.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/write_evaluation_log.py
@@ -1,0 +1,1043 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals: list[str] = []
+    seen: set[str] = set()
+    for key in ("review_mode_overrides", "review_overrides"):
+        for item in orchestrator.get(key, []):
+            if isinstance(item, dict):
+                reason = str(item.get("reason") or "").strip()
+                if reason and reason not in seen:
+                    seen.add(reason)
+                    signals.append(reason)
+            else:
+                text = str(item).strip()
+                if text and text not in seen:
+                    seen.add(text)
+                    signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "review_mode": orchestrator.get("review_mode"),
+            "packet_count": len(packet_files(orchestrator)),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "rewrite_strategy": None,
+            "qa_required": None,
+            "qa_reason": None,
+            "qa_ran": None,
+            "validation_commands": [],
+            "edited_pr_url": context.get("pr", {}).get("url"),
+            "common_path_sufficient": None,
+            "raw_reread_count": None,
+            "estimated_packet_tokens": None,
+            "estimated_delegation_savings": None,
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        packet_metrics = result.get("packet_metrics") or {}
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        packet_count = safe_int(packet_metrics.get("packet_count"))
+        if packet_count is None:
+            packet_count = safe_int(result.get("packet_count"))
+        if packet_count is not None:
+            skill_data["packet_count"] = packet_count
+        if result.get("rewrite_strategy") is not None:
+            skill_data["rewrite_strategy"] = result.get("rewrite_strategy")
+        if result.get("qa_required") is not None:
+            skill_data["qa_required"] = to_bool(result.get("qa_required"))
+        if result.get("qa_reason") is not None:
+            skill_data["qa_reason"] = result.get("qa_reason")
+        if result.get("common_path_sufficient") is not None:
+            skill_data["common_path_sufficient"] = to_bool(result.get("common_path_sufficient"))
+        if result.get("raw_reread_count") is not None:
+            skill_data["raw_reread_count"] = safe_int(result.get("raw_reread_count"))
+            orchestration["raw_reread_required"] = (safe_int(result.get("raw_reread_count")) or 0) > 0
+        estimated_packet_tokens = safe_int(packet_metrics.get("estimated_packet_tokens"))
+        estimated_delegation_savings = safe_int(packet_metrics.get("estimated_delegation_savings"))
+        if estimated_packet_tokens is not None:
+            skill_data["estimated_packet_tokens"] = estimated_packet_tokens
+        if estimated_delegation_savings is not None:
+            skill_data["estimated_delegation_savings"] = estimated_delegation_savings
+        baseline = log.setdefault("baseline", {})
+        estimated_local_only = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+        if estimated_local_only is not None:
+            baseline["estimated_local_only_tokens"] = estimated_local_only
+            baseline["method"] = "packet-byte-proxy"
+            baseline["confidence"] = "estimated"
+            baseline["paired_run_available"] = True
+        if estimated_delegation_savings is not None:
+            baseline["estimated_token_savings"] = estimated_delegation_savings
+            baseline["estimated_delegation_savings"] = estimated_delegation_savings
+        if estimated_packet_tokens is not None:
+            log.setdefault("measurement", {})["token_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        if result.get("qa_required") is not None:
+            skill_data["qa_required"] = to_bool(result.get("qa_required"))
+        if result.get("qa_reason") is not None:
+            skill_data["qa_reason"] = result.get("qa_reason")
+        if result.get("validation_commands") is not None:
+            skill_data["validation_commands"] = list_of_strings(result.get("validation_commands"))
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        if result.get("qa_required") is not None:
+            skill_data["qa_required"] = to_bool(result.get("qa_required"))
+        if result.get("qa_clear") is not None:
+            skill_data["qa_ran"] = to_bool(result.get("qa_required")) or to_bool(result.get("qa_clear"))
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_apply_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_apply_pr_writeup.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import apply_pr_writeup as apply_pr_writeup  # noqa: E402
+import validate_pr_writeup_edit as validator  # noqa: E402
+
+
+def collected_context(repo_root: Path) -> dict:
+    body = "\n".join(
+        [
+            "## Why",
+            "Clarify the shipped behavior and validation evidence.",
+            "## What changed",
+            "- Tightened diagnostics wording.",
+            "- Added lint coverage for PR text review.",
+            "## How",
+            "- Re-read the rules packet before changing PR text.",
+            "## Risk / Rollback",
+            "- Revert the PR text update if it overstates the diff.",
+            "## Testing",
+            "- Ran `python -m unittest discover tests`.",
+        ]
+    )
+    return {
+        "repo_root": str(repo_root),
+        "repo_slug": "owner/repo",
+        "pr": {
+            "number": 7,
+            "title": "docs(pr-writeup): tighten lint coverage",
+            "body": body,
+            "url": "https://example.invalid/pr/7",
+            "headRefName": "codex/guard",
+            "headRefOid": "abc123def456",
+            "baseRefName": "main",
+        },
+        "changed_files": [
+            "README.md",
+            "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+        ],
+        "changed_file_groups": {
+            "runtime": {"count": 1, "sample_files": ["ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 1, "sample_files": ["README.md"]},
+            "tests": {"count": 0, "sample_files": []},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "expected_template_sections": [
+            "Why",
+            "What changed",
+            "How",
+            "Risk / Rollback",
+            "Testing",
+        ],
+        "current_body_sections": [
+            "Why",
+            "What changed",
+            "How",
+            "Risk / Rollback",
+            "Testing",
+        ],
+        "checks": {
+            "title_matches_conventional_commit": True,
+            "title_length": 42,
+            "body_has_template_sections": True,
+        },
+    }
+
+
+def replacement_body() -> str:
+    return "\n".join(
+        [
+            "## Why",
+            "Clarify the shipped behavior and add a guarded PR edit path.",
+            "## What changed",
+            "- Added a pre-edit snapshot guard before applying PR text.",
+            "- Confirmed the updated writeup after apply.",
+            "## How",
+            "- Re-fetched the live PR snapshot before gh pr edit.",
+            "## Risk / Rollback",
+            "- Revert the PR text update if the replacement is inaccurate.",
+            "## Testing",
+            "- Ran `python -m unittest discover tests`.",
+        ]
+    )
+
+
+class ApplyPrWriteupTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def read_json(self, path: Path) -> dict:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def validation_payload(self, repo_root: Path) -> dict:
+        context = collected_context(repo_root)
+        normalized_edit = {
+            "repo_root": str(repo_root),
+            "repo_slug": "owner/repo",
+            "pr_number": 7,
+            "title": "docs(pr-writeup): add guarded apply helper",
+            "body": replacement_body(),
+            "validated_snapshot": {
+                "title": context["pr"]["title"],
+                "body": context["pr"]["body"],
+                "url": context["pr"]["url"],
+                "headRefName": context["pr"]["headRefName"],
+                "headRefOid": context["pr"]["headRefOid"],
+                "baseRefName": context["pr"]["baseRefName"],
+                "changed_files": context["changed_files"],
+            },
+            "validation_commands": ["candidate lint", "gh auth status"],
+            "review_mode": "targeted-delegation",
+            "qa_gate": {
+                "required": False,
+                "reason": None,
+                "qa_clear": False,
+                "worker_claim_conflict": False,
+                "raw_reread_reasons": [],
+                "qa_summary": None,
+            },
+        }
+        return {
+            "valid": True,
+            "can_apply": True,
+            "normalized_edit": normalized_edit,
+            "normalized_edit_fingerprint": validator.json_fingerprint(normalized_edit),
+            "context_file_fingerprint": "unused-by-apply",
+            "apply_gate_status": {
+                "status": "pass",
+                "applicable_stop_categories": ["stale_context", "validator_mismatch", "missing_auth", "unresolved_stop_reason"],
+                "covered_stop_categories": ["stale_context", "validator_mismatch", "missing_auth", "unresolved_stop_reason"],
+                "uncovered_stop_categories": [],
+                "not_applicable_stop_categories": ["ambiguous_routing", "missing_required_evidence"],
+                "local_stop_categories": ["invalid_candidate", "live_snapshot_unavailable", "unsupported_claims_detected", "qa_required"],
+            },
+        }
+
+    def test_apply_rejects_qa_required_validation_without_clear(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation = self.validation_payload(repo_root)
+            validation["normalized_edit"]["qa_gate"] = {
+                "required": True,
+                "reason": "claim conflict requires QA cross-check",
+                "qa_clear": False,
+                "worker_claim_conflict": True,
+                "raw_reread_reasons": [],
+                "qa_summary": None,
+            }
+            validation["normalized_edit_fingerprint"] = validator.json_fingerprint(validation["normalized_edit"])
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            self.write_json(validation_path, validation)
+
+            stderr = io.StringIO()
+            with mock.patch.object(
+                apply_pr_writeup.tools,
+                "run_command",
+                side_effect=AssertionError("gh command should not run while QA gate is still closed"),
+            ), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "apply_pr_writeup.py",
+                    "--validation",
+                    str(validation_path),
+                    "--result-output",
+                    str(result_path),
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = apply_pr_writeup.main()
+
+            self.assertEqual(exit_code, 1)
+            payload = self.read_json(result_path)
+            self.assertEqual(payload["stop_reason"], "validator_mismatch")
+            self.assertIn("qa", stderr.getvalue().lower())
+
+    def test_dry_run_stops_when_live_snapshot_is_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            self.write_json(validation_path, self.validation_payload(repo_root))
+            recorded_calls: list[list[str]] = []
+
+            def fake_run_command(args: list[str], cwd: Path) -> str:
+                recorded_calls.append(args)
+                if args[:3] == ["gh", "auth", "status"]:
+                    return "Logged in to github.com"
+                if args[:3] == ["gh", "pr", "view"]:
+                    return json.dumps(collected_context(repo_root)["pr"])
+                if args[:4] == ["gh", "pr", "diff", "7"]:
+                    return "\n".join(
+                        [
+                            "README.md",
+                            "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+                            "MAINTAINING.md",
+                        ]
+                    )
+                raise AssertionError(f"Unexpected command: {args}")
+
+            stderr = io.StringIO()
+            with mock.patch.object(apply_pr_writeup.tools, "run_command", side_effect=fake_run_command), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "apply_pr_writeup.py",
+                    "--validation",
+                    str(validation_path),
+                    "--result-output",
+                    str(result_path),
+                    "--dry-run",
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = apply_pr_writeup.main()
+
+            self.assertEqual(exit_code, 1)
+            payload = self.read_json(result_path)
+            self.assertEqual(payload["stop_reason"], "stale_context")
+            self.assertEqual(payload["command"], None)
+            stale_fields = payload["stale_fields"]
+            self.assertEqual(stale_fields[0]["field"], "changed_files")
+            self.assertEqual(
+                recorded_calls,
+                [
+                    ["gh", "auth", "status"],
+                    ["gh", "pr", "view", "7", "--json", "number,title,body,headRefName,headRefOid,baseRefName,url,closingIssuesReferences", "--repo", "owner/repo"],
+                    ["gh", "pr", "diff", "7", "--name-only", "--repo", "owner/repo"],
+                ],
+            )
+            self.assertIn("live PR snapshot changed", stderr.getvalue())
+
+    def test_apply_rejects_tampered_validator_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            validation = self.validation_payload(repo_root)
+            validation["normalized_edit"]["title"] = "docs(pr-writeup): tampered"
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            self.write_json(validation_path, validation)
+
+            stderr = io.StringIO()
+            with mock.patch.object(
+                apply_pr_writeup.tools,
+                "run_command",
+                side_effect=AssertionError("gh command should not run for tampered validator output"),
+            ), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "apply_pr_writeup.py",
+                    "--validation",
+                    str(validation_path),
+                    "--result-output",
+                    str(result_path),
+                ],
+            ), redirect_stderr(stderr):
+                exit_code = apply_pr_writeup.main()
+
+            self.assertEqual(exit_code, 1)
+            payload = self.read_json(result_path)
+            self.assertEqual(payload["stop_reason"], "validator_mismatch")
+            self.assertIn("validator mismatch", stderr.getvalue().lower())
+
+    def test_apply_edits_after_snapshot_guard_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            repo_root = tmp / "repo"
+            repo_root.mkdir()
+            context = collected_context(repo_root)
+            validation_path = tmp / "validation.json"
+            result_path = tmp / "result.json"
+            validation = self.validation_payload(repo_root)
+            self.write_json(validation_path, validation)
+            new_body = validation["normalized_edit"]["body"]
+            new_title = validation["normalized_edit"]["title"]
+            view_calls = 0
+
+            def fake_run_command(args: list[str], cwd: Path) -> str:
+                nonlocal view_calls
+                if args[:3] == ["gh", "auth", "status"]:
+                    return "Logged in to github.com"
+                if args[:3] == ["gh", "pr", "view"]:
+                    view_calls += 1
+                    if view_calls == 1:
+                        return json.dumps(context["pr"])
+                    confirmed = dict(context["pr"])
+                    confirmed["title"] = new_title
+                    confirmed["body"] = new_body
+                    return json.dumps(confirmed)
+                if args[:4] == ["gh", "pr", "diff", "7"]:
+                    return "\n".join(context["changed_files"])
+                if args[:3] == ["gh", "pr", "edit"]:
+                    self.assertEqual(args[4], "--title")
+                    self.assertEqual(args[5], new_title)
+                    self.assertIn("--body-file", args)
+                    return ""
+                raise AssertionError(f"Unexpected command: {args}")
+
+            stdout = io.StringIO()
+            with mock.patch.object(apply_pr_writeup.tools, "run_command", side_effect=fake_run_command), mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "apply_pr_writeup.py",
+                    "--validation",
+                    str(validation_path),
+                    "--result-output",
+                    str(result_path),
+                ],
+            ), redirect_stdout(stdout):
+                exit_code = apply_pr_writeup.main()
+
+            self.assertEqual(exit_code, 0)
+            payload = self.read_json(result_path)
+            self.assertTrue(payload["apply_succeeded"])
+            self.assertEqual(payload["command"][:3], ["gh", "pr", "edit"])
+            self.assertEqual(payload["current_pr_url"], context["pr"]["url"])
+            self.assertEqual(json.loads(stdout.getvalue())["apply_succeeded"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_build_pr_review_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_build_pr_review_packets.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import build_pr_review_packets as packets  # noqa: E402
+
+
+def base_context(*, broad: bool) -> dict:
+    changed_files = [
+        "ExampleProduct/Mod.cs",
+        "README.md",
+    ]
+    if broad:
+        changed_files.extend(
+            [
+                ".github/instructions/pull-request.instructions.md",
+                ".github/workflows/release.yml",
+                "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+                "ExampleProduct/Setting.cs",
+                "MAINTAINING.md",
+                "CONTRIBUTING.md",
+                "ExampleProduct/ExampleProduct.csproj",
+                "docs/faq.md",
+                ".github/scripts/check_release.py",
+                "tests/test_writeup_rules.py",
+            ]
+        )
+    sample_groups = {
+        "runtime": {
+            "count": 2 if broad else 1,
+            "sample_files": [
+                "ExampleProduct/Mod.cs",
+                *(["ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs"] if broad else []),
+            ],
+        },
+        "automation": {
+            "count": 2 if broad else 0,
+            "sample_files": [
+                *([ ".github/instructions/pull-request.instructions.md"] if broad else []),
+                *([".github/workflows/release.yml"] if broad else []),
+            ],
+        },
+        "docs": {
+            "count": 3 if broad else 1,
+            "sample_files": ["README.md", *(["MAINTAINING.md"] if broad else [])],
+        },
+        "tests": {
+            "count": 2 if broad else 0,
+            "sample_files": [*(["tests/writeup_packets_test.py", "tests/test_writeup_rules.py"] if broad else [])],
+        },
+        "config": {
+            "count": 1 if broad else 0,
+            "sample_files": ["ExampleProduct/ExampleProduct.csproj"] if broad else [],
+        },
+        "other": {"count": 0, "sample_files": []},
+    }
+    body = "\n".join(
+        [
+            "## Why",
+            "The current writeup is too vague.",
+            "## What changed",
+            "- Reworked the PR body structure.",
+            "## How",
+            "Updated the template sections.",
+            "## Risk / Rollback",
+            "Minimal risk.",
+            "## Testing",
+            "Not run.",
+        ]
+    )
+    return {
+        "repo_root": str(Path.cwd()),
+        "repo_slug": "owner/repo",
+        "pr": {
+            "number": 42,
+            "title": "docs: polish PR text",
+            "url": "https://example.com/pr/42",
+            "body": body,
+            "headRefName": "codex/writeup",
+            "headRefOid": "abc123",
+            "baseRefName": "main",
+            "closingIssuesReferences": [{"number": 9}],
+        },
+        "changed_files": changed_files,
+        "changed_file_groups": sample_groups,
+        "diff_stat": f" {len(changed_files)} files changed, 280 insertions(+), 35 deletions(-)" if broad else " 4 files changed, 28 insertions(+), 5 deletions(-)",
+        "checks": {
+            "title_matches_conventional_commit": False,
+            "body_has_template_sections": True,
+        },
+        "expected_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "current_body_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "rule_files": {"pull_request_template": ".github/pull_request_template.md"},
+        "instruction_snippets": {
+            "pull_request_title_rules_excerpt": "Use Conventional Commit titles.",
+            "pull_request_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+            "commit_types_excerpt": "feat, fix, docs",
+        },
+    }
+
+
+def lint_payload() -> dict:
+    return {
+        "findings": {
+            "errors": ["Template guidance text is still present in `How`."],
+            "warnings": ["`Testing` does not cite any exact command or concrete verification step."],
+            "info": [],
+            "detected": {},
+            "drafting_basis": {
+                "rewrite_strategy": "full-rewrite",
+                "active_rule_gates": ["title_pattern", "required_sections", "testing_evidence"],
+                "current_failures": {
+                    "errors": ["Template guidance text is still present in `How`."],
+                    "warnings": ["`Testing` does not cite any exact command or concrete verification step."],
+                },
+                "title_direction": {"status": "rewrite", "current_title": "docs: polish PR text", "constraint": "<type>(<scope>): <summary>"},
+                "required_sections_status": {
+                    "required": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+                    "present": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+                    "missing": [],
+                    "ordered": True,
+                },
+                "section_rewrite_requirements": [{"section": "How", "reason": "Template guidance text is still present in `How`."}],
+                "supported_claims": [{"cluster": "runtime", "basis": "runtime files changed", "evidence_anchor": "ExampleProduct/Mod.cs"}],
+                "unsupported_claim_risks": ["defaults_thresholds"],
+                "testing_evidence_status": {"present": True, "has_exact_command": False, "status": "needs-recheck"},
+                "issue_ref_status": {"metadata_refs": ["9"], "body_refs": [], "matched_refs": [], "status": "missing-body-ref"},
+                "coverage_gaps": ["testing claims need an exact command or concrete verification step."],
+            },
+        },
+        "drafting_basis": {
+            "rewrite_strategy": "full-rewrite",
+            "active_rule_gates": ["title_pattern", "required_sections", "testing_evidence"],
+            "current_failures": {
+                "errors": ["Template guidance text is still present in `How`."],
+                "warnings": ["`Testing` does not cite any exact command or concrete verification step."],
+            },
+            "title_direction": {"status": "rewrite", "current_title": "docs: polish PR text", "constraint": "<type>(<scope>): <summary>"},
+            "required_sections_status": {
+                "required": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+                "present": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+                "missing": [],
+                "ordered": True,
+            },
+            "section_rewrite_requirements": [{"section": "How", "reason": "Template guidance text is still present in `How`."}],
+            "supported_claims": [{"cluster": "runtime", "basis": "runtime files changed", "evidence_anchor": "ExampleProduct/Mod.cs"}],
+            "unsupported_claim_risks": ["defaults_thresholds"],
+            "testing_evidence_status": {"present": True, "has_exact_command": False, "status": "needs-recheck"},
+            "issue_ref_status": {"metadata_refs": ["9"], "body_refs": [], "matched_refs": [], "status": "missing-body-ref"},
+            "coverage_gaps": ["testing claims need an exact command or concrete verification step."],
+        },
+    }
+
+
+class BuildPrReviewPacketsTests(unittest.TestCase):
+    def run_builder(self, context: dict, lint: dict) -> tuple[Path, dict]:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        tmp = Path(temp_dir.name)
+        context_path = tmp / "context.json"
+        lint_path = tmp / "lint.json"
+        output_dir = tmp / "packets"
+        result_path = tmp / "build-result.json"
+        context_path.write_text(json.dumps(context), encoding="utf-8")
+        lint_path.write_text(json.dumps(lint), encoding="utf-8")
+        argv = [
+            "build_pr_review_packets.py",
+            "--context",
+            str(context_path),
+            "--lint",
+            str(lint_path),
+            "--output-dir",
+            str(output_dir),
+            "--result-output",
+            str(result_path),
+        ]
+        with patch.object(sys, "argv", argv):
+            self.assertEqual(packets.main(), 0)
+        return output_dir, json.loads(result_path.read_text(encoding="utf-8"))
+
+    def test_broad_full_rewrite_emits_packet_heavy_profile_and_qa_gate(self) -> None:
+        output_dir, build_result = self.run_builder(base_context(broad=True), lint_payload())
+        orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+        global_packet = json.loads((output_dir / "global_packet.json").read_text(encoding="utf-8"))
+        rules_packet = json.loads((output_dir / "rules_packet.json").read_text(encoding="utf-8"))
+        synthesis_packet = json.loads((output_dir / "synthesis_packet.json").read_text(encoding="utf-8"))
+        packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(orchestrator["orchestrator_profile"], "packet-heavy-orchestrator")
+        self.assertEqual(orchestrator["shared_local_packet"], "synthesis_packet.json")
+        self.assertEqual(orchestrator["packet_worker_map"], packets.PACKET_WORKER_MAP)
+        self.assertEqual(global_packet["packet_worker_map"], packets.PACKET_WORKER_MAP)
+        self.assertNotIn("packet_size_bytes", orchestrator)
+        self.assertNotIn("estimated_packet_tokens", orchestrator)
+        self.assertIn("packet_size_bytes", packet_metrics)
+        self.assertGreater(packet_metrics["estimated_delegation_savings"], 0)
+        self.assertLess(packet_metrics["estimated_packet_tokens"], packet_metrics["estimated_local_only_tokens"])
+        self.assertEqual(build_result["qa_required"], True)
+        self.assertEqual(synthesis_packet["qa_required"], True)
+        self.assertEqual(synthesis_packet["rewrite_strategy"], "full-rewrite")
+        self.assertEqual(synthesis_packet["focused_packet_hint"], "testing_packet.json")
+        self.assertNotIn("repo_instruction_excerpts", synthesis_packet)
+        self.assertNotIn("current_failures", rules_packet)
+        self.assertIn("repo_instruction_excerpts", rules_packet)
+        self.assertIn("current_failures", synthesis_packet)
+        self.assertEqual(orchestrator["common_path_contract"]["required_packets"], ["rules_packet.json", "synthesis_packet.json"])
+
+    def test_small_full_rewrite_does_not_force_qa(self) -> None:
+        output_dir, build_result = self.run_builder(base_context(broad=False), lint_payload())
+        synthesis_packet = json.loads((output_dir / "synthesis_packet.json").read_text(encoding="utf-8"))
+        self.assertEqual(build_result["review_mode"], "local-only")
+        self.assertFalse(build_result["qa_required"])
+        self.assertFalse(synthesis_packet["qa_required"])
+        self.assertIsNone(synthesis_packet["qa_reason"])
+
+    def test_common_path_contract_and_metrics_result_are_written(self) -> None:
+        output_dir, build_result = self.run_builder(base_context(broad=False), lint_payload())
+        packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+        self.assertTrue(build_result["common_path_sufficient"])
+        self.assertEqual(build_result["raw_reread_count"], 0)
+        self.assertEqual(packet_metrics["common_path_packets"][:2], ["rules_packet.json", "synthesis_packet.json"])
+        self.assertTrue(packet_metrics["packet_insufficiency_is_failure"])
+        self.assertIn("synthesis_packet.json", build_result["packet_files"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_collect_pr_context.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_collect_pr_context.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import collect_pr_context as collect_pr_context  # type: ignore  # noqa: E402
+
+
+class CollectPrContextTests(unittest.TestCase):
+    def test_main_stops_cleanly_when_build_context_raises_runtime_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            profile_path = tmp / "profile.json"
+            profile_path.write_text('{"name":"default","summary":"test"}\n', encoding="utf-8")
+            stderr = io.StringIO()
+            argv = [
+                "collect_pr_context.py",
+                "1",
+                "--repo-root",
+                str(tmp),
+                "--profile",
+                str(profile_path),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(
+                    collect_pr_context,
+                    "build_context",
+                    side_effect=RuntimeError("gh executable not found"),
+                ),
+                redirect_stderr(stderr),
+            ):
+                exit_code = collect_pr_context.main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("collect_pr_context.py: gh executable not found", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_lint_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_lint_pr_writeup.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import lint_pr_writeup as lint  # noqa: E402
+
+
+def broken_context() -> dict:
+    body = "\n".join(
+        [
+            "## Why",
+            "The existing PR writeup is vague.",
+            "Refs: #",
+            "## What changed",
+            "- ",
+            "## How",
+            "Note any important defaults, thresholds, reload/restart requirements, or",
+            "## PR Classification (optional)",
+            "- [x] Bug fix",
+            "",
+            "Justification:",
+        ]
+    )
+    return {
+        "pr": {
+            "number": 42,
+            "title": "Rewrite PR writeup",
+            "url": "https://example.invalid/pr/42",
+            "body": body,
+        },
+        "expected_template_sections": [
+            "Why",
+            "What changed",
+            "How",
+            "Risk / Rollback",
+            "Testing",
+            "PR Classification (optional)",
+        ],
+        "current_body_sections": [
+            "Why",
+            "What changed",
+            "How",
+            "PR Classification (optional)",
+        ],
+        "changed_file_groups": {
+            "runtime": {"count": 1, "sample_files": ["ExampleProduct/Mod.cs"]},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 1, "sample_files": ["README.md"]},
+            "tests": {"count": 0, "sample_files": []},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+    }
+
+
+def clean_context() -> dict:
+    body = "\n".join(
+        [
+            "## Why",
+            "Clarify the shipped change and the validation evidence.",
+            "## What changed",
+            "- Tightened the audit report contract reference.",
+            "- Added deterministic linter coverage for the audit payload.",
+            "## How",
+            "- Re-read the rules packet before any local edit.",
+            "## Risk / Rollback",
+            "- Revert the PR text update if it overstates the diff.",
+            "## Testing",
+            "- Ran `python -m unittest discover tests`.",
+        ]
+    )
+    return {
+        "pr": {
+            "number": 7,
+            "title": "docs(pr-writeup): tighten lint coverage",
+            "url": "https://example.invalid/pr/7",
+            "body": body,
+        },
+        "expected_template_sections": [
+            "Why",
+            "What changed",
+            "How",
+            "Risk / Rollback",
+            "Testing",
+        ],
+        "current_body_sections": [
+            "Why",
+            "What changed",
+            "How",
+            "Risk / Rollback",
+            "Testing",
+        ],
+        "changed_file_groups": {
+            "runtime": {"count": 0, "sample_files": []},
+            "automation": {"count": 0, "sample_files": []},
+            "docs": {"count": 2, "sample_files": ["SKILL.md", "references/pr-writeup-contract.md"]},
+            "tests": {"count": 1, "sample_files": ["tests/test_lint_pr_writeup.py"]},
+            "config": {"count": 0, "sample_files": []},
+            "other": {"count": 0, "sample_files": []},
+        },
+    }
+
+
+class LintPrWriteupTests(unittest.TestCase):
+    def test_collect_findings_flags_title_and_template_errors(self) -> None:
+        context = broken_context()
+        findings = lint.collect_findings(context)
+
+        self.assertTrue(
+            any("Title does not match" in message for message in findings["errors"])
+        )
+        self.assertIn(
+            "Body is missing template sections: Risk / Rollback, Testing.",
+            findings["errors"],
+        )
+        self.assertIn("Changed areas: runtime, docs", findings["info"])
+
+    def test_main_emits_findings_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            context_path = tmp / "context.json"
+            output_path = tmp / "lint.json"
+            context_path.write_text(json.dumps(clean_context()), encoding="utf-8")
+
+            argv = [
+                "lint_pr_writeup.py",
+                "--context",
+                str(context_path),
+                "--output",
+                str(output_path),
+            ]
+            with patch.object(sys, "argv", argv):
+                self.assertEqual(lint.main(), 0)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["findings"]["errors"], [])
+            self.assertEqual(payload["findings"]["warnings"], [])
+            self.assertNotIn("audit_report", payload)
+            self.assertEqual(payload["url"], "https://example.invalid/pr/7")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_pr_writeup_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_pr_writeup_tools.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import pr_writeup_tools as tools  # noqa: E402
+
+
+class PrWriteupToolsTests(unittest.TestCase):
+    def test_infer_repo_slug_accepts_dotted_repo_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "remote", "add", "origin", "git@github.com:owner/my.repo.git"],
+                cwd=str(repo_root),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(tools.infer_repo_slug(repo_root), "owner/my.repo")
+
+    def test_run_command_wraps_missing_executable(self) -> None:
+        with mock.patch.object(tools.subprocess, "run", side_effect=FileNotFoundError("gh")):
+            with self.assertRaises(RuntimeError) as exc_info:
+                tools.run_command(["gh", "auth", "status"], cwd=Path("C:/repo"))
+        self.assertEqual(str(exc_info.exception), "gh executable not found")
+
+    def test_classify_changed_files_and_summary_cover_expected_groups(self) -> None:
+        groups = tools.classify_changed_files(
+            [
+                "ExampleProduct/Mod.cs",
+                ".github/workflows/check.yml",
+                "docs/guide.md",
+                "tests/writeup_test.py",
+                "Directory.Build.props",
+                "assets/icon.png",
+            ]
+        )
+        summary = tools.summarize_groups(groups)
+
+        self.assertEqual(summary["runtime"]["count"], 1)
+        self.assertEqual(summary["automation"]["count"], 1)
+        self.assertEqual(summary["docs"]["count"], 1)
+        self.assertEqual(summary["tests"]["count"], 1)
+        self.assertEqual(summary["config"]["count"], 1)
+        self.assertEqual(summary["other"]["count"], 1)
+        self.assertEqual(summary["runtime"]["sample_files"], ["ExampleProduct/Mod.cs"])
+        self.assertEqual(summary["tests"]["sample_files"], ["tests/writeup_test.py"])
+        self.assertEqual(summary["config"]["sample_strategy"], "directory_round_robin")
+
+    def test_select_representative_files_round_robins_then_preserves_original_order(self) -> None:
+        selected = tools.select_representative_files(
+            [
+                "src/a/one.cs",
+                "src/a/two.cs",
+                "src/b/one.cs",
+                "src/b/two.cs",
+                "docs/alpha.md",
+                "docs/beta.md",
+            ],
+            limit=4,
+        )
+
+        self.assertEqual(
+            selected,
+            [
+                "src/a/one.cs",
+                "src/a/two.cs",
+                "src/b/one.cs",
+                "docs/alpha.md",
+            ],
+        )
+
+    def test_first_heading_block_returns_requested_heading_only(self) -> None:
+        markdown = "\n".join(
+            [
+                "# Title",
+                "## PR Title",
+                "- Use a conventional title.",
+                "",
+                "## Body",
+                "- Keep the template order.",
+            ]
+        )
+
+        self.assertEqual(
+            tools.first_heading_block(markdown, "## PR Title"),
+            "## PR Title\n- Use a conventional title.",
+        )
+
+    def test_load_pr_changed_files_falls_back_to_api_when_diff_is_too_large(self) -> None:
+        with mock.patch.object(
+            tools,
+            "run_command",
+            side_effect=[
+                subprocess.CalledProcessError(
+                    1,
+                    ["gh", "pr", "diff", "7", "--name-only", "--repo", "owner/repo"],
+                    stderr=(
+                        "could not find pull request diff: HTTP 406: Sorry, the diff exceeded "
+                        "the maximum number of lines (20000)\nPullRequest.diff too_large"
+                    ),
+                ),
+                "src/foo.py\nsrc/bar.py\n",
+            ],
+        ) as run_command:
+            result = tools.load_pr_changed_files(7, Path("C:/repo"), "owner/repo")
+
+        self.assertEqual(result, ["src/foo.py", "src/bar.py"])
+        self.assertEqual(run_command.call_count, 2)
+        self.assertEqual(
+            run_command.call_args_list[1].args[0],
+            [
+                "gh",
+                "api",
+                "repos/owner/repo/pulls/7/files",
+                "--paginate",
+                "--jq",
+                ".[].filename",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_validate_pr_writeup_edit.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_validate_pr_writeup_edit.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import validate_pr_writeup_edit as validator  # noqa: E402
+
+
+def collected_context(repo_root: Path, *, broad: bool = False) -> dict:
+    body = "\n".join(
+        [
+            "## Why",
+            "Clarify the shipped behavior and validation evidence.",
+            "## What changed",
+            "- Tightened diagnostics wording.",
+            "- Added lint coverage for PR text review.",
+            "## How",
+            "- Re-read the rules packet before changing PR text.",
+            "## Risk / Rollback",
+            "- Revert the PR text update if it overstates the diff.",
+            "## Testing",
+            "- Ran `python -m unittest discover tests`.",
+        ]
+    )
+    changed_files = [
+        "README.md",
+        "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs",
+    ]
+    if broad:
+        changed_files.extend(
+            [
+                ".github/instructions/pull-request.instructions.md",
+                ".github/workflows/release.yml",
+                "MAINTAINING.md",
+                "CONTRIBUTING.md",
+                "ExampleProduct/Setting.cs",
+                "tests/test_writeup_rules.py",
+                "ExampleProduct/ExampleProduct.csproj",
+                "docs/faq.md",
+                ".github/scripts/check_release.py",
+                "README_ko.md",
+                "README.md.bak",
+                "docs/usage.md",
+                "docs/testing.md",
+                ".github/ISSUE_TEMPLATE/bug_report.yml",
+                "ExampleProduct/Telemetry/Probe.cs",
+                "ExampleProduct/Mod.cs",
+                "ExampleProduct/Patches/Hook.cs",
+                "ExampleProduct/Properties/PublishConfiguration.xml",
+                "tests/test_apply_guard.py",
+                "tests/test_build_packets.py",
+                "tests/test_lint.py",
+            ]
+        )
+    return {
+        "repo_root": str(repo_root),
+        "repo_slug": "owner/repo",
+        "pr": {
+            "number": 7,
+            "title": "docs(pr-writeup): tighten lint coverage",
+            "body": body,
+            "url": "https://example.invalid/pr/7",
+            "headRefName": "codex/guard",
+            "headRefOid": "abc123def456",
+            "baseRefName": "main",
+            "closingIssuesReferences": [{"number": 42}],
+        },
+        "changed_files": changed_files,
+        "changed_file_groups": {
+            "runtime": {"count": 2 if broad else 1, "sample_files": ["ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs", *(["ExampleProduct/Setting.cs"] if broad else [])]},
+            "automation": {"count": 3 if broad else 0, "sample_files": [".github/instructions/pull-request.instructions.md", *([".github/workflows/release.yml"] if broad else [])]},
+            "docs": {"count": 4 if broad else 1, "sample_files": ["README.md", *(["MAINTAINING.md"] if broad else [])]},
+            "tests": {"count": 3 if broad else 0, "sample_files": ["tests/test_writeup_rules.py"] if broad else []},
+            "config": {"count": 1 if broad else 0, "sample_files": ["ExampleProduct/ExampleProduct.csproj"] if broad else []},
+            "other": {"count": 0, "sample_files": []},
+        },
+        "expected_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "current_body_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "checks": {
+            "title_matches_conventional_commit": True,
+            "title_length": 42,
+            "body_has_template_sections": True,
+        },
+        "diff_stat": (" 23 files changed, 280 insertions(+), 40 deletions(-)" if broad else " 2 files changed, 5 insertions(+), 1 deletion(-)"),
+    }
+
+
+def valid_candidate_body() -> str:
+    return "\n".join(
+        [
+            "## Why",
+            "Clarify the shipped behavior and evidence boundaries.",
+            "## What changed",
+            "- Added a guarded validate/apply path for PR text edits.",
+            "- Kept the final writeup aligned with the inspected diff.",
+            "## How",
+            "- Re-fetched the live PR snapshot before the guarded mutation.",
+            "## Risk / Rollback",
+            "- Revert the PR text if the replacement proves inaccurate.",
+            "## Testing",
+            "- Ran `python -m unittest discover tests`.",
+            "Refs: #42",
+        ]
+    )
+
+
+def qa_keep() -> dict:
+    return {
+        "keep_or_revise": "keep",
+        "rule_violations": [],
+        "coverage_gaps": [],
+        "unsupported_claims": [],
+    }
+
+
+class ValidatePrWriteupEditTests(unittest.TestCase):
+    def test_validator_rejects_invalid_candidate_before_gh_calls(self) -> None:
+        context = collected_context(Path.cwd())
+        with mock.patch.object(
+            validator.tools,
+            "run_command",
+            side_effect=AssertionError("gh command should not run for invalid candidate lint"),
+        ):
+            payload = validator.validate_pr_writeup_edit(context, "bad title", "## Why\nInvalid.\n")
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("invalid_candidate", payload["stop_reasons"])
+        codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["candidate_lint_failed"], codes)
+
+    def test_validator_flags_unsupported_claims(self) -> None:
+        context = collected_context(Path.cwd())
+        body = valid_candidate_body().replace(
+            "- Re-fetched the live PR snapshot before the guarded mutation.",
+            "- Restart required after deploy because defaults changed.",
+        )
+        with mock.patch.object(
+            validator.tools,
+            "run_command",
+            side_effect=AssertionError("gh command should not run once unsupported claims are detected"),
+        ):
+            payload = validator.validate_pr_writeup_edit(
+                context,
+                "docs(pr-writeup): add guarded validator flow",
+                body,
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("unsupported_claims_detected", payload["stop_reasons"])
+        codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["unsupported_claims"], codes)
+
+    def test_validator_rejects_stale_context_after_live_snapshot_check(self) -> None:
+        context = collected_context(Path.cwd())
+
+        def fake_run_command(args: list[str], cwd: Path) -> str:
+            if args[:3] == ["gh", "auth", "status"]:
+                return "Logged in to github.com"
+            if args[:3] == ["gh", "pr", "view"]:
+                return json.dumps(context["pr"])
+            if args[:4] == ["gh", "pr", "diff", "7"]:
+                return "\n".join(context["changed_files"] + ["MAINTAINING.md"])
+            raise AssertionError(f"Unexpected command: {args}")
+
+        with mock.patch.object(validator.tools, "run_command", side_effect=fake_run_command):
+            payload = validator.validate_pr_writeup_edit(
+                context,
+                "docs(pr-writeup): add guarded validator flow",
+                valid_candidate_body(),
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("stale_context", payload["stop_reasons"])
+        self.assertEqual(payload["stale_fields"][0]["field"], "changed_files")
+
+    def test_validator_emits_normalized_edit_when_candidate_is_apply_safe(self) -> None:
+        context = collected_context(Path.cwd())
+
+        def fake_run_command(args: list[str], cwd: Path) -> str:
+            if args[:3] == ["gh", "auth", "status"]:
+                return "Logged in to github.com"
+            if args[:3] == ["gh", "pr", "view"]:
+                return json.dumps(context["pr"])
+            if args[:4] == ["gh", "pr", "diff", "7"]:
+                return "\n".join(context["changed_files"])
+            raise AssertionError(f"Unexpected command: {args}")
+
+        with mock.patch.object(validator.tools, "run_command", side_effect=fake_run_command):
+            payload = validator.validate_pr_writeup_edit(
+                context,
+                "docs(pr-writeup): add guarded validator flow",
+                valid_candidate_body(),
+            )
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["can_apply"])
+        self.assertEqual(payload["normalized_edit"]["pr_number"], 7)
+        self.assertEqual(payload["apply_gate_status"]["status"], "pass")
+        self.assertFalse(payload["qa_required"])
+        self.assertEqual(
+            sorted(payload["normalized_edit"]["validated_snapshot"].keys()),
+            sorted(["title", "body", "url", "headRefName", "headRefOid", "baseRefName", "changed_files"]),
+        )
+
+    def test_broad_full_rewrite_requires_qa_clear(self) -> None:
+        context = collected_context(Path.cwd(), broad=True)
+        full_rewrite = "\n".join(
+            [
+                "## Why",
+                "Rewrite the PR explanation to cover the full multi-area change set.",
+                "## What changed",
+                "- Rebuilt the whole writeup from scratch.",
+                "## How",
+                "- Rephrased the PR text after re-reading packets.",
+                "## Risk / Rollback",
+                "- Revert the PR text if the draft overstates the diff.",
+                "## Testing",
+                "- Ran `python -m unittest discover tests`.",
+                "Refs: #42",
+            ]
+        )
+
+        def fake_run_command(args: list[str], cwd: Path) -> str:
+            if args[:3] == ["gh", "auth", "status"]:
+                return "Logged in to github.com"
+            if args[:3] == ["gh", "pr", "view"]:
+                return json.dumps(context["pr"])
+            if args[:4] == ["gh", "pr", "diff", "7"]:
+                return "\n".join(context["changed_files"])
+            raise AssertionError(f"Unexpected command: {args}")
+
+        with mock.patch.object(validator.tools, "run_command", side_effect=fake_run_command):
+            payload = validator.validate_pr_writeup_edit(
+                context,
+                "docs(pr-writeup): rewrite multi-area summary",
+                full_rewrite,
+            )
+
+        self.assertFalse(payload["valid"])
+        self.assertTrue(payload["qa_required"])
+        self.assertIn("qa_required", payload["stop_reasons"])
+
+    def test_worker_claim_conflict_requires_qa(self) -> None:
+        context = collected_context(Path.cwd())
+
+        def fake_run_command(args: list[str], cwd: Path) -> str:
+            if args[:3] == ["gh", "auth", "status"]:
+                return "Logged in to github.com"
+            if args[:3] == ["gh", "pr", "view"]:
+                return json.dumps(context["pr"])
+            if args[:4] == ["gh", "pr", "diff", "7"]:
+                return "\n".join(context["changed_files"])
+            raise AssertionError(f"Unexpected command: {args}")
+
+        with mock.patch.object(validator.tools, "run_command", side_effect=fake_run_command):
+            payload = validator.validate_pr_writeup_edit(
+                context,
+                "docs(pr-writeup): add guarded validator flow",
+                valid_candidate_body(),
+                worker_claim_conflict=True,
+                qa_result=qa_keep(),
+            )
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["qa_required"])
+        self.assertTrue(payload["qa_clear"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_write_evaluation_log_gh_fix_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_write_evaluation_log_gh_fix_pr_writeup.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # noqa: E402
+
+
+def context() -> dict:
+    return {
+        "repo_root": str(Path.cwd()),
+        "repo_slug": "owner/repo",
+        "changed_files": ["README.md", "ExampleProduct/Systems/OfficeDemandDiagnosticsSystem.cs"],
+        "expected_template_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "current_body_sections": ["Why", "What changed", "How", "Risk / Rollback", "Testing"],
+        "pr": {
+            "number": 7,
+            "title": "docs(pr-writeup): tighten lint coverage",
+            "body": "body",
+            "url": "https://example.invalid/pr/7",
+            "headRefName": "codex/guard",
+            "headRefOid": "abc123def456",
+            "baseRefName": "main",
+        },
+    }
+
+
+def orchestrator() -> dict:
+    return {
+        "review_mode": "targeted-delegation",
+        "recommended_worker_count": 2,
+        "packet_files": [
+            "global_packet.json",
+            "rules_packet.json",
+            "runtime_packet.json",
+            "synthesis_packet.json",
+            "orchestrator.json",
+        ],
+        "shared_packet": "global_packet.json",
+    }
+
+
+class WriteEvaluationLogGhFixPrWriteupTests(unittest.TestCase):
+    def test_build_phase_merges_packet_metrics_and_common_path_fields(self) -> None:
+        log = eval_log.build_base_log(Path(eval_log.__file__), context(), orchestrator(), None)
+        result = {
+            "review_mode": "broad-delegation",
+            "recommended_worker_count": 3,
+            "rewrite_strategy": "full-rewrite",
+            "qa_required": True,
+            "qa_reason": "broad-delegation full rewrite requires QA cross-check",
+            "common_path_sufficient": True,
+            "raw_reread_count": 0,
+            "packet_metrics": {
+                "packet_count": 6,
+                "estimated_local_only_tokens": 2400,
+                "estimated_packet_tokens": 900,
+                "estimated_delegation_savings": 1500,
+            },
+        }
+
+        eval_log.apply_phase_update(log, "build", result, 0.25)
+
+        data = log["skill_specific"]["data"]
+        self.assertEqual(data["packet_count"], 6)
+        self.assertEqual(data["rewrite_strategy"], "full-rewrite")
+        self.assertTrue(data["qa_required"])
+        self.assertTrue(data["common_path_sufficient"])
+        self.assertEqual(data["raw_reread_count"], 0)
+        self.assertEqual(data["estimated_packet_tokens"], 900)
+        self.assertEqual(data["estimated_delegation_savings"], 1500)
+        self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 2400)
+        self.assertEqual(log["baseline"]["estimated_token_savings"], 1500)
+        self.assertEqual(log["measurement"]["token_source"], "estimated")
+
+    def test_validate_and_apply_merge_qa_state(self) -> None:
+        log = eval_log.build_base_log(Path(eval_log.__file__), context(), orchestrator(), None)
+
+        eval_log.apply_phase_update(
+            log,
+            "validate",
+            {
+                "valid": True,
+                "qa_required": True,
+                "qa_reason": "worker-local claim conflict",
+                "validation_commands": ["candidate lint", "gh auth status"],
+                "stop_reasons": [],
+            },
+            0.1,
+        )
+        eval_log.apply_phase_update(
+            log,
+            "apply",
+            {
+                "dry_run": True,
+                "qa_required": True,
+                "qa_clear": True,
+                "apply_succeeded": True,
+                "mutation_type": "gh_pr_edit",
+            },
+            0.2,
+        )
+
+        data = log["skill_specific"]["data"]
+        self.assertTrue(data["qa_required"])
+        self.assertEqual(data["qa_reason"], "worker-local claim conflict")
+        self.assertTrue(data["qa_ran"])
+        self.assertEqual(data["validation_commands"], ["candidate lint", "gh auth status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/SKILL.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: git-split-and-commit
+description: Review the active repository's current working tree, split local changes into logical commits, draft repo-compliant commit messages, and commit automatically when confidence is high. Use when Codex needs to inspect staged, unstaged, and untracked non-ignored changes, decide whether they belong in one or more commits, and apply the commits safely with packetized evidence and targeted validation.
+---
+
+# Git Split And Commit
+
+Use this skill as the packet-driven orchestration layer for turning one working tree into logical commits.
+
+This workflow follows the packet-workflow standard:
+- collect context deterministically before reading raw diffs broadly
+- build decision-ready packets and keep the final plan local
+- treat worker output as proposal-grade only
+- use `gpt-5.4-mini` only for narrow packet analysis when review mode says to delegate
+- keep git mutation local and stop on low confidence or stale worktree state
+
+Boundary:
+- Keep reusable packet-workflow semantics in `references/core-contract.md`.
+- Keep default repo bindings and review-doc ownership in `profiles/default/profile.json`.
+- Keep vendored repo overrides data-only in `.codex/project/profiles/`.
+
+Read `references/architecture-rationale.md` before changing packet metadata, delegation shape, or the default whole-file bias.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/git-split-and-commit/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/git-split-and-commit/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/git-split-and-commit/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Collect rules and worktree context before planning commits.
+- Write helper artifacts outside the repo root, preferably in a system temp directory.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_commit_rules.py --repo <repo-root> --output <rules-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_worktree_context.py --repo <repo-root> --output <worktree-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_commit_packets.py --rules <rules-json> --worktree <worktree-json> --output-dir <packet-dir> --result-output <build-result-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <worktree-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>`.
+- Merge the build result with `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --phase build --result <build-result-json> --log <eval-log-json>`.
+- Read `<packet-dir>/orchestrator.json` first.
+- Keep `<packet-dir>/global_packet.json` in view before reading any focused packet.
+- Read `rules_packet.json` and `worktree_packet.json` locally before drafting `commit-plan.json`.
+- Treat `rules_packet.json + worktree_packet.json + one focused packet at a time` as the common path. Raw diff rereads are exception-only after packet generation.
+
+2. Follow the review mode from `orchestrator.json`.
+- `local-only`: keep commit planning local.
+- `targeted-delegation`: use the routed mini workers for `rules_packet.json`, `worktree_packet.json`, `candidate-batch-XX.json`, or `split-file-XX.json`.
+- `broad-delegation`: use the routed mini workers and add QA only when batches, split candidates, or findings conflict.
+- Treat `packet_worker_map` as the routing authority and `preferred_worker_families` as explanatory metadata.
+- Treat `task_packet_names` as basename-only packet metadata and `packet_order` as the file-oriented packet list.
+- If `spawn_agent` is unavailable or fails, stay local on the same packet workflow.
+
+3. Respect the decision-ready packet contract.
+- `decision_ready_packets=true`
+- `worker_return_contract=classification-oriented`
+- `worker_output_shape=hierarchical`
+- Workers return hierarchical `candidates[]` plus `footer`; their output is proposal-grade only.
+- `candidate-batch-XX.json` packets describe logical commit buckets.
+- `split-file-XX.json` packets describe files that may need a split decision.
+- `candidate-batch-XX.json` and `split-file-XX.json` should be sufficient for common-path local adjudication; raw rereads stay exception-only after packet generation.
+
+4. Keep the critical path local.
+- Draft `commit-plan.json` locally using `references/commit-plan-contract.md`.
+- Re-check the rules and worktree packets locally before finalizing the plan.
+- Prefer whole-file commits unless a split-file packet clearly justifies a split.
+- Stop and ask when hunk confidence is low, the worktree fingerprint changed, a split packet stays ambiguous, or targeted checks cannot run locally.
+- If packet evidence is insufficient, record an explicit reread reason instead of silently falling back to the raw diff.
+- Validate `commit-plan.json` before running `apply_commit_plan.py`.
+- Treat `validate_commit_plan.py` as the only source of `normalized_plan` for apply and `--dry-run`.
+- Run `apply_commit_plan.py --validation <validation-json>` only after the validator emits a current, apply-safe normalized plan.
+
+## Delegation Rules
+
+- Pass `global_packet.json` plus one focused packet per worker.
+- Keep workers narrow and read-only.
+- Prefer these roles:
+  - `docs_verifier` for `rules_packet.json`
+  - `repo_mapper` for `worktree_packet.json`
+  - `evidence_summarizer` for `candidate-batch-XX.json`
+  - `large_diff_auditor` for `split-file-XX.json` and any QA pass
+- Require hierarchical proposal output from each worker:
+  - `candidates[]`
+  - `footer`
+  - `fact_summary`
+  - `proposal_classification`
+- `classification_rationale`
+- `supporting_references`
+- `ambiguity`
+- `confidence`
+- `reread_control`
+- Current domain aliases assume file/path-oriented evidence first, so `supporting_paths` should stay path-shaped unless the contract is deliberately expanded.
+- Read `references/delegation-playbook.md` when `review_mode` is not `local-only`.
+
+## Scripts
+
+- `scripts/collect_commit_rules.py`
+  - Collect canonical commit-message rules, repo defaults, and recent scope vocabulary.
+- `scripts/collect_worktree_context.py`
+  - Collect the current working-tree surface, fingerprint, hunk candidates, and validation commands.
+- `scripts/build_commit_packets.py`
+  - Build `global_packet.json`, `rules_packet.json`, `worktree_packet.json`, the candidate batches, the split-file packets, `packet_metrics.json`, and orchestrator metadata plus an optional build-result artifact.
+- `scripts/validate_commit_plan.py`
+  - Validate coverage, active git operations, hunk uniqueness, split safety, targeted-check feasibility, unknown-field handling, and worktree fingerprint consistency, then emit the normalized plan and stop categories that apply consumes.
+- `scripts/apply_commit_plan.py`
+  - Consume validator output only, re-stage each planned commit, run targeted checks, create commits, emit structured hard-stop payloads, and roll created commits back to the original HEAD with worktree edits preserved when a later apply step fails.
+- `scripts/write_evaluation_log.py`
+  - Record the shared evaluation log for efficiency, quality, and safety tracking, including build-phase packet metrics and common-path sufficiency.
+
+- `scripts/smoke_git_split_and_commit.py`
+  - Run the temp-repo smoke path for collect -> build -> validate -> apply `--dry-run` -> evaluation logging.
+
+## Evaluation
+
+- Use `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <worktree-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>` after packet generation.
+- Merge deterministic phase results with `phase` after validation or apply.
+- Finalize the evaluation log after the run with worker usage, packet usage, confidence, validation status, and any stop reasons.
+- Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
+- Read `references/evaluation-log-contract.md` for the shared envelope and `references/git-split-and-commit-evaluation-contract.md` for commit-planning-specific fields.
+
+## Maintenance Notes
+
+- Prefer `<python-bin> -B ...` when running bundled scripts so local verification does not leave fresh bytecode artifacts in the distributable skill folder.
+- Keep distributable bundles free of `__pycache__/` directories and `.pyc` files.
+- Re-read `references/architecture-rationale.md` before changing the orchestrator profile, worker families, or whole-file/split defaults.
+
+## Output
+
+- Tell the user how many commit buckets the current plan uses and why.
+- Tell the user whether the skill applied commits or stopped at validation.
+- If the skill stopped, name the blocker precisely with the hard-stop category when available.
+- Local hard-stop categories include `active_git_operation`, `ambiguous_split_rematch`, `partial_split_unsupported`, `targeted_check_unavailable`, `targeted_check_failed`, `commit_creation_failed`, and `rollback_failed`.

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/SKILL.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/SKILL.md
@@ -94,7 +94,7 @@ Read `references/architecture-rationale.md` before changing packet metadata, del
 - `ambiguity`
 - `confidence`
 - `reread_control`
-- Current domain aliases assume file/path-oriented evidence first, so `supporting_paths` should stay path-shaped unless the contract is deliberately expanded.
+- Current domain aliases assume file/path-oriented evidence first, so `supporting_paths` should stay path-shaped, evidence-only, and outside path ownership unless the contract is deliberately expanded.
 - Read `references/delegation-playbook.md` when `review_mode` is not `local-only`.
 
 ## Scripts

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Split And Commit"
+  short_description: "Split working-tree changes into logical commits"
+  default_prompt: "Use $git-split-and-commit to review the current working tree, split it into logical commits, and commit automatically if confidence is high."

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/builder-spec.json
@@ -1,0 +1,104 @@
+{
+  "skill_name": "git-split-and-commit",
+  "description": "Review the active repository's current working tree, split local changes into logical commits, draft repo-compliant commit messages, and commit automatically when confidence is high. Use when Codex needs to inspect staged, unstaged, and untracked non-ignored changes, decide whether they belong in one or more commits, and apply the commits safely with packetized evidence and targeted validation.",
+  "domain_slug": "git_split_and_commit",
+  "workflow_family": "git-history",
+  "archetype": "plan-validate-apply",
+  "primary_goal": "turn one working tree into a validated logical commit plan with packetized evidence and local final adjudication",
+  "trigger_phrases": [
+    "split changes into commits",
+    "plan logical commits",
+    "draft commit plan",
+    "commit grouped changes safely"
+  ],
+  "task_packet_names": [
+    "rules",
+    "worktree",
+    "candidate-batch",
+    "split-file"
+  ],
+  "needs_validate": true,
+  "needs_apply": true,
+  "decision_ready_packets": true,
+  "worker_return_contract": "classification-oriented",
+  "worker_output_shape": "hierarchical",
+  "packet_worker_map": {
+    "rules": [
+      "docs_verifier"
+    ],
+    "worktree": [
+      "repo_mapper"
+    ],
+    "candidate-batch": [
+      "evidence_summarizer"
+    ],
+    "split-file": [
+      "large_diff_auditor"
+    ]
+  },
+  "repo_profile": {
+    "name": "default",
+    "summary": "Default reusable profile scaffold for worktree commit planning. Replace with project-local commit-guidance docs, ownership hints, and repo-specific path globs when vendored.",
+    "repo_match": {
+      "root_markers": [
+        ".git",
+        "README.md"
+      ],
+      "remote_patterns": []
+    },
+    "bindings": {
+      "primary_readme_path": "README.md",
+      "settings_source_path": null,
+      "publish_config_path": null
+    },
+    "packet_defaults": {
+      "review_docs": {
+        "rules": [
+          "CONTRIBUTING.md",
+          "README.md"
+        ],
+        "worktree": [
+          "README.md"
+        ],
+        "candidate-batch": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ],
+        "split-file": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ]
+      },
+      "source_path_globs": {
+        "rules": [
+          ".github/**",
+          "*.md"
+        ],
+        "worktree": [
+          "**/*"
+        ],
+        "candidate-batch": [
+          "**/*"
+        ],
+        "split-file": [
+          "**/*"
+        ]
+      }
+    },
+    "lint_rules": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "notes": [
+      "Keep repo-specific commit guidance and file ownership hints in project-local profile data.",
+      "Do not place split safety policy, hunk matching rules, or apply rollback behavior in the profile."
+    ]
+  },
+  "builder_versioning": {
+    "builder_family": "packet-workflow",
+    "builder_semver": "0.1.0",
+    "compatibility_epoch": 1,
+    "builder_spec_schema_version": 1,
+    "repo_profile_schema_version": 1
+  }
+}

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/migration-worksheet.md
@@ -1,0 +1,58 @@
+# Migration Worksheet: git-split-and-commit
+
+## Workflow Snapshot
+- `workflow_family`: `git-history`
+- Current runtime shape: `standard`, `classification-oriented`, `hierarchical`, validator/apply split
+- Primary packets: `global_packet`, `rules_packet`, `worktree_packet`, `candidate-batch-*`, `split-file-*`
+- Current authoritative files:
+  - references: `commit-plan-contract.md`, `architecture-rationale.md`
+  - scripts: `collect_commit_rules.py`, `collect_worktree_context.py`, `build_commit_packets.py`, `validate_commit_plan.py`, `apply_commit_plan.py`
+  - tests: build/validate/apply/smoke coverage exists
+
+## Repo-Specific Inputs Seen In Legacy Skill
+- repo commit-guidance docs and recent scope vocabulary
+- path-to-area heuristics and scope suggestions
+- targeted validation command hints derived from current repo layout
+
+## Migration Classification
+- `core`
+  - decision-ready packet semantics
+  - hierarchical worker contract
+  - validator/apply boundary and apply rollback rules
+- `profiles/default/profile.json`
+  - commit-guidance doc paths
+  - repo markers and source-path globs
+  - declarative ownership hints
+- Skill-local
+  - commit plan schema and split safety rules
+  - hunk rematch behavior
+  - staged/apply rollback mechanics
+
+## Legacy Inventory Mapping
+- references kept as domain-local: `commit-plan-contract.md`
+- new retained interface additions: `builder-spec.json`, `references/core-contract.md`, `profiles/default/profile.json`
+- scripts to update for profile metadata wiring: `collect_worktree_context.py`, `build_commit_packets.py`
+
+## Retained vs Consumer-Local 판정
+- Data-only profile로 표현 가능한 repo-specific 차이:
+  - commit guidance locations
+  - ownership/source-path hints
+  - repo markers
+- 실행 의미/정책/행동 계약까지 건드리는 차이:
+  - 없음. split validation, rollback semantics, and packet adjudication rules are reusable skill-local contracts.
+- Decision: `retained`
+
+## Core 승격 기준
+- 반복 shared gap 여부:
+  - profile loading and packet profile metadata propagation repeat across retained skills
+  - generic area/path heuristics repeat across Git-oriented retained skills
+- 일회성 우회 여부:
+  - commit split safety, hunk rematch, and rollback behavior are one-skill domain logic
+- Decision:
+  - shared profile-loading and generic path classification boundaries should be documented at foundry level
+  - commit-plan semantics stay local
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/profiles/default/profile.json
@@ -1,0 +1,67 @@
+{
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "publish_config_path": null,
+    "settings_source_path": null
+  },
+  "lint_rules": {
+    "missing_review_docs_are_errors": false,
+    "require_readme_settings_table": false
+  },
+  "name": "default",
+  "notes": [
+    "Keep repo-specific commit guidance and file ownership hints in project-local profile data.",
+    "Do not place split safety policy, hunk matching rules, or apply rollback behavior in the profile."
+  ],
+  "packet_defaults": {
+    "review_docs": {
+      "candidate-batch": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "rules": [
+        "CONTRIBUTING.md",
+        "README.md"
+      ],
+      "split-file": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "worktree": [
+        "README.md"
+      ]
+    },
+    "source_path_globs": {
+      "candidate-batch": [
+        "**/*"
+      ],
+      "rules": [
+        ".github/**",
+        "*.md"
+      ],
+      "split-file": [
+        "**/*"
+      ],
+      "worktree": [
+        "**/*"
+      ]
+    }
+  },
+  "profile_path": "profiles/default/profile.json",
+  "repo_match": {
+    "remote_patterns": [],
+    "root_markers": [
+      ".git",
+      "README.md"
+    ]
+  },
+  "summary": "Default reusable profile scaffold for worktree commit planning. Replace with project-local commit-guidance docs, ownership hints, and repo-specific path globs when vendored.",
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/architecture-rationale.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/architecture-rationale.md
@@ -1,0 +1,6 @@
+# Architecture Rationale
+
+- Keep the `standard` profile because packet generation shapes evidence, but commit planning, validation, and apply stay local.
+- Keep whole-file handling as the default because safe partial splits depend on stable tracked-text hunks and clear packet evidence.
+- Skip `packet_explorer` because this workflow needs commit-boundary judgment more than execution-path tracing.
+- Use `broad-delegation` sparingly; most runs should stay local or targeted so the final plan remains easy to re-check against the live worktree.

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/commit-plan-contract.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/commit-plan-contract.md
@@ -62,7 +62,7 @@ Commit-entry fields:
   - `untracked_paths`
   - `split_paths`
   - `selected_hunk_ids`
-  - `supporting_paths` (assume file/path-oriented evidence first unless the contract is explicitly widened)
+  - `supporting_paths` (assume file/path-oriented evidence first unless the contract is explicitly widened; evidence-only and not path ownership)
   - `targeted_checks`
   - `confidence`
 - allowed
@@ -119,7 +119,7 @@ Each item in `commits` must include:
 - `untracked_paths`
 - `split_paths`
 - `selected_hunk_ids`
-- `supporting_paths` (assume file/path-oriented evidence first unless the contract is explicitly widened)
+- `supporting_paths` (assume file/path-oriented evidence first unless the contract is explicitly widened; evidence-only and not path ownership)
 - `targeted_checks`
 - `confidence`
 
@@ -128,6 +128,8 @@ Each item in `commits` must include:
 - Every changed path must appear exactly once across:
   - one commit entry, or
   - `omitted_paths`
+- Only `whole_file_paths`, `untracked_paths`, and `split_paths` satisfy path coverage and ownership.
+- `supporting_paths` may reference changed paths as supporting evidence, but does not satisfy path coverage and must not affect staging ownership.
 - `untracked_paths` must contain only untracked files.
 - `split_paths` must contain only tracked modified text files marked split-eligible in `worktree.json`.
 - Every `selected_hunk_id` must belong to one file in `split_paths`.

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/commit-plan-contract.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/commit-plan-contract.md
@@ -1,0 +1,234 @@
+# Commit Plan Contract
+
+Draft `commit-plan.json` as a single JSON object.
+
+## Packet Interface
+
+- The focused packets are decision-ready and feed local adjudication.
+- Workers read `global_packet.json` first, then one focused packet such as `rules_packet.json`, `worktree_packet.json`, `candidate-batch-XX.json`, or `split-file-XX.json`.
+- Workers return proposal-grade candidate records only; the final plan stays local.
+- Keep `commit-plan.json` consistent with the packet routing and stop conditions emitted by `orchestrator.json`.
+- Common-path local adjudication should finish with `rules_packet.json + worktree_packet.json + one focused packet at a time`.
+- Raw diff rereads are allowed only for explicit exception reasons:
+  - `conflicting_signals`
+  - `missing_required_evidence`
+  - `schema_mismatch`
+  - `insufficient_excerpt_quality`
+  - `stale_worktree_fingerprint`
+  - `ambiguous_hunk_match`
+- On canonical common-path fixtures, `insufficient_excerpt_quality` is a packet-contract failure rather than a normal fallback.
+
+## Required Top-Level Fields
+
+- `repo_root`
+- `base_head`
+- `worktree_fingerprint`
+- `input_scope`
+- `overall_confidence`
+- `validation_commands`
+- `omitted_paths`
+- `stop_reasons`
+- `commits`
+
+## Phase Field Tables
+
+### Draft Plan
+
+Top-level fields:
+- required
+  - `repo_root`
+  - `base_head`
+  - `worktree_fingerprint`
+  - `input_scope`
+  - `overall_confidence`
+  - `validation_commands`
+  - `omitted_paths`
+  - `stop_reasons`
+  - `commits`
+- allowed
+  - none
+- ignored
+  - none
+
+Commit-entry fields:
+- required
+  - `commit_index`
+  - `intent_summary`
+  - `type`
+  - `scope`
+  - `subject`
+  - `body`
+  - `whole_file_paths`
+  - `untracked_paths`
+  - `split_paths`
+  - `selected_hunk_ids`
+  - `supporting_paths` (assume file/path-oriented evidence first unless the contract is explicitly widened)
+  - `targeted_checks`
+  - `confidence`
+- allowed
+  - none
+- ignored
+  - none
+
+### Validator Output
+
+`validate_commit_plan.py` must emit:
+
+- `valid`
+- `can_apply`
+- `errors`
+- `warnings`
+- `error_details`
+- `warning_details`
+- `stop_reasons`
+- `stop_categories`
+- `deduped_validation_commands`
+- `normalized_plan`
+- `normalized_plan_fingerprint`
+- `expected_worktree_fingerprint`
+- `current_worktree_fingerprint`
+- `apply_gate_status`
+
+`normalized_plan` must contain only normalized required fields. Unknown extra fields from the draft plan are removed and surfaced through fixed warning codes.
+`apply_gate_status` must include `current_stop_categories` and `local_hard_stop_categories`.
+
+### Apply Input
+
+- `apply_commit_plan.py` consumes validator output, not raw `commit-plan.json`.
+- `--dry-run` follows the same rule and must read `normalized_plan` from the validator output.
+- Apply must fail closed when:
+  - validator output is invalid
+  - the normalized-plan fingerprint does not match
+  - the current worktree fingerprint has changed since validation
+  - applicable stop categories remain uncovered or unresolved
+- Apply must emit structured JSON for both success and hard-stop outcomes.
+- Hard-stop payloads must name the `apply_status.stop_category` when known.
+- If apply fails after creating one or more commits, it must roll back those created commits to the original HEAD with a non-destructive reset that preserves the user's working-tree changes.
+
+## Commit Entry Fields
+
+Each item in `commits` must include:
+
+- `commit_index`
+- `intent_summary`
+- `type`
+- `scope`
+- `subject`
+- `body`
+- `whole_file_paths`
+- `untracked_paths`
+- `split_paths`
+- `selected_hunk_ids`
+- `supporting_paths` (assume file/path-oriented evidence first unless the contract is explicitly widened)
+- `targeted_checks`
+- `confidence`
+
+## Validation Expectations
+
+- Every changed path must appear exactly once across:
+  - one commit entry, or
+  - `omitted_paths`
+- `untracked_paths` must contain only untracked files.
+- `split_paths` must contain only tracked modified text files marked split-eligible in `worktree.json`.
+- Every `selected_hunk_id` must belong to one file in `split_paths`.
+- If a file is split, all of its current hunks must be assigned exactly once across the plan.
+- `validation_commands` should be the deduped union of all `targeted_checks`.
+- Keep `stop_reasons` empty when the plan is safe to apply.
+- Validation must fail closed on active git operations, ambiguous split rematch risk, unsupported partial splits, and infeasible targeted checks.
+
+## Fixed Codes
+
+Validator warning codes:
+
+- `W_PLAN_UNKNOWN_TOP_LEVEL_FIELD`
+- `W_PLAN_UNKNOWN_COMMIT_FIELD`
+- `W_PLAN_BODY_STRING_NORMALIZED`
+- `W_PLAN_COMMIT_INDEX_NON_SEQUENTIAL`
+- `W_PLAN_EMPTY_SCOPE`
+- `W_PLAN_NON_BULLET_BODY`
+- `W_PLAN_TARGETED_CHECK_MISSING_FROM_PLAN`
+
+Validator error codes:
+
+- `E_PLAN_MISSING_FIELD`
+- `E_PLAN_EMPTY_COMMITS`
+- `E_PLAN_HEAD_CHANGED`
+- `E_PLAN_FINGERPRINT_CHANGED`
+- `E_PLAN_REPO_ROOT_MISMATCH`
+- `E_PLAN_BASE_HEAD_MISMATCH`
+- `E_PLAN_WORKTREE_FINGERPRINT_MISMATCH`
+- `E_PLAN_ACTIVE_GIT_OPERATION`
+- `E_PLAN_DUPLICATE_VALIDATION_COMMAND`
+- `E_PLAN_UNKNOWN_PATH`
+- `E_PLAN_INVALID_UNTRACKED_PATH`
+- `E_PLAN_INVALID_SPLIT_PATH`
+- `E_PLAN_PARTIAL_SPLIT_UNSUPPORTED`
+- `E_PLAN_UNKNOWN_HUNK`
+- `E_PLAN_PATH_ASSIGNMENT_MISMATCH`
+- `E_PLAN_HUNK_ASSIGNMENT_MISMATCH`
+- `E_PLAN_AMBIGUOUS_SPLIT_REMATCH`
+- `E_PLAN_ADJACENT_SPLIT_HUNKS`
+- `E_PLAN_TARGETED_CHECK_UNAVAILABLE`
+
+## Local Hard Stops
+
+Apply and local validation must preserve explicit hard-stop categories for operator-facing reporting:
+
+- `active_git_operation`
+- `ambiguous_split_rematch`
+- `partial_split_unsupported`
+- `targeted_check_unavailable`
+- `targeted_check_failed`
+- `commit_creation_failed`
+- `rollback_failed`
+
+## Message Construction
+
+- Compose the final subject as `<type>(<scope>): <subject>` unless the collected rules explicitly say otherwise.
+- Keep `subject` to the human-readable summary fragment only, not the full Conventional Commit line.
+- Keep `body` as a list of bullet lines or an empty list.
+
+Example shape:
+
+```json
+{
+  "repo_root": "C:/repo",
+  "base_head": "abc123",
+  "worktree_fingerprint": "sha256:...",
+  "input_scope": "all-local-changes",
+  "overall_confidence": "high",
+  "validation_commands": [
+    "python -m unittest discover -s .github/scripts/tests -p \"test_perf_telemetry_automation.py\""
+  ],
+  "omitted_paths": [],
+  "stop_reasons": [],
+  "commits": [
+    {
+      "commit_index": 1,
+      "intent_summary": "Allow direct telemetry comparisons when exactly one fix toggle differs.",
+      "type": "fix",
+      "scope": "infra",
+      "subject": "allow single fix-toggle comparisons",
+      "body": [
+        "- update telemetry automation to accept one known fix-toggle delta",
+        "- add tests and reporting guidance for the new comparison rule"
+      ],
+      "whole_file_paths": [
+        ".github/scripts/perf_telemetry_automation.py",
+        ".github/scripts/tests/test_perf_telemetry_automation.py",
+        ".github/ISSUE_TEMPLATE/performance_telemetry_report.yml",
+        "MAINTAINING.md",
+        "PERF_REPORTING.md"
+      ],
+      "untracked_paths": [],
+      "split_paths": [],
+      "selected_hunk_ids": [],
+      "supporting_paths": [],
+      "targeted_checks": [
+        "python -m unittest discover -s .github/scripts/tests -p \"test_perf_telemetry_automation.py\""
+      ],
+      "confidence": "high"
+    }
+  ]
+}
+```

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/core-contract.md
@@ -168,6 +168,7 @@ Stop conditions:
 
 - Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/core-contract.md
@@ -1,0 +1,177 @@
+# Git Split And Commit Core Contract
+
+This file captures the reusable packet-workflow core for the generated `git-split-and-commit` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+
+## Core Metadata
+
+- `workflow_family`: `git-history`
+- `archetype`: `plan-validate-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `true`
+- `worker_return_contract`: `classification-oriented`
+- `worker_output_shape`: `hierarchical`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `rules.json`
+- `worktree.json`
+- `candidate-batch.json`
+- `split-file.json`
+- No additional orchestrator-profile-specific runtime packet is required.
+
+Review mode overrides inherited by default:
+- diff churn exceeds a configured threshold
+- core runtime, config, or process files span multiple groups
+- generated files are present but are not the majority of the change
+
+Authority order:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+## Generic Worker Contract
+
+## Generic Adjudication Structure
+
+- This scaffold uses the `classification-oriented` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Worker output shape: `hierarchical`
+- Proposal classifications are worker proposal only. The main agent may override them during local adjudication.
+- Hierarchical worker output uses fixed top-level keys:
+  - `candidates[]`
+  - `footer`
+- Candidate field bundles:
+- `fact_and_evidence`
+  - required: yes
+  - Candidate-level factual summary and supporting references.
+  - fields:
+    - candidate-level factual summary (`fact_summary`)
+    - supporting references (`supporting_references`)
+- `proposal_assessment`
+  - required: yes
+  - Worker proposal, rationale, ambiguity, and confidence signals.
+  - fields:
+    - worker proposal classification (`proposal_classification`)
+    - classification rationale for the worker proposal (`classification_rationale`)
+    - open ambiguity affecting adjudication (`ambiguity`)
+    - worker confidence for the candidate (`confidence`)
+- `reread_control`
+  - required: yes
+  - Exception-only raw reread control.
+  - fields:
+    - allowed reread reason or null (`reread_control`)
+- Worker footer fields:
+- `packet_ids`: packets or packet slices the worker actually used
+- `candidate_ids`: candidate ids in the same stable order as `candidates[]`
+- `primary_outcome`: worker-level batch summary only
+- `overall_confidence`: worker batch confidence only; final plan confidence is recomputed locally
+- `coverage_gaps`: unread or insufficiently verified scope
+- `overall_risk`: remaining worker batch risk
+- Allowed reread reasons:
+- `conflicting_signals`
+- `missing_required_evidence`
+- `schema_mismatch`
+- `insufficient_excerpt_quality`
+
+## Worker Families
+
+- The builder keeps worker-family structure generic and reusable across packet-driven workflows.
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `candidate_producers`: decision-ready candidate records for local adjudication-heavy workflows
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+
+- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:
+- `repo_mapper`
+- `packet_explorer`
+- `docs_verifier`
+- `evidence_summarizer`
+- `large_diff_auditor`
+- `log_triager`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `rules`
+  - `docs_verifier`
+- `worktree`
+  - `repo_mapper`
+- `candidate-batch`
+  - `evidence_summarizer`
+- `split-file`
+  - `large_diff_auditor`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Summary: Default reusable profile scaffold for worktree commit planning. Replace with project-local commit-guidance docs, ownership hints, and repo-specific path globs when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `rules`
+    - `CONTRIBUTING.md`
+    - `README.md`
+  - `worktree`
+    - `README.md`
+  - `candidate-batch`
+    - `README.md`
+    - `CONTRIBUTING.md`
+  - `split-file`
+    - `README.md`
+    - `CONTRIBUTING.md`
+- source path globs:
+  - `rules`
+    - `.github/**`
+    - `*.md`
+  - `worktree`
+    - `**/*`
+  - `candidate-batch`
+    - `**/*`
+  - `split-file`
+    - `**/*`
+- Default lint rules:
+- `require_readme_settings_table`: false
+- `missing_review_docs_are_errors`: false
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes
+
+- Optional local helpers remain non-authoritative even when collected.
+- Final plan confidence is recomputed locally even when `footer.overall_confidence` is present.

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/delegation-playbook.md
@@ -1,0 +1,75 @@
+# Delegation Playbook
+
+Read this file when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`: no workers
+- `targeted-delegation`: 2 workers
+- `broad-delegation`: 3-4 workers
+- Optional QA worker: only when split risk is broad or worker findings conflict
+
+## Local Gates
+
+- Read `rules_packet.json` and `worktree_packet.json` locally before drafting a plan.
+- Keep `rules_packet.json + worktree_packet.json + one focused packet at a time` as the common path for local adjudication.
+- Treat `task_packet_names` as basename metadata only; use `packet_order` or concrete packet filenames when you need file-oriented references.
+- Re-check the final plan against those packets locally before validation and before apply.
+- Keep local hard stops local: `active_git_operation`, `ambiguous_split_rematch`, `partial_split_unsupported`, `targeted_check_unavailable`, and `rollback_failed`.
+- Do not reread raw diffs unless an explicit exception reason applies; worker disagreement alone is not enough without a matching packet-level conflict.
+
+## Preferred Worker Mapping
+
+- `global_packet.json`
+  - Every worker reads this first
+  - Purpose: keep the shared packet contract, stop conditions, and routing metadata in view
+- `rules_packet.json`
+  - Prefer `docs_verifier`
+  - Purpose: extract hard commit-message rules, allowed types, scope requirements, subject/body constraints, and scope vocabulary
+- `worktree_packet.json`
+  - Prefer `repo_mapper`
+  - Purpose: extract touched-surface, fingerprint, and validation-candidate facts
+- `candidate-batch-XX.json`
+  - Prefer `evidence_summarizer`
+  - If you need an explicit model override, use `gpt-5.4-mini`
+  - Purpose: summarize one logical commit bucket and its likely type/scope
+- `split-file-XX.json`
+  - Prefer `large_diff_auditor`
+  - If you need an explicit model override, use `gpt-5.4-mini`
+  - Purpose: judge whether the file is one intent or multiple intents, and whether the split risk is acceptable
+- Optional QA pass
+  - Prefer `large_diff_auditor`
+  - If you need an explicit model override, use `gpt-5.4-mini`
+  - Purpose: compare the draft plan against the packet evidence before apply
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use [$git-split-and-commit](<skill-path>/SKILL.md) to analyze one packet.
+
+Read only:
+- <global-packet>
+- <rules-or-worktree-packet>
+- <specific candidate-batch or split-file packet>
+
+Return exactly:
+- packet ids
+- primary intent
+- evidence files
+- recommended type/scope
+- body needed
+- unsupported split risk
+```
+
+Keep each worker narrow. Do not hand a worker the whole diff or the final plan.
+
+## Integration Rules
+
+- Start workers, then keep drafting the final plan locally instead of waiting immediately.
+- Treat worker output as evidence, not as the final commit text.
+- If workers disagree, inspect only the conflicting packets locally and add the optional QA worker if the disagreement changes the final plan.
+- If packet evidence still cannot resolve the boundary, record an explicit reread reason instead of silently rereading the diff.
+- Keep `apply_commit_plan.py` local. Do not delegate staging, hunk rematch, or `git commit`.
+- Do not ask workers to adjudicate rollback or to reinterpret an ambiguous split rematch; those are local hard stops.

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/references/git-split-and-commit-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/references/git-split-and-commit-evaluation-contract.md
@@ -1,0 +1,49 @@
+# Git Split Evaluation Contract
+
+Use this file for `git-split-and-commit` evaluation logs.
+
+## Skill-Specific Focus
+
+Record the signals that matter for split planning and commit application:
+- bucket count and split confidence
+- validation commands and targeted checks
+- staged commit hashes and final head
+- hunk rematch or fingerprint failures
+- hard-stop category and rollback status when apply stops
+- dry-run versus applied-plan outcomes
+- packet routing and decision-ready metadata when available
+
+## Skill-Specific Data
+
+Keep these values in `skill_specific.data` when they are available:
+- `commit_buckets_planned`
+- `commit_buckets_applied`
+- `split_file_count`
+- `decision_ready_packets`
+- `worker_return_contract`
+- `worker_output_shape`
+- `common_path_sufficient`
+- `raw_reread_count`
+- `raw_reread_reasons`
+- `packet_count`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+- Derive fallback packet counts from the file-oriented `packet_order` or `packet_files` list when explicit packet metrics are absent.
+- `validation_commands`
+- `targeted_checks`
+- `created_hashes`
+- `final_head`
+- `dry_run`
+- `plan_validation`
+- `apply_status`
+- `stop_categories`
+- `rollback_status`
+
+## Phase Guidance
+
+- `init`
+  - capture the collected worktree and packet orchestration snapshot
+- `phase`
+  - record build-phase packet metrics and common-path sufficiency, then validation or apply-stage results
+- `finalize`
+  - record the created commit hashes and any remaining apply caveat

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/apply_commit_plan.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/apply_commit_plan.py
@@ -263,7 +263,8 @@ def rollback_created_commits(repo_root: Path, original_head: str) -> None:
 
 
 def stage_commit(repo_root: Path, commit: dict[str, Any], hunk_lookup: dict[str, dict[str, Any]]) -> None:
-    for path in string_list(commit.get("whole_file_paths")) + string_list(commit.get("supporting_paths")) + string_list(commit.get("untracked_paths")):
+    # `supporting_paths` are evidence references and do not participate in staging ownership.
+    for path in string_list(commit.get("whole_file_paths")) + string_list(commit.get("untracked_paths")):
         run_git(repo_root, ["add", "--all", "--", path])
 
     selected_hunk_ids = string_list(commit.get("selected_hunk_ids"))

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/apply_commit_plan.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/apply_commit_plan.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""Apply a validator-approved commit plan to the current working tree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from collect_worktree_context import detect_operation, parse_patch_hunks, raw_diff_against_head
+from validate_commit_plan import (
+    command_feasibility_issues,
+    json_fingerprint,
+    load_json,
+    normalize_body,
+    string_list,
+    validate_plan_against_worktree,
+)
+
+
+class ApplyHardStop(RuntimeError):
+    def __init__(self, category: str, message: str, payload: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.category = category
+        self.payload = payload
+
+
+def run_git(
+    repo: Path,
+    args: list[str],
+    *,
+    check: bool = True,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        input=input_text,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result
+
+
+def build_commit_message(commit: dict[str, Any]) -> str:
+    message_type = str(commit.get("type", "")).strip()
+    scope = str(commit.get("scope", "")).strip()
+    subject = str(commit.get("subject", "")).strip()
+    first_line = f"{message_type}({scope}): {subject}" if scope else f"{message_type}: {subject}"
+    body_lines = normalize_body(commit.get("body"))
+    if not body_lines:
+        return first_line + "\n"
+    return first_line + "\n\n" + "\n".join(body_lines) + "\n"
+
+
+def build_hunk_lookup(worktree: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    lookup: dict[str, dict[str, Any]] = {}
+    for entry in worktree.get("files", []):
+        for hunk in entry.get("hunks", []):
+            payload = dict(hunk)
+            payload["path"] = entry["path"]
+            lookup[str(hunk["hunk_id"])] = payload
+    return lookup
+
+
+def diff_header_text(patch_text: str, path: str) -> str:
+    header_lines: list[str] = []
+    for line in patch_text.splitlines():
+        if line.startswith("@@ "):
+            break
+        header_lines.append(line)
+    if header_lines:
+        return "\n".join(header_lines) + "\n"
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n"
+
+
+def build_patch_for_current_hunks(path: str, patch_text: str, hunks: list[dict[str, Any]]) -> str:
+    ordered_hunks = sorted(hunks, key=lambda item: (int(item["old_start"]), int(item["new_start"])))
+    body = "".join(str(hunk["raw_patch"]) for hunk in ordered_hunks)
+    return diff_header_text(patch_text, path) + body
+
+
+def build_apply_status(
+    *,
+    status: str,
+    stop_category: str | None,
+    message: str,
+    rollback_performed: bool,
+    rollback_status: str,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "stop_category": stop_category,
+        "message": message,
+        "rollback_performed": rollback_performed,
+        "rollback_status": rollback_status,
+    }
+
+
+def build_apply_payload(
+    *,
+    dry_run: bool,
+    validation_source: str,
+    normalized_plan_fingerprint: str | None,
+    validation: dict[str, Any] | None,
+    commands: list[str],
+    commits: list[dict[str, Any]],
+    created_hashes: list[str],
+    final_head: str | None,
+    apply_succeeded: bool | None,
+    applied: bool,
+    stop_reasons: list[str],
+    apply_status: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "dry_run": dry_run,
+        "validation_source": validation_source,
+        "normalized_plan_fingerprint": normalized_plan_fingerprint,
+        "validation": validation,
+        "commands": commands,
+        "commits": commits,
+        "created_hashes": created_hashes,
+        "final_head": final_head,
+        "apply_succeeded": apply_succeeded,
+        "ok": apply_succeeded is not False,
+        "applied": applied,
+        "rollback_needed": bool(apply_status.get("rollback_performed")),
+        "stop_reasons": stop_reasons,
+        "apply_status": apply_status,
+    }
+
+
+def make_hard_stop(
+    category: str,
+    message: str,
+    *,
+    dry_run: bool,
+    normalized_plan_fingerprint: str | None = None,
+    validation: dict[str, Any] | None = None,
+    commands: list[str] | None = None,
+    commits: list[dict[str, Any]] | None = None,
+    created_hashes: list[str] | None = None,
+    rollback_performed: bool = False,
+    rollback_status: str = "not_needed",
+) -> ApplyHardStop:
+    payload = build_apply_payload(
+        dry_run=dry_run,
+        validation_source="validator_normalized_plan",
+        normalized_plan_fingerprint=normalized_plan_fingerprint,
+        validation=validation,
+        commands=list(commands or []),
+        commits=list(commits or []),
+        created_hashes=list(created_hashes or []),
+        final_head=None,
+        apply_succeeded=False,
+        applied=False,
+        stop_reasons=[message],
+        apply_status=build_apply_status(
+            status="hard_stop",
+            stop_category=category,
+            message=message,
+            rollback_performed=rollback_performed,
+            rollback_status=rollback_status,
+        ),
+    )
+    return ApplyHardStop(category, message, payload)
+
+
+def current_hunk_match(path: str, original_hunk: dict[str, Any], current_hunks: list[dict[str, Any]]) -> dict[str, Any]:
+    matches = [
+        hunk
+        for hunk in current_hunks
+        if str(hunk.get("removed_digest")) == str(original_hunk.get("removed_digest"))
+        and str(hunk.get("added_digest")) == str(original_hunk.get("added_digest"))
+    ]
+    if len(matches) != 1:
+        if not matches:
+            raise make_hard_stop(
+                "ambiguous_split_rematch",
+                f"hunk `{original_hunk['hunk_id']}` for `{path}` is missing from the current diff; apply will not reinterpret the split",
+                dry_run=False,
+            )
+        raise make_hard_stop(
+            "ambiguous_split_rematch",
+            f"hunk `{original_hunk['hunk_id']}` for `{path}` is ambiguous in the current diff; apply will not reinterpret the split",
+            dry_run=False,
+        )
+    return matches[0]
+
+
+def ensure_targeted_checks_feasible(repo_root: Path, commands: list[str], *, dry_run: bool) -> None:
+    issues = command_feasibility_issues(repo_root, commands)
+    if not issues:
+        return
+    first_issue = issues[0]
+    raise make_hard_stop(
+        "targeted_check_unavailable",
+        f"targeted check `{first_issue['command']}` is not feasible locally: {first_issue['detail']}.",
+        dry_run=dry_run,
+        commands=commands,
+    )
+
+
+def run_targeted_checks(repo_root: Path, commands: list[str]) -> None:
+    ensure_targeted_checks_feasible(repo_root, commands, dry_run=False)
+    for command in commands:
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            shell=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "targeted check failed"
+            raise make_hard_stop(
+                "targeted_check_failed",
+                f"targeted check failed: {command}: {detail}",
+                dry_run=False,
+                commands=commands,
+            )
+
+
+def apply_cached_patch(repo_root: Path, patch_text: str) -> None:
+    temp_root = repo_root / ".codex" / "tmp" / "packet-workflow" / "git-split-and-commit"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        newline="\n",
+        suffix=".patch",
+        dir=temp_root,
+        delete=False,
+    ) as handle:
+        patch_path = Path(handle.name)
+        handle.write(patch_text)
+    try:
+        run_git(repo_root, ["apply", "--cached", "--unidiff-zero", "--recount", str(patch_path)])
+    finally:
+        patch_path.unlink(missing_ok=True)
+
+
+def reset_index(repo_root: Path, pathspecs: list[str]) -> None:
+    if pathspecs:
+        run_git(repo_root, ["reset", "HEAD", "--", *pathspecs])
+    else:
+        run_git(repo_root, ["reset", "--mixed", "HEAD"])
+
+
+def rollback_created_commits(repo_root: Path, original_head: str) -> None:
+    run_git(repo_root, ["reset", "--mixed", original_head])
+
+
+def stage_commit(repo_root: Path, commit: dict[str, Any], hunk_lookup: dict[str, dict[str, Any]]) -> None:
+    for path in string_list(commit.get("whole_file_paths")) + string_list(commit.get("supporting_paths")) + string_list(commit.get("untracked_paths")):
+        run_git(repo_root, ["add", "--all", "--", path])
+
+    selected_hunk_ids = string_list(commit.get("selected_hunk_ids"))
+    if not selected_hunk_ids:
+        return
+
+    split_paths = set(string_list(commit.get("split_paths")))
+    hunks_by_path: dict[str, list[dict[str, Any]]] = {}
+    for hunk_id in selected_hunk_ids:
+        original_hunk = hunk_lookup.get(hunk_id)
+        if original_hunk is None:
+            raise make_hard_stop(
+                "partial_split_unsupported",
+                f"plan references unknown hunk id `{hunk_id}` during apply",
+                dry_run=False,
+            )
+        path = str(original_hunk["path"])
+        if path not in split_paths:
+            raise make_hard_stop(
+                "partial_split_unsupported",
+                f"hunk `{hunk_id}` belongs to `{path}` which is not listed in `split_paths`",
+                dry_run=False,
+            )
+        hunks_by_path.setdefault(path, []).append(original_hunk)
+
+    for path, original_hunks in hunks_by_path.items():
+        current_patch = raw_diff_against_head(repo_root, path)
+        current_hunks = parse_patch_hunks(path, current_patch)
+        selected_current_hunks = [current_hunk_match(path, original_hunk, current_hunks) for original_hunk in original_hunks]
+        apply_cached_patch(repo_root, build_patch_for_current_hunks(path, current_patch, selected_current_hunks))
+
+
+def created_commit_hash(repo_root: Path) -> str:
+    return run_git(repo_root, ["rev-parse", "HEAD"]).stdout.strip()
+
+
+def first_validation_stop_category(validation_payload: dict[str, Any], fallback: str) -> str:
+    apply_gate_status = validation_payload.get("apply_gate_status") or {}
+    stop_categories = string_list(apply_gate_status.get("current_stop_categories"))
+    if stop_categories:
+        return stop_categories[0]
+    return fallback
+
+
+def load_validated_plan(validation_payload: dict[str, Any], *, dry_run: bool) -> tuple[dict[str, Any], str]:
+    normalized_plan = validation_payload.get("normalized_plan")
+    if not isinstance(normalized_plan, dict):
+        raise make_hard_stop(
+            "validator_mismatch",
+            "validator output is missing `normalized_plan`",
+            dry_run=dry_run,
+            validation=validation_payload,
+        )
+    normalized_plan_fingerprint = str(validation_payload.get("normalized_plan_fingerprint", "")).strip()
+    if not normalized_plan_fingerprint:
+        raise make_hard_stop(
+            "validator_mismatch",
+            "validator output is missing `normalized_plan_fingerprint`",
+            dry_run=dry_run,
+            validation=validation_payload,
+        )
+    if json_fingerprint(normalized_plan) != normalized_plan_fingerprint:
+        raise make_hard_stop(
+            "validator_mismatch",
+            "validator output normalized-plan fingerprint does not match the normalized plan",
+            dry_run=dry_run,
+            validation=validation_payload,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+        )
+    if not validation_payload.get("valid"):
+        raise make_hard_stop(
+            first_validation_stop_category(validation_payload, "validator_mismatch"),
+            "refusing to apply validator output marked invalid",
+            dry_run=dry_run,
+            validation=validation_payload,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+        )
+    if not validation_payload.get("can_apply"):
+        raise make_hard_stop(
+            first_validation_stop_category(validation_payload, "validator_mismatch"),
+            "refusing to apply validator output marked not apply-safe",
+            dry_run=dry_run,
+            validation=validation_payload,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+        )
+    apply_gate_status = validation_payload.get("apply_gate_status") or {}
+    if string_list(apply_gate_status.get("uncovered_stop_categories")):
+        raise make_hard_stop(
+            "validator_mismatch",
+            "refusing to apply while applicable stop categories remain uncovered",
+            dry_run=dry_run,
+            validation=validation_payload,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+        )
+    return normalized_plan, normalized_plan_fingerprint
+
+
+def handle_apply_failure(
+    failure: ApplyHardStop,
+    *,
+    repo_root: Path,
+    original_head: str,
+    pathspecs: list[str],
+    created_hashes: list[str],
+    dry_run: bool,
+    normalized_plan_fingerprint: str,
+    validation: dict[str, Any],
+    commands: list[str],
+    commits: list[dict[str, Any]],
+) -> None:
+    if created_hashes:
+        try:
+            rollback_created_commits(repo_root, original_head)
+        except Exception as rollback_exc:
+            raise make_hard_stop(
+                "rollback_failed",
+                f"{failure}. Rollback to `{original_head}` failed: {rollback_exc}",
+                dry_run=dry_run,
+                normalized_plan_fingerprint=normalized_plan_fingerprint,
+                validation=validation,
+                commands=commands,
+                commits=commits,
+                created_hashes=created_hashes,
+                rollback_performed=True,
+                rollback_status="failed",
+            ) from rollback_exc
+        raise make_hard_stop(
+            failure.category,
+            str(failure),
+            dry_run=dry_run,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=validation,
+            commands=commands,
+            commits=commits,
+            created_hashes=created_hashes,
+            rollback_performed=True,
+            rollback_status="success",
+        ) from failure
+
+    try:
+        reset_index(repo_root, pathspecs)
+    except Exception as cleanup_exc:
+        raise make_hard_stop(
+            "rollback_failed",
+            f"{failure}. Index cleanup failed before any commit was created: {cleanup_exc}",
+            dry_run=dry_run,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=validation,
+            commands=commands,
+            commits=commits,
+            created_hashes=created_hashes,
+            rollback_performed=False,
+            rollback_status="failed",
+        ) from cleanup_exc
+    raise failure
+
+
+def apply_validated_plan(worktree: dict[str, Any], validation_payload: dict[str, Any], dry_run: bool) -> dict[str, Any]:
+    repo_root = Path(str(worktree.get("repo_root", "")))
+    normalized_plan, normalized_plan_fingerprint = load_validated_plan(validation_payload, dry_run=dry_run)
+    revalidated = validate_plan_against_worktree(worktree, normalized_plan)
+    if not revalidated.get("valid"):
+        raise make_hard_stop(
+            first_validation_stop_category(revalidated, "stale_context"),
+            "commit plan validation failed after revalidation",
+            dry_run=dry_run,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=revalidated,
+        )
+    if not revalidated.get("can_apply"):
+        raise make_hard_stop(
+            first_validation_stop_category(revalidated, "validator_mismatch"),
+            "commit plan is no longer apply-safe after revalidation",
+            dry_run=dry_run,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=revalidated,
+        )
+    if str(revalidated.get("normalized_plan_fingerprint", "")).strip() != normalized_plan_fingerprint:
+        raise make_hard_stop(
+            "validator_mismatch",
+            "validator mismatch: revalidated normalized plan fingerprint changed",
+            dry_run=dry_run,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=revalidated,
+        )
+
+    commands = list(revalidated.get("deduped_validation_commands", []))
+    commit_summaries = [
+        {
+            "commit_index": int(commit["commit_index"]),
+            "subject": build_commit_message(commit).splitlines()[0],
+            "whole_file_paths": string_list(commit.get("whole_file_paths")),
+            "supporting_paths": string_list(commit.get("supporting_paths")),
+            "untracked_paths": string_list(commit.get("untracked_paths")),
+            "split_paths": string_list(commit.get("split_paths")),
+            "targeted_checks": string_list(commit.get("targeted_checks")),
+        }
+        for commit in normalized_plan.get("commits", [])
+        if isinstance(commit, dict)
+    ]
+
+    active_operation = detect_operation(repo_root)
+    if active_operation:
+        raise make_hard_stop(
+            "active_git_operation",
+            f"git operation already in progress: {active_operation}",
+            dry_run=dry_run,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=revalidated,
+            commands=commands,
+            commits=commit_summaries,
+        )
+
+    ensure_targeted_checks_feasible(repo_root, commands, dry_run=dry_run)
+    original_head = run_git(repo_root, ["rev-parse", "HEAD"]).stdout.strip()
+
+    if dry_run:
+        return build_apply_payload(
+            dry_run=True,
+            validation_source="validator_normalized_plan",
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=revalidated,
+            commands=commands,
+            commits=commit_summaries,
+            created_hashes=[],
+            final_head=original_head,
+            apply_succeeded=True,
+            applied=False,
+            stop_reasons=[],
+            apply_status=build_apply_status(
+                status="dry_run",
+                stop_category=None,
+                message="Validated normalized plan is ready for apply --dry-run only.",
+                rollback_performed=False,
+                rollback_status="not_needed",
+            ),
+        )
+
+    pathspecs = list(worktree.get("pathspecs", []))
+    try:
+        run_targeted_checks(repo_root, commands)
+        reset_index(repo_root, pathspecs)
+        hunk_lookup = build_hunk_lookup(worktree)
+    except ApplyHardStop:
+        raise
+    except Exception as exc:
+        raise make_hard_stop(
+            "commit_creation_failed",
+            str(exc),
+            dry_run=False,
+            normalized_plan_fingerprint=normalized_plan_fingerprint,
+            validation=revalidated,
+            commands=commands,
+            commits=commit_summaries,
+        ) from exc
+    created_hashes: list[str] = []
+
+    for commit in sorted(normalized_plan.get("commits", []), key=lambda item: int(item["commit_index"])):
+        try:
+            stage_commit(repo_root, commit, hunk_lookup)
+            cached_diff = run_git(repo_root, ["diff", "--cached", "--name-only"], check=False).stdout.strip()
+            if not cached_diff:
+                raise make_hard_stop(
+                    "commit_creation_failed",
+                    f"commit {commit['commit_index']} staged no changes",
+                    dry_run=False,
+                    normalized_plan_fingerprint=normalized_plan_fingerprint,
+                    validation=revalidated,
+                    commands=commands,
+                    commits=commit_summaries,
+                    created_hashes=created_hashes,
+                )
+            message = build_commit_message(commit)
+            temp_root = repo_root / ".codex" / "tmp" / "packet-workflow" / "git-split-and-commit"
+            temp_root.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=temp_root,
+                delete=False,
+            ) as handle:
+                message_path = Path(handle.name)
+                handle.write(message)
+            try:
+                run_git(repo_root, ["commit", "--no-gpg-sign", "-F", str(message_path)])
+            finally:
+                message_path.unlink(missing_ok=True)
+            created_hashes.append(created_commit_hash(repo_root))
+        except ApplyHardStop as failure:
+            handle_apply_failure(
+                failure,
+                repo_root=repo_root,
+                original_head=original_head,
+                pathspecs=pathspecs,
+                created_hashes=created_hashes,
+                dry_run=False,
+                normalized_plan_fingerprint=normalized_plan_fingerprint,
+                validation=revalidated,
+                commands=commands,
+                commits=commit_summaries,
+            )
+        except Exception as exc:
+            handle_apply_failure(
+                make_hard_stop(
+                    "commit_creation_failed",
+                    str(exc),
+                    dry_run=False,
+                    normalized_plan_fingerprint=normalized_plan_fingerprint,
+                    validation=revalidated,
+                    commands=commands,
+                    commits=commit_summaries,
+                    created_hashes=created_hashes,
+                ),
+                repo_root=repo_root,
+                original_head=original_head,
+                pathspecs=pathspecs,
+                created_hashes=created_hashes,
+                dry_run=False,
+                normalized_plan_fingerprint=normalized_plan_fingerprint,
+                validation=revalidated,
+                commands=commands,
+                commits=commit_summaries,
+            )
+
+    final_head = created_hashes[-1] if created_hashes else original_head
+    return build_apply_payload(
+        dry_run=False,
+        validation_source="validator_normalized_plan",
+        normalized_plan_fingerprint=normalized_plan_fingerprint,
+        validation=revalidated,
+        commands=commands,
+        commits=commit_summaries,
+        created_hashes=created_hashes,
+        final_head=final_head,
+        apply_succeeded=True,
+        applied=True,
+        stop_reasons=[],
+        apply_status=build_apply_status(
+            status="applied",
+            stop_category=None,
+            message=f"Applied {len(created_hashes)} commit(s) from the validator-approved normalized plan.",
+            rollback_performed=False,
+            rollback_status="not_needed",
+        ),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply a commit plan to the current working tree.")
+    parser.add_argument("--worktree", type=Path, required=True, help="Path to worktree JSON from collect_worktree_context.py")
+    parser.add_argument("--validation", type=Path, required=True, help="Path to validator output JSON from validate_commit_plan.py")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would happen without mutating git state")
+    parser.add_argument("--result-output", type=Path, help="Optional path to write the JSON result payload.")
+    return parser.parse_args()
+
+
+def write_payload(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        worktree = load_json(args.worktree)
+        validation_payload = load_json(args.validation)
+        payload = apply_validated_plan(worktree, validation_payload, args.dry_run)
+        exit_code = 0
+    except ApplyHardStop as exc:  # pragma: no cover - command-line error path
+        payload = exc.payload
+        exit_code = 1
+    except Exception as exc:  # pragma: no cover - command-line error path
+        payload = build_apply_payload(
+            dry_run=bool(args.dry_run),
+            validation_source="validator_normalized_plan",
+            normalized_plan_fingerprint=None,
+            validation=None,
+            commands=[],
+            commits=[],
+            created_hashes=[],
+            final_head=None,
+            apply_succeeded=False,
+            applied=False,
+            stop_reasons=[str(exc)],
+            apply_status=build_apply_status(
+                status="hard_stop",
+                stop_category="validator_mismatch",
+                message=str(exc),
+                rollback_performed=False,
+                rollback_status="not_needed",
+            ),
+        )
+        exit_code = 1
+
+    write_payload(args.result_output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/build_commit_packets.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/build_commit_packets.py
@@ -721,7 +721,10 @@ def main() -> int:
             "reread_control": "raw_reread_reason",
         },
         "alias_notes": {
-            "supporting_paths": "Current domain aliases assume file/path-oriented evidence first.",
+            "supporting_paths": (
+                "Current domain aliases assume file/path-oriented evidence first; "
+                "`supporting_paths` is evidence-only and does not claim path ownership."
+            ),
         },
         "reference_only_candidate_values": ["reference_only"],
         "output_inclusion_rules": {

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/build_commit_packets.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/build_commit_packets.py
@@ -1,0 +1,1133 @@
+#!/usr/bin/env python3
+"""Build compact packet artifacts for token-efficient commit planning."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from commit_packet_contract import (
+    COMMON_PATH_CONTRACT,
+    DECISION_READY_PACKETS,
+    ORCHESTRATOR_PROFILE,
+    PACKET_NAMES,
+    PREFERRED_WORKER_FAMILIES,
+    RAW_REREAD_ALLOWED_REASONS,
+    WORKER_OUTPUT_SHAPE,
+    WORKER_RETURN_CONTRACT,
+    WORKER_SELECTION_GUIDANCE,
+    XHIGH_REREAD_POLICY,
+    build_packet_worker_map,
+    build_task_packet_names,
+    compute_packet_metrics,
+    dedupe_preserve,
+    packet_basename,
+)
+
+
+LOCAL_FILE_LIMIT = 8
+LOCAL_BATCH_LIMIT = 2
+TARGETED_BATCH_LIMIT = 4
+BROAD_FILE_LIMIT = 20
+CHURN_OVERRIDE_LIMIT = 300
+GENERATED_FILE_OVERRIDE_RATIO = 0.5
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def parse_shortstat(shortstat: str | None) -> dict[str, int]:
+    if not shortstat:
+        return {"files_changed": 0, "insertions": 0, "deletions": 0, "churn": 0}
+    files = re.search(r"(\d+)\s+files?\s+changed", shortstat)
+    insertions = re.search(r"(\d+)\s+insertions?\(\+\)", shortstat)
+    deletions = re.search(r"(\d+)\s+deletions?\(-\)", shortstat)
+    file_count = int(files.group(1)) if files else 0
+    added = int(insertions.group(1)) if insertions else 0
+    removed = int(deletions.group(1)) if deletions else 0
+    return {
+        "files_changed": file_count,
+        "insertions": added,
+        "deletions": removed,
+        "churn": added + removed,
+    }
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def candidate_scopes(files: list[dict[str, Any]], rules: dict[str, Any]) -> list[str]:
+    known_scopes = list(rules.get("recent_scope_vocabulary", [])) + list(
+        rules.get("rules", {}).get("scope_suggestions", [])
+    )
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for entry in files:
+        path = normalize_path(str(entry["path"])).lower()
+        derived = None
+        if "/systems/" in path:
+            derived = "systems"
+        elif "/patches/" in path:
+            derived = "patches"
+        elif path.startswith(".github/"):
+            derived = "infra"
+        elif path.endswith(".md") or path.startswith("docs/"):
+            derived = "docs"
+        elif path.endswith((".yml", ".yaml", ".json", ".toml", ".xml")):
+            derived = "config"
+        elif "/tests/" in path or path.endswith("_test.py"):
+            derived = "test"
+        if derived and derived not in seen:
+            candidates.append(derived)
+            seen.add(derived)
+    for scope in known_scopes:
+        if scope in seen:
+            continue
+        if any(scope.lower() in normalize_path(str(entry["path"])).lower() for entry in files):
+            candidates.append(scope)
+            seen.add(scope)
+    return candidates[:6]
+
+
+def feature_tokens(entry: dict[str, Any]) -> list[str]:
+    tokens = list(entry.get("path_tokens", []))
+    for hunk in entry.get("hunks", []):
+        for token in hunk.get("tokens", []):
+            if token not in tokens:
+                tokens.append(token)
+    return tokens[:20]
+
+
+def source_test_partner(path: str) -> str | None:
+    normalized = normalize_path(path)
+    if normalized.startswith(".github/scripts/tests/test_") and normalized.endswith(".py"):
+        stem = Path(normalized).stem.removeprefix("test_")
+        return f".github/scripts/{stem}.py"
+    if normalized.startswith(".github/scripts/") and normalized.endswith(".py") and not normalized.startswith(".github/scripts/tests/"):
+        return f".github/scripts/tests/test_{Path(normalized).stem}.py"
+    return None
+
+
+def token_overlap(entry_a: dict[str, Any], entry_b: dict[str, Any]) -> int:
+    return len(set(feature_tokens(entry_a)) & set(feature_tokens(entry_b)))
+
+
+def adjacency_score(entry_a: dict[str, Any], entry_b: dict[str, Any]) -> tuple[int, list[str]]:
+    reasons: list[str] = []
+    score = 0
+    path_a = normalize_path(str(entry_a["path"]))
+    path_b = normalize_path(str(entry_b["path"]))
+    if source_test_partner(path_a) == path_b or source_test_partner(path_b) == path_a:
+        score += 5
+        reasons.append("source_test_adjacency")
+
+    overlap = token_overlap(entry_a, entry_b)
+    if overlap >= 2:
+        score += 3
+        reasons.append("feature_token_overlap")
+    elif overlap == 1 and (
+        str(entry_a.get("area")) in {"docs", "config", "other"}
+        or str(entry_b.get("area")) in {"docs", "config", "other"}
+    ):
+        score += 2
+        reasons.append("supporting_token_overlap")
+
+    parent_a = path_a.rsplit("/", 1)[0] if "/" in path_a else "."
+    parent_b = path_b.rsplit("/", 1)[0] if "/" in path_b else "."
+    if parent_a == parent_b and parent_a != ".":
+        score += 1
+        reasons.append("same_directory")
+
+    return score, reasons
+
+
+def connected_components(files: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    if not files:
+        return []
+    index_to_neighbors: dict[int, set[int]] = {index: set() for index in range(len(files))}
+    for left in range(len(files)):
+        for right in range(left + 1, len(files)):
+            score, _ = adjacency_score(files[left], files[right])
+            if score >= 3:
+                index_to_neighbors[left].add(right)
+                index_to_neighbors[right].add(left)
+
+    visited: set[int] = set()
+    components: list[list[dict[str, Any]]] = []
+    for index in range(len(files)):
+        if index in visited:
+            continue
+        queue = [index]
+        visited.add(index)
+        members: list[int] = []
+        while queue:
+            current = queue.pop()
+            members.append(current)
+            for neighbor in index_to_neighbors[current]:
+                if neighbor not in visited:
+                    visited.add(neighbor)
+                    queue.append(neighbor)
+        component = [files[item] for item in sorted(members, key=lambda value: str(files[value]["path"]))]
+        components.append(component)
+    components.sort(key=lambda batch: str(batch[0]["path"]))
+    return components
+
+
+def dominant_type(batch: list[dict[str, Any]]) -> str:
+    areas = {str(entry.get("area")) for entry in batch}
+    if areas <= {"docs", "config", "other"} and "docs" in areas:
+        return "docs"
+    if areas == {"tests"}:
+        return "test"
+    if "runtime" in areas or "automation" in areas:
+        return "fix"
+    if "config" in areas:
+        return "chore"
+    return "fix"
+
+
+def body_needed(batch: list[dict[str, Any]]) -> bool:
+    return len(batch) > 1 or any(entry.get("split_eligible") for entry in batch)
+
+
+def hunk_overlap_ratio(hunks: list[dict[str, Any]]) -> float:
+    if len(hunks) < 2:
+        return 1.0
+    scores: list[float] = []
+    for left in range(len(hunks)):
+        left_tokens = set(hunks[left].get("tokens", []))
+        for right in range(left + 1, len(hunks)):
+            right_tokens = set(hunks[right].get("tokens", []))
+            union = left_tokens | right_tokens
+            scores.append((len(left_tokens & right_tokens) / len(union)) if union else 1.0)
+    return sum(scores) / len(scores) if scores else 1.0
+
+
+def split_candidate_packet(entry: dict[str, Any], batch_size: int) -> dict[str, Any] | None:
+    hunks = list(entry.get("hunks", []))
+    if not entry.get("split_eligible") or len(hunks) < 2:
+        return None
+    area = str(entry.get("area"))
+    path = normalize_path(str(entry.get("path")))
+    if area not in {"runtime", "automation", "tests"}:
+        return None
+    if path.startswith(".github/ISSUE_TEMPLATE/") or path.endswith(".md"):
+        return None
+    sorted_hunks = sorted(hunks, key=lambda item: (int(item["old_start"]), int(item["new_start"])))
+    line_span = max(int(hunk["new_start"]) for hunk in sorted_hunks) - min(int(hunk["new_start"]) for hunk in sorted_hunks)
+    average_overlap = hunk_overlap_ratio(sorted_hunks)
+    digest_pairs = [(str(hunk["removed_digest"]), str(hunk["added_digest"])) for hunk in sorted_hunks]
+    duplicate_digest_pairs = len(digest_pairs) != len(set(digest_pairs))
+    should_inspect = duplicate_digest_pairs or (
+        batch_size == 1
+        and len(hunks) >= 4
+        and line_span >= 250
+        and average_overlap < 0.15
+        and area in {"runtime", "automation"}
+    )
+    if not should_inspect:
+        return None
+
+    return {
+        "path": entry["path"],
+        "reason": {
+            "line_span": line_span,
+            "average_hunk_token_overlap": round(average_overlap, 3),
+            "duplicate_digest_pairs": duplicate_digest_pairs,
+        },
+        "hunks": [
+            {
+                "hunk_id": hunk["hunk_id"],
+                "header": hunk["header"],
+                "tokens": hunk.get("tokens", []),
+                "removed_digest": hunk["removed_digest"],
+                "added_digest": hunk["added_digest"],
+            }
+            for hunk in sorted_hunks
+        ],
+    }
+
+
+def override_signals(files: list[dict[str, Any]], diff_totals: dict[str, int]) -> list[dict[str, str]]:
+    signals: list[dict[str, str]] = []
+    if diff_totals.get("churn", 0) >= CHURN_OVERRIDE_LIMIT:
+        signals.append(
+            {
+                "reason": "diff_stat_threshold",
+                "detail": f"Tracked diff churn reached {diff_totals['churn']} lines (threshold {CHURN_OVERRIDE_LIMIT}).",
+            }
+        )
+
+    batch_areas = sorted({str(entry.get("area")) for entry in files if str(entry.get("area")) in {"runtime", "automation", "config"}})
+    if len(batch_areas) >= 2:
+        signals.append(
+            {
+                "reason": "core_files_across_groups",
+                "detail": "Core runtime/config/process files span multiple groups: " + ", ".join(batch_areas),
+            }
+        )
+
+    generated_count = sum(1 for entry in files if entry.get("generated"))
+    if files and generated_count and (generated_count / len(files)) < GENERATED_FILE_OVERRIDE_RATIO:
+        signals.append(
+            {
+                "reason": "generated_files_not_majority",
+                "detail": f"Generated files are present but not the majority ({generated_count}/{len(files)}).",
+            }
+        )
+    return signals
+
+
+def determine_review_mode(file_count: int, batch_count: int, split_count: int, overrides: list[dict[str, str]]) -> tuple[str, int]:
+    if file_count <= LOCAL_FILE_LIMIT and batch_count <= LOCAL_BATCH_LIMIT and split_count == 0:
+        review_mode = "local-only"
+    elif batch_count >= 5 or file_count > BROAD_FILE_LIMIT:
+        review_mode = "broad-delegation"
+    elif batch_count >= 3 or split_count > 0:
+        review_mode = "targeted-delegation"
+    else:
+        review_mode = "local-only"
+
+    override_reasons = {str(item.get("reason", "")) for item in overrides}
+    if overrides and review_mode == "local-only":
+        if batch_count > 1 or split_count > 0 or "diff_stat_threshold" in override_reasons:
+            review_mode = "targeted-delegation"
+    elif overrides and review_mode == "targeted-delegation":
+        if batch_count > TARGETED_BATCH_LIMIT or split_count > 1 or "diff_stat_threshold" in override_reasons:
+            review_mode = "broad-delegation"
+
+    if review_mode == "local-only":
+        return review_mode, 0
+    if review_mode == "targeted-delegation":
+        return review_mode, 2
+    return review_mode, 4 if batch_count > TARGETED_BATCH_LIMIT else 3
+
+
+def packet_name(prefix: str, index: int) -> str:
+    return f"{prefix}-{index:02d}.json"
+
+
+def summarize_changed_lines(lines: list[str], *, limit: int = 4) -> list[str]:
+    preview: list[str] = []
+    for line in lines:
+        if not line.startswith(("+", "-")):
+            continue
+        payload = line[1:].strip()
+        if not payload:
+            continue
+        candidate = f"{line[0]} {payload[:140]}"
+        if candidate not in preview:
+            preview.append(candidate)
+        if len(preview) >= limit:
+            break
+    return preview
+
+
+def representative_hunk_headers(entry: dict[str, Any], *, limit: int = 3) -> list[str]:
+    return [str(hunk.get("header", "")) for hunk in entry.get("hunks", [])[:limit] if str(hunk.get("header", "")).strip()]
+
+
+def file_change_synopsis(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "insertions": entry.get("insertions"),
+        "deletions": entry.get("deletions"),
+        "diff_header_text": entry.get("diff_header_text", ""),
+        "hunk_headers": representative_hunk_headers(entry),
+        "representative_tokens": feature_tokens(entry)[:8],
+        "changed_line_preview": summarize_changed_lines(
+            [line for hunk in entry.get("hunks", []) for line in hunk.get("raw_body_lines", [])]
+        ),
+    }
+
+
+def validation_candidate_map(validation_candidates: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    mapping: dict[str, list[dict[str, Any]]] = {}
+    for item in validation_candidates:
+        command = str(item.get("command") or "").strip()
+        if not command:
+            continue
+        payload = {
+            "command": command,
+            "reason": item.get("reason"),
+            "confidence": item.get("confidence"),
+        }
+        for path in item.get("paths", []):
+            mapping.setdefault(str(path), []).append(payload)
+    return mapping
+
+
+def single_file_basis(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    basis = [
+        {
+            "kind": "single_file_scope",
+            "paths": [str(entry["path"])],
+            "detail": "The batch contains one changed file, so commit cohesion is file-bounded.",
+        }
+    ]
+    partner = source_test_partner(str(entry["path"]))
+    if partner:
+        basis.append(
+            {
+                "kind": "source_test_pair",
+                "paths": [str(entry["path"]), partner],
+                "detail": "The file has a conventional source/test partner and should stay grouped with that companion change when both appear.",
+            }
+        )
+    return basis
+
+
+def batch_cohesion_basis(batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not batch:
+        return []
+    if len(batch) == 1:
+        return single_file_basis(batch[0])
+
+    basis: list[dict[str, Any]] = []
+    for left in range(len(batch)):
+        for right in range(left + 1, len(batch)):
+            score, reasons = adjacency_score(batch[left], batch[right])
+            if score < 3:
+                continue
+            detail_parts = []
+            if "source_test_adjacency" in reasons:
+                detail_parts.append("source/test adjacency")
+            if "feature_token_overlap" in reasons:
+                detail_parts.append("shared feature tokens")
+            if "supporting_token_overlap" in reasons:
+                detail_parts.append("supporting token overlap")
+            if "same_directory" in reasons:
+                detail_parts.append("same directory")
+            basis.append(
+                {
+                    "kind": "adjacency_signal",
+                    "paths": [str(batch[left]["path"]), str(batch[right]["path"])],
+                    "score": score,
+                    "reasons": reasons,
+                    "detail": ", ".join(detail_parts) if detail_parts else "grouping signal detected",
+                }
+            )
+    return basis
+
+
+def batch_boundary_risks(
+    batch: list[dict[str, Any]],
+    split_paths: list[str],
+    relevant_commands: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    risks: list[dict[str, Any]] = []
+    areas = sorted({str(entry.get("area")) for entry in batch})
+    if len(areas) > 1:
+        risks.append(
+            {
+                "risk": "mixed_areas",
+                "detail": "The batch spans multiple areas: " + ", ".join(areas),
+            }
+        )
+    if split_paths:
+        risks.append(
+            {
+                "risk": "split_candidate_present",
+                "detail": "One or more files may need split adjudication before the batch is safe to apply.",
+                "paths": split_paths,
+            }
+        )
+    if not relevant_commands:
+        risks.append(
+            {
+                "risk": "no_targeted_validation",
+                "detail": "No targeted validation command was matched to this batch.",
+            }
+        )
+    generated = [str(entry["path"]) for entry in batch if entry.get("generated")]
+    if generated and len(generated) != len(batch):
+        risks.append(
+            {
+                "risk": "generated_and_handwritten_mix",
+                "detail": "Generated files are mixed with handwritten files in the same batch.",
+                "paths": generated,
+            }
+        )
+    return risks
+
+
+def batch_coverage_gaps(
+    batch: list[dict[str, Any]],
+    split_paths: list[str],
+    relevant_commands: list[dict[str, Any]],
+) -> list[str]:
+    gaps: list[str] = []
+    if split_paths:
+        gaps.append("Resolve split-file packets before treating the batch as whole-file safe.")
+    if not relevant_commands:
+        gaps.append("No targeted validation command was matched to this batch.")
+    if any(entry.get("binary") for entry in batch):
+        gaps.append("Binary files limit patch-level evidence; rely on whole-file handling only.")
+    return gaps
+
+
+def batch_quality_escape_hints(batch: list[dict[str, Any]], split_paths: list[str]) -> list[dict[str, Any]]:
+    hints: list[dict[str, Any]] = []
+    if len(batch) <= 1:
+        return hints
+    cohesion = batch_cohesion_basis(batch)
+    strong_reasons = {
+        reason
+        for item in cohesion
+        for reason in item.get("reasons", [])
+        if reason != "same_directory"
+    }
+    if not strong_reasons and split_paths:
+        hints.append(
+            {
+                "reason": "conflicting_signals",
+                "detail": "The batch groups multiple files without strong cross-file evidence beyond directory locality, and a split candidate is present.",
+                "paths": split_paths,
+                "common_path_blocking": False,
+            }
+        )
+    return hints
+
+
+def batch_whole_file_recommendation(split_paths: list[str]) -> dict[str, Any]:
+    if split_paths:
+        return {
+            "mode": "defer-to-split-packet",
+            "detail": "Keep the batch whole-file by default unless the matching split-file packet gives clear multi-intent support.",
+            "paths": split_paths,
+        }
+    return {
+        "mode": "whole-file",
+        "detail": "No split candidates were identified in this batch.",
+        "paths": [],
+    }
+
+
+def hunk_preview_quality(hunk: dict[str, Any]) -> dict[str, Any]:
+    preview = summarize_changed_lines(list(hunk.get("raw_body_lines", [])))
+    tokens = [str(token) for token in hunk.get("tokens", []) if str(token).strip()]
+    return {
+        "preview_lines": preview,
+        "preview_count": len(preview),
+        "token_count": len(tokens),
+        "tokens": tokens[:8],
+    }
+
+
+def split_decision_basis(packet: dict[str, Any]) -> dict[str, Any]:
+    hunks = list(packet.get("hunks", []))
+    hunk_summaries: list[dict[str, Any]] = []
+    adjacent_hunks = False
+    last_new_start: int | None = None
+    for hunk in hunks:
+        quality = hunk_preview_quality(hunk)
+        new_start = int(hunk.get("new_start", 0))
+        if last_new_start is not None and abs(new_start - last_new_start) <= 12:
+            adjacent_hunks = True
+        last_new_start = new_start
+        hunk_summaries.append(
+            {
+                "hunk_id": hunk.get("hunk_id"),
+                "header": hunk.get("header"),
+                "tokens": quality["tokens"],
+                "preview_lines": quality["preview_lines"],
+                "removed_digest": hunk.get("removed_digest"),
+                "added_digest": hunk.get("added_digest"),
+            }
+        )
+    reason = dict(packet.get("reason") or {})
+    return {
+        "line_span": reason.get("line_span"),
+        "average_hunk_token_overlap": reason.get("average_hunk_token_overlap"),
+        "duplicate_digest_pairs": bool(reason.get("duplicate_digest_pairs")),
+        "adjacent_hunks_detected": adjacent_hunks,
+        "hunk_summaries": hunk_summaries,
+    }
+
+
+def split_adjacent_hunk_risk(packet: dict[str, Any]) -> dict[str, Any]:
+    basis = split_decision_basis(packet)
+    adjacent = bool(basis.get("adjacent_hunks_detected"))
+    return {
+        "present": adjacent,
+        "level": "medium" if adjacent else "low",
+        "detail": "Neighboring hunks sit close together; prefer whole-file unless the intent boundary stays clear." if adjacent else "No close hunk adjacency was detected.",
+    }
+
+
+def split_rematch_risk(packet: dict[str, Any]) -> dict[str, Any]:
+    duplicate = bool((packet.get("reason") or {}).get("duplicate_digest_pairs"))
+    return {
+        "present": duplicate,
+        "level": "high" if duplicate else "low",
+        "detail": "Duplicate digest pairs reduce rematch confidence and increase ambiguous hunk risk." if duplicate else "Hunk digests remain distinct enough for rematch.",
+    }
+
+
+def split_quality_escape_hints(packet: dict[str, Any]) -> list[dict[str, Any]]:
+    hints: list[dict[str, Any]] = []
+    duplicate = bool((packet.get("reason") or {}).get("duplicate_digest_pairs"))
+    empty_preview = any(
+        not hunk_preview_quality(hunk)["preview_count"] and not hunk_preview_quality(hunk)["token_count"]
+        for hunk in packet.get("hunks", [])
+    )
+    if duplicate and empty_preview:
+        hints.append(
+            {
+                "reason": "insufficient_excerpt_quality",
+                "detail": "A split candidate has duplicate digest pairs but no preview or token evidence, so packet-only adjudication is insufficient.",
+                "paths": [str(packet.get("path"))],
+                "common_path_blocking": True,
+            }
+        )
+    elif duplicate:
+        hints.append(
+            {
+                "reason": "ambiguous_hunk_match",
+                "detail": "Duplicate digest pairs remain a quality escape hatch if the packet evidence is still inconclusive.",
+                "paths": [str(packet.get("path"))],
+                "common_path_blocking": False,
+            }
+        )
+    return hints
+
+
+def aggregate_quality_escape_hints(*hint_lists: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    aggregated: list[dict[str, Any]] = []
+    seen: set[tuple[str, tuple[str, ...], str]] = set()
+    for hint_list in hint_lists:
+        for item in hint_list:
+            reason = str(item.get("reason") or "")
+            paths = tuple(str(path) for path in item.get("paths", []) if str(path).strip())
+            detail = str(item.get("detail") or "")
+            key = (reason, paths, detail)
+            if not reason or key in seen:
+                continue
+            seen.add(key)
+            aggregated.append(item)
+    return aggregated
+
+
+def build_result_payload(
+    *,
+    review_mode: str,
+    recommended_workers: list[dict[str, Any]],
+    packet_order: list[str],
+    active_packets: list[str],
+    applied_override_signals: list[str],
+    candidate_batch_count: int,
+    split_file_count: int,
+    packet_metrics: dict[str, int],
+    common_path_sufficient: bool,
+    raw_reread_reasons: list[str],
+) -> dict[str, Any]:
+    return {
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "recommended_workers": recommended_workers,
+        "packet_order": packet_order,
+        "active_packets": active_packets,
+        "active_packet_count": len(active_packets),
+        "candidate_batch_count": candidate_batch_count,
+        "split_file_count": split_file_count,
+        "applied_override_signals": applied_override_signals,
+        "common_path_sufficient": common_path_sufficient,
+        "raw_reread_count": len(raw_reread_reasons),
+        "raw_reread_reasons": raw_reread_reasons,
+        "packet_metrics": packet_metrics,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build packet artifacts for token-efficient commit planning."
+    )
+    parser.add_argument("--rules", type=Path, required=True, help="Path to rules JSON from collect_commit_rules.py")
+    parser.add_argument("--worktree", type=Path, required=True, help="Path to worktree JSON from collect_worktree_context.py")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory for generated packets")
+    parser.add_argument("--result-output", type=Path, help="Optional path to write build result JSON.")
+    args = parser.parse_args()
+
+    rules = load_json(args.rules)
+    worktree = load_json(args.worktree)
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(list(worktree.get("files", [])), key=lambda item: str(item["path"]))
+    changed_paths = [str(entry["path"]) for entry in files]
+    diff_totals = parse_shortstat(worktree.get("diff_shortstat"))
+    overrides = override_signals(files, diff_totals)
+    batches = connected_components(files)
+    split_packets: list[dict[str, Any]] = []
+    batch_size_by_path = {
+        str(entry["path"]): len(batch)
+        for batch in batches
+        for entry in batch
+    }
+    for entry in files:
+        packet = split_candidate_packet(entry, batch_size_by_path.get(str(entry["path"]), 1))
+        if packet is not None:
+            split_packets.append(packet)
+
+    review_mode, worker_count = determine_review_mode(
+        file_count=len(files),
+        batch_count=len(batches),
+        split_count=len(split_packets),
+        overrides=overrides,
+    )
+
+    worker_selection_guidance = {
+        **WORKER_SELECTION_GUIDANCE,
+        "notes": (
+            "Keep workers narrow: rules_packet for hard commit-message constraints, worktree_packet for touched-surface facts, "
+            "candidate batches for logical commit buckets, and split-file packets for split adjudication."
+        ),
+    }
+    candidate_field_bundles = [
+        {
+            "name": "candidate",
+            "description": "Proposal-grade commit bucket candidate data.",
+            "required": True,
+            "fields": [
+                "fact_summary",
+                "proposal_classification",
+                "classification_rationale",
+                "supporting_references",
+                "ambiguity",
+                "confidence",
+                "reread_control",
+            ],
+        }
+    ]
+    worker_footer_fields = [
+        "packet_ids",
+        "candidate_ids",
+        "primary_outcome",
+        "overall_confidence",
+        "coverage_gaps",
+        "overall_risk",
+    ]
+    domain_overlay = {
+        "proposal_enum_values": ["commit_bucket", "split_file", "reference_only", "ignore"],
+        "candidate_field_aliases": {
+            "fact_summary": "intent_summary",
+            "proposal_classification": "recommended_type",
+            "supporting_references": "supporting_paths",
+            "ambiguity": "open_ambiguity",
+            "reread_control": "raw_reread_reason",
+        },
+        "alias_notes": {
+            "supporting_paths": "Current domain aliases assume file/path-oriented evidence first.",
+        },
+        "reference_only_candidate_values": ["reference_only"],
+        "output_inclusion_rules": {
+            "commit_bucket": "standalone",
+            "split_file": "standalone",
+            "reference_only": "support",
+            "ignore": "exclude",
+        },
+        "bundle_overrides": {},
+    }
+
+    rules_packet = {
+        "purpose": "Extract hard commit-message rules and preferred scope vocabulary.",
+        "rule_files": rules.get("rule_files", {}),
+        "rules": rules.get("rules", {}),
+        "rule_derivation": rules.get("rule_derivation", {}),
+        "recent_scope_vocabulary": rules.get("recent_scope_vocabulary", []),
+        "recent_subject_samples": rules.get("recent_subject_samples", []),
+        "instruction_snippets": rules.get("instruction_snippets", {}),
+    }
+
+    batch_map: dict[str, list[str]] = {}
+    candidate_batch_names: list[str] = []
+    candidate_payloads: dict[str, dict[str, Any]] = {}
+    candidate_quality_hints: list[dict[str, Any]] = []
+    validation_map = validation_candidate_map(list(worktree.get("validation_candidates", [])))
+    for index, batch in enumerate(batches, start=1):
+        batch_name = packet_name("candidate-batch", index)
+        candidate_batch_names.append(batch_name)
+        batch_id = packet_basename(batch_name)
+        batch_map[batch_id] = [str(entry["path"]) for entry in batch]
+        split_paths = [str(entry["path"]) for entry in batch if any(packet["path"] == entry["path"] for packet in split_packets)]
+        relevant_commands = [
+            item
+            for item in worktree.get("validation_candidates", [])
+            if set(item.get("paths", [])) & {str(entry["path"]) for entry in batch}
+        ]
+        cohesion_basis = batch_cohesion_basis(batch)
+        boundary_risks = batch_boundary_risks(batch, split_paths, relevant_commands)
+        coverage_gaps = batch_coverage_gaps(batch, split_paths, relevant_commands)
+        quality_escape_hints = batch_quality_escape_hints(batch, split_paths)
+        candidate_quality_hints.extend(quality_escape_hints)
+        batch_packet = {
+            "purpose": "Describe one logical commit candidate from the current working tree.",
+            "batch_id": batch_id,
+            "paths": [str(entry["path"]) for entry in batch],
+            "areas": sorted({str(entry.get("area")) for entry in batch}),
+            "intent_tokens": sorted({token for entry in batch for token in feature_tokens(entry)})[:20],
+            "recommended_type": dominant_type(batch),
+            "scope_candidates": candidate_scopes(batch, rules),
+            "body_needed": body_needed(batch),
+            "split_candidate_paths": split_paths,
+            "cohesion_basis": cohesion_basis,
+            "boundary_risks": boundary_risks,
+            "whole_file_recommendation": batch_whole_file_recommendation(split_paths),
+            "supporting_validation_commands": relevant_commands,
+            "coverage_gaps": coverage_gaps,
+            "quality_escape_hints": quality_escape_hints,
+            "validation_candidates": relevant_commands,
+            "files": [
+                {
+                    "path": entry["path"],
+                    "change_kind": entry["change_kind"],
+                    "area": entry["area"],
+                    "generated": entry["generated"],
+                    "binary": entry.get("binary"),
+                    "split_eligible": entry.get("split_eligible"),
+                    "hunk_count": len(entry.get("hunks", [])),
+                    "change_synopsis": file_change_synopsis(entry),
+                    "validation_candidates": validation_map.get(str(entry["path"]), []),
+                }
+                for entry in batch
+            ],
+        }
+        candidate_payloads[batch_name] = batch_packet
+        (output_dir / batch_name).write_text(
+            json.dumps(batch_packet, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+
+    split_packet_names: list[str] = []
+    split_payloads: dict[str, dict[str, Any]] = {}
+    split_quality_hints: list[dict[str, Any]] = []
+    for index, packet in enumerate(split_packets, start=1):
+        packet_name_value = packet_name("split-file", index)
+        split_packet_names.append(packet_name_value)
+        split_hints = split_quality_escape_hints(packet)
+        split_quality_hints.extend(split_hints)
+        payload = {
+            "purpose": "Inspect whether one modified file should stay whole or split across commits.",
+            "file": packet,
+            "split_decision_basis": split_decision_basis(packet),
+            "adjacent_hunk_risk": split_adjacent_hunk_risk(packet),
+            "rematch_risk": split_rematch_risk(packet),
+            "whole_file_fallback_guidance": {
+                "mode": "prefer_whole_file_on_ambiguity",
+                "detail": "If the hunk intent boundary stays ambiguous after packet review, keep the file whole or stop instead of improvising a split.",
+            },
+            "quality_escape_hints": split_hints,
+        }
+        split_payloads[packet_name_value] = payload
+        (output_dir / packet_name_value).write_text(
+            json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+
+    active_packets = [PACKET_NAMES["rules"], PACKET_NAMES["worktree"], *candidate_batch_names, *split_packet_names]
+    task_packet_names = build_task_packet_names(candidate_batch_names, split_packet_names)
+    packet_worker_map = build_packet_worker_map(candidate_batch_names, split_packet_names)
+
+    all_quality_hints = aggregate_quality_escape_hints(candidate_quality_hints, split_quality_hints)
+    raw_reread_reasons = dedupe_preserve(
+        [
+            str(item.get("reason"))
+            for item in all_quality_hints
+            if item.get("common_path_blocking")
+        ]
+    )
+    common_path_sufficient = not raw_reread_reasons
+
+    worktree_packet = {
+        "purpose": "Summarize the current working tree before drafting commit buckets.",
+        "head_commit": worktree.get("head_commit"),
+        "branch": worktree.get("branch"),
+        "status_branch_line": worktree.get("status_branch_line"),
+        "changed_paths": changed_paths,
+        "changed_file_groups": worktree.get("changed_file_groups", {}),
+        "diff_shortstat": worktree.get("diff_shortstat"),
+        "diff_stat": worktree.get("diff_stat"),
+        "validation_candidates": worktree.get("validation_candidates", []),
+        "validation_candidate_map": validation_map,
+        "active_operation": worktree.get("active_operation"),
+        "review_overrides": overrides,
+        "candidate_batch_order": candidate_batch_names,
+        "split_candidate_paths": [packet["path"] for packet in split_packets],
+        "quality_escape_hints": all_quality_hints,
+        "common_path_sufficient": common_path_sufficient,
+        "raw_reread_reasons": raw_reread_reasons,
+    }
+
+    global_packet = {
+        "purpose": "Shared context every worker should keep in view before reading its packet.",
+        "orchestrator_profile": ORCHESTRATOR_PROFILE,
+        "repo_profile_name": worktree.get("repo_profile_name"),
+        "repo_profile_path": worktree.get("repo_profile_path"),
+        "repo_profile_summary": worktree.get("repo_profile_summary"),
+        "repo_profile": worktree.get("repo_profile"),
+        "input_scope": worktree.get("input_scope"),
+        "repo_root": worktree.get("repo_root"),
+        "head_commit": worktree.get("head_commit"),
+        "branch": worktree.get("branch"),
+        "worktree_fingerprint": worktree.get("worktree_fingerprint"),
+        "active_operation": worktree.get("active_operation"),
+        "required_message_rules": {
+            "format": rules.get("rules", {}).get("format"),
+            "allowed_types": rules.get("rules", {}).get("allowed_types", []),
+            "scope_required": rules.get("rules", {}).get("scope_required"),
+            "subject_length_limit": rules.get("rules", {}).get("subject_length_limit"),
+            "repo_defaults": rules.get("rules", {}).get("repo_defaults", []),
+        },
+        "worktree_summary": {
+            "changed_file_count": len(files),
+            "diff_shortstat": diff_totals,
+            "candidate_batch_count": len(batches),
+            "split_candidate_count": len(split_packets),
+        },
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "task_packet_names": task_packet_names,
+        "common_path_contract": COMMON_PATH_CONTRACT,
+        "worker_selection_guidance": worker_selection_guidance,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": packet_worker_map,
+        "candidate_field_bundles": candidate_field_bundles,
+        "worker_footer_fields": worker_footer_fields,
+        "reread_reason_values": RAW_REREAD_ALLOWED_REASONS,
+        "xhigh_reread_policy": XHIGH_REREAD_POLICY,
+        "domain_overlay": domain_overlay,
+        "disallowed_actions": [
+            "Do not preserve the existing index layout as authoritative.",
+            "Do not apply a split to new, deleted, renamed, copied, or binary files.",
+            "Do not guess when a hunk id is missing or ambiguous in the current diff.",
+            "Do not continue applying later commits after staging or validation fails.",
+            "Do not auto-widen a failed split to whole-file unless the plan explicitly chose that fallback.",
+        ],
+    }
+
+    recommended_workers: list[dict[str, Any]] = []
+    optional_workers: list[dict[str, Any]] = []
+    if review_mode == "targeted-delegation":
+        recommended_workers.append(
+            {
+                "name": "rules",
+                "agent_type": "docs_verifier",
+                "packets": ["global_packet.json", "rules_packet.json"],
+                "responsibility": "Extract hard commit-message rules, scope requirements, and repo defaults.",
+                "reasoning_effort": "medium",
+            }
+        )
+        if candidate_batch_names:
+            recommended_workers.append(
+                {
+                    "name": "commit-batches",
+                    "agent_type": "evidence_summarizer",
+                    "packets": ["global_packet.json", *candidate_batch_names[:2]],
+                    "responsibility": "Summarize the strongest logical commit buckets and recommended type/scope.",
+                    "reasoning_effort": "medium",
+                    "model": "gpt-5.4-mini",
+                }
+            )
+        optional_workers.append(
+            {
+                "name": "worktree",
+                "agent_type": "repo_mapper",
+                "packets": ["global_packet.json", "worktree_packet.json"],
+                "responsibility": "Summarize touched areas, validation-candidate coverage, and override signals.",
+                "reasoning_effort": "medium",
+            }
+        )
+        if split_packet_names:
+            optional_workers.append(
+                {
+                    "name": "split-review",
+                    "agent_type": "large_diff_auditor",
+                    "packets": ["global_packet.json", split_packet_names[0]],
+                    "responsibility": "Decide whether the split candidate file is one intent or multiple intents.",
+                    "reasoning_effort": "medium",
+                    "model": "gpt-5.4-mini",
+                }
+            )
+    elif review_mode == "broad-delegation":
+        recommended_workers.append(
+            {
+                "name": "rules",
+                "agent_type": "docs_verifier",
+                "packets": ["global_packet.json", "rules_packet.json"],
+                "responsibility": "Extract hard commit-message rules, scope requirements, and repo defaults.",
+                "reasoning_effort": "medium",
+            }
+        )
+        for batch_name in candidate_batch_names[: max(worker_count - 1, 1)]:
+            recommended_workers.append(
+                {
+                    "name": packet_basename(batch_name),
+                    "agent_type": "evidence_summarizer",
+                    "packets": ["global_packet.json", batch_name],
+                    "responsibility": "Summarize one candidate batch and recommend type/scope.",
+                    "reasoning_effort": "medium",
+                    "model": "gpt-5.4-mini",
+                }
+            )
+        recommended_workers = recommended_workers[:worker_count]
+        optional_workers.append(
+            {
+                "name": "worktree",
+                "agent_type": "repo_mapper",
+                "packets": ["global_packet.json", "worktree_packet.json"],
+                "responsibility": "Summarize touched areas, validation-candidate coverage, and override signals.",
+                "reasoning_effort": "medium",
+            }
+        )
+        if split_packet_names:
+            optional_workers.append(
+                {
+                    "name": "split-review",
+                    "agent_type": "large_diff_auditor",
+                    "packets": ["global_packet.json", *split_packet_names[:2]],
+                    "responsibility": "Review the highest-risk split-file packets.",
+                    "reasoning_effort": "medium",
+                    "model": "gpt-5.4-mini",
+                }
+            )
+        optional_workers.append(
+            {
+                "name": "qa",
+                "agent_type": "large_diff_auditor",
+                "packets": ["global_packet.json", *candidate_batch_names[:3], *split_packet_names[:1]],
+                "responsibility": "Compare the draft commit plan against the packet evidence before apply.",
+                "reasoning_effort": "medium",
+                }
+            )
+
+    packet_order = ["global_packet.json", "rules_packet.json", "worktree_packet.json", *candidate_batch_names, *split_packet_names]
+    orchestrator = {
+        "head_commit": worktree.get("head_commit"),
+        "branch": worktree.get("branch"),
+        "orchestrator_profile": ORCHESTRATOR_PROFILE,
+        "repo_profile_name": worktree.get("repo_profile_name"),
+        "repo_profile_path": worktree.get("repo_profile_path"),
+        "repo_profile_summary": worktree.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "worker_budget": len(recommended_workers),
+        "recommended_worker_count": len(recommended_workers),
+        "shared_packet": "global_packet.json",
+        "shared_packet_name": "global_packet.json",
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "task_packet_names": task_packet_names,
+        "candidate_batch_count": len(candidate_batch_names),
+        "split_file_count": len(split_packet_names),
+        "worker_selection_guidance": worker_selection_guidance,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": packet_worker_map,
+        "common_path_contract": COMMON_PATH_CONTRACT,
+        "reread_reason_values": RAW_REREAD_ALLOWED_REASONS,
+        "xhigh_reread_policy": XHIGH_REREAD_POLICY,
+        "candidate_batch_map": batch_map,
+        "split_candidate_paths": [packet["path"] for packet in split_packets],
+        "review_overrides": overrides,
+        "applied_override_signals": [str(item.get("reason")) for item in overrides if str(item.get("reason") or "").strip()],
+        "local_responsibilities": [
+            "Read rules_packet.json and worktree_packet.json locally before drafting commit-plan.json.",
+            "Keep the current staged state as a hint, not a contract.",
+            "Prefer whole-file commits unless a split-file packet clearly justifies a split.",
+            "Do not reread raw diffs on the common path; use explicit reread reasons only when packet evidence stays insufficient or conflicting.",
+            "Stop and ask when hunk confidence is low or any split packet stays ambiguous.",
+            "Validate commit-plan.json before running apply_commit_plan.py.",
+        ],
+        "packet_order": packet_order,
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+        "common_path_sufficient": common_path_sufficient,
+        "raw_reread_reasons": raw_reread_reasons,
+    }
+
+    packet_payloads: dict[str, dict[str, Any]] = {
+        "orchestrator.json": orchestrator,
+        "global_packet.json": global_packet,
+        "rules_packet.json": rules_packet,
+        "worktree_packet.json": worktree_packet,
+        **candidate_payloads,
+        **split_payloads,
+    }
+    local_only_surfaces = {
+        "candidate_batches": [
+            {
+                "batch_id": packet_basename(batch_name),
+                "files": [
+                    entry
+                    for entry in files
+                    if str(entry["path"]) in batch_map.get(packet_basename(batch_name), [])
+                ],
+            }
+            for batch_name in candidate_batch_names
+        ],
+        "split_candidates": split_packets,
+    }
+    packet_metrics = compute_packet_metrics(
+        packet_payloads,
+        local_only_sources={
+            "rules.json": rules,
+            "worktree.json": worktree,
+            "raw_focus_surfaces.json": local_only_surfaces,
+        },
+        shared_packets=[],
+    )
+    build_result = build_result_payload(
+        review_mode=review_mode,
+        recommended_workers=recommended_workers,
+        packet_order=packet_order,
+        active_packets=active_packets,
+        applied_override_signals=orchestrator["applied_override_signals"],
+        candidate_batch_count=len(candidate_batch_names),
+        split_file_count=len(split_packet_names),
+        packet_metrics=packet_metrics,
+        common_path_sufficient=common_path_sufficient,
+        raw_reread_reasons=raw_reread_reasons,
+    )
+
+    for path_name, payload in (
+        ("rules_packet.json", rules_packet),
+        ("worktree_packet.json", worktree_packet),
+        ("global_packet.json", global_packet),
+        ("orchestrator.json", orchestrator),
+        ("packet_metrics.json", packet_metrics),
+    ):
+        (output_dir / path_name).write_text(
+            json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.result_output:
+        args.result_output.write_text(
+            json.dumps(build_result, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output_dir),
+                "review_mode": review_mode,
+                "candidate_batch_count": len(batches),
+                "split_packet_count": len(split_packets),
+                "recommended_worker_count": len(recommended_workers),
+                "common_path_sufficient": common_path_sufficient,
+                "raw_reread_count": len(raw_reread_reasons),
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_commit_rules.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_commit_rules.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Collect repo-specific commit-message rules into a compact JSON artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+RULE_TEXT_SUFFIXES = (".md", ".txt", ".json", ".yml", ".yaml", ".js", ".cjs", ".mjs", ".ts")
+SUBJECT_RE = re.compile(
+    r"^(?P<type>[a-z][a-z0-9-]*)(?:\((?P<scope>[A-Za-z0-9._/-]+)\))?(?P<breaking>!)?: (?P<summary>.+)$"
+)
+FIXED_RULE_FILES = {
+    "commit_message_instructions": ".github/instructions/commit-message.instructions.md",
+    "copilot_instructions": ".github/copilot-instructions.md",
+    "contributing": "CONTRIBUTING.md",
+    "maintaining": "MAINTAINING.md",
+}
+
+
+def run_git(repo: Path, args: list[str], check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def parse_heading_blocks(markdown_text: str | None) -> dict[str, str]:
+    if not markdown_text:
+        return {}
+    blocks: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                blocks[current] = "\n".join(buffer).strip()
+            current = line[3:].strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        blocks[current] = "\n".join(buffer).strip()
+    return blocks
+
+
+def find_block(blocks: dict[str, str], prefix: str) -> str | None:
+    for heading, body in blocks.items():
+        if heading.lower().startswith(prefix.lower()):
+            return "## " + heading + ("\n" + body if body else "")
+    return None
+
+
+def extract_bullets(block: str | None) -> list[str]:
+    if not block:
+        return []
+    bullets: list[str] = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+    return bullets
+
+
+def extract_backtick_tokens(block: str | None) -> list[str]:
+    if not block:
+        return []
+    seen: list[str] = []
+    for token in re.findall(r"`([^`]+)`", block):
+        if token not in seen:
+            seen.append(token)
+    return seen
+
+
+def normalize_token_list(tokens: list[str]) -> list[str]:
+    seen: list[str] = []
+    for token in tokens:
+        cleaned = token.strip().strip("`").strip()
+        lowered = cleaned.lower()
+        if not re.fullmatch(r"[a-z][a-z0-9-]*", lowered):
+            continue
+        if lowered not in seen:
+            seen.append(lowered)
+    return seen
+
+
+def subject_length_limit(subject_block: str | None) -> int | None:
+    if not subject_block:
+        return None
+    match = re.search(r"(\d+)\s+characters?\s+or\s+fewer", subject_block, flags=re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def explicit_scope_requirement(format_block: str | None, scopes_block: str | None) -> bool | None:
+    combined = "\n".join(part for part in (format_block, scopes_block) if part)
+    if not combined:
+        return None
+    if re.search(r"scope`?\s+(?:is\s+)?optional", combined, flags=re.IGNORECASE):
+        return False
+    if re.search(r"scope`?\s+(?:is\s+)?not required", combined, flags=re.IGNORECASE):
+        return False
+    if re.search(r"scope`?\s+is\s+required", combined, flags=re.IGNORECASE):
+        return True
+    if "<type>(<scope>): <subject>" in combined:
+        return True
+    if re.search(r"(?:<type>|type)\s*!?\s*:\s*(?:<subject>|subject)", combined, flags=re.IGNORECASE):
+        return False
+    return None
+
+
+def commit_related_excerpt(text: str | None) -> list[str]:
+    if not text:
+        return []
+    matches: list[str] = []
+    for line in text.splitlines():
+        lowered = line.lower()
+        if "commit" in lowered or "conventional commit" in lowered or "subject" in lowered:
+            stripped = line.strip()
+            if stripped and stripped not in matches:
+                matches.append(stripped)
+        if len(matches) >= 8:
+            break
+    return matches
+
+
+def parse_subject_line(subject: str) -> dict[str, str | bool] | None:
+    match = SUBJECT_RE.match(subject.strip())
+    if not match:
+        return None
+    return {
+        "type": match.group("type"),
+        "scope": match.group("scope") or "",
+        "breaking": bool(match.group("breaking")),
+        "summary": match.group("summary"),
+    }
+
+
+def recent_subjects(repo_root: Path, count: int = 20) -> list[str]:
+    output = run_git(repo_root, ["log", f"-n{count}", "--format=%s"], check=False)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def recent_scopes(subjects: list[str]) -> list[str]:
+    seen: list[str] = []
+    for subject in subjects:
+        parsed = parse_subject_line(subject)
+        scope = str(parsed.get("scope", "")) if parsed else ""
+        if scope and scope not in seen:
+            seen.append(scope)
+    return seen
+
+
+def tracked_files(repo_root: Path) -> list[str]:
+    output = run_git(repo_root, ["ls-files"], check=False)
+    return [line.strip().replace("\\", "/") for line in output.splitlines() if line.strip()]
+
+
+def rule_file_key(rel_path: str) -> str | None:
+    lowered = rel_path.lower()
+    basename = Path(rel_path).name.lower()
+    for key, fixed_path in FIXED_RULE_FILES.items():
+        if lowered == fixed_path.lower():
+            return key
+
+    commitlint_names = {
+        ".commitlintrc",
+        ".commitlintrc.json",
+        ".commitlintrc.yml",
+        ".commitlintrc.yaml",
+        ".commitlintrc.js",
+        ".commitlintrc.cjs",
+        ".commitlintrc.mjs",
+        ".commitlintrc.ts",
+        "commitlint.config.js",
+        "commitlint.config.cjs",
+        "commitlint.config.mjs",
+        "commitlint.config.ts",
+    }
+    if basename in commitlint_names:
+        return "commitlint_config"
+    if basename in {".gitmessage", ".gitmessage.txt", "gitmessage.txt"}:
+        return "gitmessage_template"
+    if basename == "package.json":
+        return "package_json"
+    if not lowered.endswith(RULE_TEXT_SUFFIXES):
+        return None
+    if any(token in lowered for token in ("commit", "conventional", "semantic-release", "gitmessage")):
+        sanitized = re.sub(r"[^a-z0-9]+", "_", rel_path.lower()).strip("_")
+        return f"extra_rule_file_{sanitized}"
+    return None
+
+
+def discover_rule_files(repo_root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    seen_paths: set[str] = set()
+    for key, rel_path in FIXED_RULE_FILES.items():
+        path = (repo_root / rel_path).resolve()
+        if path.exists():
+            normalized_path = str(path)
+            result[key] = normalized_path
+            seen_paths.add(normalized_path)
+    for rel_path in tracked_files(repo_root):
+        key = rule_file_key(rel_path)
+        if key is None:
+            continue
+        normalized_path = str((repo_root / rel_path).resolve())
+        if normalized_path in seen_paths:
+            continue
+        unique_key = key
+        suffix = 2
+        while unique_key in result:
+            unique_key = f"{key}_{suffix}"
+            suffix += 1
+        result[unique_key] = normalized_path
+        seen_paths.add(normalized_path)
+    return result
+
+
+def load_rule_texts(files: dict[str, str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key, path_str in files.items():
+        text = read_text_if_exists(Path(path_str))
+        if text:
+            result[key] = text
+    return result
+
+
+def infer_format_from_text(text: str | None) -> str | None:
+    if not text:
+        return None
+    normalized = " ".join(text.split())
+    if re.search(
+        r"(?:<type>|type)\s*\(\s*(?:<scope>|scope)\s*\)\s*!?\s*:\s*(?:<subject>|subject)",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        return "<type>(<scope>): <subject>"
+    if re.search(
+        r"(?:<type>|type)\s*!?\s*:\s*(?:<subject>|subject)",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        return "<type>: <subject>"
+    return None
+
+
+def infer_format_from_recent_subjects(subjects: list[str]) -> str | None:
+    parsed = [item for subject in subjects if (item := parse_subject_line(subject)) is not None]
+    if len(parsed) < 3:
+        return None
+    if any(str(item.get("scope", "")) for item in parsed):
+        return "<type>(<scope>): <subject>"
+    return "<type>: <subject>"
+
+
+def infer_allowed_types(types_block: str | None, texts: dict[str, str], subjects: list[str]) -> tuple[list[str], str | None]:
+    explicit_tokens = normalize_token_list(extract_backtick_tokens(types_block))
+    if explicit_tokens:
+        return explicit_tokens, "commit_message_instructions"
+
+    commitlint_pattern = re.compile(
+        r"type-enum['\"]?\s*:\s*\[\s*\d+\s*,\s*['\"]always['\"]\s*,\s*\[(?P<body>.*?)\]\s*\]",
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    for key, text in texts.items():
+        match = commitlint_pattern.search(text)
+        if not match:
+            continue
+        tokens = normalize_token_list(re.findall(r"['\"]([A-Za-z0-9-]+)['\"]", match.group("body")))
+        if tokens:
+            return tokens, key
+
+    recent_types: list[str] = []
+    for subject in subjects:
+        parsed = parse_subject_line(subject)
+        if not parsed:
+            continue
+        message_type = str(parsed["type"]).lower()
+        if message_type not in recent_types:
+            recent_types.append(message_type)
+    return recent_types[:12], ("recent_subjects" if recent_types else None)
+
+
+def infer_scope_requirement(
+    format_block: str | None,
+    scopes_block: str | None,
+    texts: dict[str, str],
+    subjects: list[str],
+) -> tuple[bool | None, str | None]:
+    explicit = explicit_scope_requirement(format_block, scopes_block)
+    if explicit is not None:
+        return explicit, "commit_message_instructions"
+
+    for key, text in texts.items():
+        required_match = re.search(
+            r"scope-empty['\"]?\s*:\s*\[\s*\d+\s*,\s*['\"](?P<mode>always|never)['\"]",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if required_match:
+            return required_match.group("mode").lower() == "never", key
+
+    parsed = [item for subject in subjects if (item := parse_subject_line(subject)) is not None]
+    if len(parsed) >= 5:
+        with_scope = sum(1 for item in parsed if str(item.get("scope", "")))
+        if with_scope == len(parsed):
+            return True, "recent_subjects"
+        if with_scope == 0:
+            return False, "recent_subjects"
+    return None, None
+
+
+def infer_subject_length_limit(subject_block: str | None, texts: dict[str, str]) -> tuple[int | None, str | None]:
+    explicit = subject_length_limit(subject_block)
+    if explicit is not None:
+        return explicit, "commit_message_instructions"
+
+    header_limit_pattern = re.compile(
+        r"header-max-length['\"]?\s*:\s*\[\s*\d+\s*,\s*['\"]always['\"]\s*,\s*(?P<limit>\d+)\s*\]",
+        flags=re.IGNORECASE,
+    )
+    prose_limit_pattern = re.compile(r"(?P<limit>\d+)\s+characters?\s+or\s+fewer", flags=re.IGNORECASE)
+    for key, text in texts.items():
+        config_match = header_limit_pattern.search(text)
+        if config_match:
+            return int(config_match.group("limit")), key
+        prose_match = prose_limit_pattern.search(text)
+        if prose_match:
+            return int(prose_match.group("limit")), key
+    return None, None
+
+
+def derive_repo_defaults(type_selection_block: str | None, texts: dict[str, str]) -> tuple[list[str], str | None]:
+    defaults = extract_bullets(type_selection_block)
+    if defaults:
+        return defaults, "commit_message_instructions"
+
+    keywords = ("prefer ", "when uncertain", "default to ", "use `fix`", "use `feat`")
+    derived: list[str] = []
+    for key, text in texts.items():
+        for line in commit_related_excerpt(text):
+            lowered = line.lower()
+            if any(keyword in lowered for keyword in keywords) and line not in derived:
+                derived.append(line)
+        if derived:
+            return derived, key
+    return [], None
+
+
+def build_doc_mentions(texts: dict[str, str]) -> dict[str, list[str]]:
+    return {
+        key: commit_related_excerpt(text)
+        for key, text in texts.items()
+        if commit_related_excerpt(text)
+    }
+
+
+def build_rules(repo_root: Path) -> dict[str, object]:
+    repo_root = Path(run_git(repo_root, ["rev-parse", "--show-toplevel"]).strip())
+    files = discover_rule_files(repo_root)
+    texts = load_rule_texts(files)
+
+    instructions_text = texts.get("commit_message_instructions")
+    blocks = parse_heading_blocks(instructions_text)
+    format_block = find_block(blocks, "Format")
+    types_block = find_block(blocks, "Types")
+    type_selection_block = find_block(blocks, "Type Selection")
+    scopes_block = find_block(blocks, "Scopes")
+    subject_block = find_block(blocks, "Subject Rules")
+    body_block = find_block(blocks, "Body Rules")
+    refs_block = find_block(blocks, "References")
+
+    subjects = recent_subjects(repo_root)
+    recent_scope_words = recent_scopes(subjects)
+    format_from_instructions = infer_format_from_text(format_block)
+    inferred_format, format_source = (
+        (format_from_instructions, "commit_message_instructions")
+        if format_from_instructions
+        else (None, None)
+    )
+    if inferred_format is None:
+        for key, text in texts.items():
+            if key == "commit_message_instructions":
+                continue
+            candidate = infer_format_from_text(text)
+            if candidate:
+                inferred_format = candidate
+                format_source = key
+                break
+    if inferred_format is None:
+        recent_format = infer_format_from_recent_subjects(subjects)
+        inferred_format = recent_format or "<type>(<scope>): <subject>"
+        format_source = "recent_subjects" if recent_format else "fallback_default"
+
+    scope_suggestions = normalize_token_list(extract_backtick_tokens(scopes_block))
+    for scope in recent_scope_words:
+        if scope not in scope_suggestions:
+            scope_suggestions.append(scope)
+
+    allowed_types, allowed_types_source = infer_allowed_types(types_block, texts, subjects)
+    scope_is_required, scope_required_source = infer_scope_requirement(
+        format_block,
+        scopes_block,
+        texts,
+        subjects,
+    )
+    subject_limit, subject_limit_source = infer_subject_length_limit(subject_block, texts)
+    repo_defaults, repo_defaults_source = derive_repo_defaults(type_selection_block, texts)
+
+    return {
+        "repo_root": str(repo_root),
+        "rule_files": files,
+        "rules": {
+            "format": inferred_format,
+            "allowed_types": allowed_types,
+            "scope_required": scope_is_required,
+            "scope_suggestions": scope_suggestions,
+            "subject_length_limit": subject_limit,
+            "subject_rules": extract_bullets(subject_block),
+            "body_rules": extract_bullets(body_block),
+            "references_rules": extract_bullets(refs_block),
+            "repo_defaults": repo_defaults,
+        },
+        "rule_derivation": {
+            "format_source": format_source,
+            "allowed_types_source": allowed_types_source,
+            "scope_required_source": scope_required_source,
+            "subject_length_limit_source": subject_limit_source,
+            "repo_defaults_source": repo_defaults_source,
+        },
+        "recent_scope_vocabulary": recent_scope_words,
+        "recent_subject_samples": subjects[:12],
+        "instruction_snippets": {
+            "format": format_block,
+            "types": types_block,
+            "type_selection": type_selection_block,
+            "scopes": scopes_block,
+            "subject_rules": subject_block,
+            "body_rules": body_block,
+            "references": refs_block,
+        },
+        "doc_mentions": build_doc_mentions(texts),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect repo-specific commit-message rules into JSON."
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository path. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the JSON artifact. Prints JSON to stdout when omitted.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = build_rules(args.repo)
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(f"collect_commit_rules.py: {exc}", file=sys.stderr)
+        return 1
+
+    serialized = json.dumps(payload, indent=2, ensure_ascii=True) + "\n"
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+        print(f"Wrote commit rules to {args.output}")
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_worktree_context.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_worktree_context.py
@@ -1,0 +1,821 @@
+﻿#!/usr/bin/env python3
+"""Collect the current working-tree state for packet-based commit planning."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+
+
+GENERATED_FILE_PATTERNS = (
+    re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
+    re.compile(r"\.(g|generated)\.[^.]+$"),
+    re.compile(r"\.designer\.[^.]+$"),
+    re.compile(r"(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|cargo\.lock)$"),
+    re.compile(r"\.min\.(js|css)$"),
+)
+HUNK_HEADER_RE = re.compile(
+    r"^@@ -(?P<old_start>\d+)(?:,(?P<old_count>\d+))? \+(?P<new_start>\d+)(?:,(?P<new_count>\d+))? @@(?P<context>.*)$"
+)
+TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_]{2,}")
+TOKEN_STOPWORDS = {
+    "github",
+    "issue",
+    "template",
+    "maintaining",
+    "readme",
+    "docs",
+    "doc",
+    "tests",
+    "test",
+    "scripts",
+    "script",
+    "workflow",
+    "workflows",
+    "automation",
+    "file",
+    "files",
+    "update",
+    "updated",
+    "changes",
+    "change",
+    "report",
+    "reporting",
+}
+TOKEN_NORMALIZATION = {
+    "performance": "perf",
+    "perf": "perf",
+    "telemetry": "telemetry",
+    "comparison": "compare",
+    "comparable": "compare",
+    "comparisons": "compare",
+    "reporting": "report",
+    "reports": "report",
+}
+GROUP_SAMPLE_LIMIT = 16
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise RuntimeError(f"missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("repo profile must be a JSON object")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def run_git(repo: Path, args: list[str], check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout
+
+
+def resolve_repo_root(repo: Path) -> Path:
+    return Path(run_git(repo, ["rev-parse", "--show-toplevel"]).strip())
+
+
+def normalize_path(value: str) -> str:
+    return value.replace("\\", "/")
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def git_dir(repo_root: Path) -> Path:
+    raw = Path(run_git(repo_root, ["rev-parse", "--git-dir"]).strip())
+    return raw if raw.is_absolute() else (repo_root / raw)
+
+
+def detect_operation(repo_root: Path) -> str | None:
+    current_git_dir = git_dir(repo_root)
+    markers = {
+        "rebase": [current_git_dir / "rebase-merge", current_git_dir / "rebase-apply"],
+        "cherry-pick": [current_git_dir / "CHERRY_PICK_HEAD"],
+        "merge": [current_git_dir / "MERGE_HEAD"],
+        "bisect": [current_git_dir / "BISECT_LOG"],
+    }
+    for name, paths in markers.items():
+        if any(path.exists() for path in paths):
+            return name
+    return None
+
+
+def branch_state(repo_root: Path) -> dict[str, Any]:
+    branch = run_git(repo_root, ["branch", "--show-current"], check=False).strip()
+    status_branch = run_git(repo_root, ["status", "--short", "--branch"], check=False)
+    upstream = run_git(
+        repo_root,
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        check=False,
+    ).strip()
+    ahead = 0
+    behind = 0
+    if upstream:
+        counts = run_git(repo_root, ["rev-list", "--left-right", "--count", f"{upstream}...HEAD"], check=False).strip()
+        if counts:
+            parts = counts.split()
+            if len(parts) == 2:
+                behind = int(parts[0])
+                ahead = int(parts[1])
+    return {
+        "branch": branch,
+        "detached_head": branch == "",
+        "upstream_branch": upstream or None,
+        "ahead_count": ahead,
+        "behind_count": behind,
+        "status_branch_line": status_branch.splitlines()[0] if status_branch.splitlines() else "",
+    }
+
+
+def parse_status(repo_root: Path, pathspecs: list[str]) -> tuple[list[dict[str, Any]], str]:
+    args = ["status", "--porcelain=v1", "--untracked-files=all", "--ignored=no", "--branch"]
+    if pathspecs:
+        args.extend(["--", *pathspecs])
+    output = run_git(repo_root, args, check=False)
+    records: list[dict[str, Any]] = []
+    branch_line = ""
+    for line in output.splitlines():
+        if line.startswith("## "):
+            branch_line = line
+            continue
+        if len(line) < 4:
+            continue
+        xy = line[:2]
+        raw_path = line[3:]
+        path = raw_path
+        original_path = None
+        if " -> " in raw_path and any(marker in xy for marker in ("R", "C")):
+            original_path, path = raw_path.split(" -> ", 1)
+        records.append(
+            {
+                "xy": xy,
+                "staged_status": xy[0],
+                "unstaged_status": xy[1],
+                "path": normalize_path(path.strip()),
+                "original_path": normalize_path(original_path.strip()) if original_path else None,
+            }
+        )
+    return records, branch_line
+
+
+def classify_path(path: str) -> str:
+    lower = normalize_path(path).lower()
+    if (
+        "/tests/" in lower
+        or lower.endswith("_test.py")
+        or lower.endswith(".tests.cs")
+        or lower.endswith(".spec.ts")
+        or lower.startswith(".github/scripts/tests/")
+    ):
+        return "tests"
+    if (
+        lower.startswith(".github/workflows/")
+        or lower.startswith(".github/scripts/")
+        or lower.startswith(".github/issue_template/")
+        or lower.startswith(".github/instructions/")
+    ):
+        return "automation"
+    if lower.endswith(".md") or lower.startswith("docs/"):
+        return "docs"
+    if lower.endswith((".yml", ".yaml", ".toml", ".json", ".csproj", ".props", ".targets", ".xml")):
+        return "config"
+    if lower.endswith((".cs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java")):
+        return "runtime"
+    return "other"
+
+
+def is_generated_file(path: str) -> bool:
+    lowered = normalize_path(path).lower()
+    return any(pattern.search(lowered) for pattern in GENERATED_FILE_PATTERNS)
+
+
+def sample_parent(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else "."
+
+
+def select_representative_files(paths: list[str], limit: int = GROUP_SAMPLE_LIMIT) -> list[str]:
+    ordered_paths: list[str] = []
+    for path in paths:
+        if path not in ordered_paths:
+            ordered_paths.append(path)
+    if len(ordered_paths) <= limit:
+        return ordered_paths
+
+    buckets: dict[str, list[str]] = {}
+    bucket_order: list[str] = []
+    for path in ordered_paths:
+        parent = sample_parent(path)
+        if parent not in buckets:
+            buckets[parent] = []
+            bucket_order.append(parent)
+        buckets[parent].append(path)
+
+    selected: list[str] = []
+    while len(selected) < limit:
+        progressed = False
+        for parent in bucket_order:
+            bucket = buckets[parent]
+            if not bucket:
+                continue
+            selected.append(bucket.pop(0))
+            progressed = True
+            if len(selected) >= limit:
+                break
+        if not progressed:
+            break
+    original_index = {path: index for index, path in enumerate(ordered_paths)}
+    return sorted(selected, key=original_index.__getitem__)
+
+
+def summarize_groups(paths: list[str]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[str]] = {
+        "runtime": [],
+        "automation": [],
+        "docs": [],
+        "tests": [],
+        "config": [],
+        "other": [],
+    }
+    for path in paths:
+        grouped[classify_path(path)].append(path)
+
+    summary: dict[str, dict[str, Any]] = {}
+    for name, items in grouped.items():
+        sample_files = select_representative_files(items)
+        summary[name] = {
+            "count": len(items),
+            "sample_files": sample_files,
+            "omitted_file_count": max(len(items) - len(sample_files), 0),
+        }
+    return summary
+
+
+def classify_change_kind(record: dict[str, Any]) -> str:
+    xy = str(record["xy"])
+    if xy == "??":
+        return "untracked"
+    if "U" in xy:
+        return "unmerged"
+    if "R" in xy:
+        return "renamed"
+    if "C" in xy:
+        return "copied"
+    if "A" in xy:
+        return "added"
+    if "D" in xy:
+        return "deleted"
+    if "T" in xy:
+        return "typechange"
+    return "modified"
+
+
+def raw_diff_against_head(repo_root: Path, path: str) -> str:
+    return run_git(
+        repo_root,
+        [
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--no-renames",
+            "--binary",
+            "--full-index",
+            "--unified=0",
+            "HEAD",
+            "--",
+            path,
+        ],
+        check=False,
+    )
+
+
+def numstat_against_head(repo_root: Path, path: str) -> tuple[int | None, int | None, bool]:
+    output = run_git(
+        repo_root,
+        ["diff", "--no-ext-diff", "--no-textconv", "--no-renames", "--numstat", "HEAD", "--", path],
+        check=False,
+    )
+    lines = [line for line in output.splitlines() if line.strip()]
+    if not lines:
+        return 0, 0, False
+    parts = lines[-1].split("\t")
+    if len(parts) < 3:
+        return None, None, False
+    if parts[0] == "-" and parts[1] == "-":
+        return None, None, True
+    return int(parts[0]), int(parts[1]), False
+
+
+def is_probably_binary(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    sample = path.read_bytes()[:8192]
+    return b"\x00" in sample
+
+
+def normalize_token(token: str) -> str | None:
+    lowered = token.lower()
+    lowered = TOKEN_NORMALIZATION.get(lowered, lowered)
+    if lowered in TOKEN_STOPWORDS:
+        return None
+    if len(lowered) < 3:
+        return None
+    return lowered
+
+
+def identifier_tokens(text: str) -> list[str]:
+    tokens: list[str] = []
+    for raw in TOKEN_RE.findall(text):
+        expanded = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", raw).replace("_", " ")
+        for piece in expanded.split():
+            normalized = normalize_token(piece)
+            if normalized and normalized not in tokens:
+                tokens.append(normalized)
+    return tokens
+
+
+def path_tokens(path: str) -> list[str]:
+    return identifier_tokens(path.replace("/", " "))
+
+
+def parse_patch_hunks(path: str, patch_text: str) -> list[dict[str, Any]]:
+    lines = patch_text.splitlines()
+    hunks: list[dict[str, Any]] = []
+    index = 0
+    while index < len(lines):
+        header = lines[index]
+        if not header.startswith("@@ "):
+            index += 1
+            continue
+        match = HUNK_HEADER_RE.match(header)
+        if not match:
+            index += 1
+            continue
+
+        body_lines: list[str] = []
+        index += 1
+        while index < len(lines) and not lines[index].startswith("@@ "):
+            if lines[index].startswith("diff --git "):
+                break
+            body_lines.append(lines[index])
+            index += 1
+
+        removed_lines = [line[1:] for line in body_lines if line.startswith("-")]
+        added_lines = [line[1:] for line in body_lines if line.startswith("+")]
+        removed_digest = sha256_text("\n".join(removed_lines))
+        added_digest = sha256_text("\n".join(added_lines))
+        match_digest = sha256_text("\n".join(["removed", removed_digest, "added", added_digest]))
+        hunk_id = "hunk-" + sha256_text(
+            "\n".join(
+                [
+                    normalize_path(path),
+                    header,
+                    removed_digest,
+                    added_digest,
+                ]
+            )
+        )[:16]
+        tokens = identifier_tokens(match.group("context") or "")
+        for line in body_lines:
+            if line.startswith(("+", "-")):
+                for token in identifier_tokens(line[1:]):
+                    if token not in tokens:
+                        tokens.append(token)
+
+        hunks.append(
+            {
+                "hunk_id": hunk_id,
+                "match_digest": match_digest,
+                "header": header,
+                "old_start": int(match.group("old_start")),
+                "old_count": int(match.group("old_count") or "1"),
+                "new_start": int(match.group("new_start")),
+                "new_count": int(match.group("new_count") or "1"),
+                "context": (match.group("context") or "").strip(),
+                "removed_digest": removed_digest,
+                "added_digest": added_digest,
+                "raw_body_lines": body_lines,
+                "raw_patch": "\n".join([header, *body_lines]) + "\n",
+                "tokens": tokens[:12],
+            }
+        )
+    return hunks
+
+
+def diff_header_text(patch_text: str) -> str:
+    header_lines: list[str] = []
+    for line in patch_text.splitlines():
+        if line.startswith("@@ "):
+            break
+        header_lines.append(line)
+    return ("\n".join(header_lines) + "\n") if header_lines else ""
+
+
+def tracked_test_for_script(repo_root: Path, path: str) -> str | None:
+    normalized = normalize_path(path)
+    if not normalized.startswith(".github/scripts/") or normalized.startswith(".github/scripts/tests/"):
+        return None
+    stem = Path(normalized).stem
+    candidate = repo_root / ".github/scripts/tests" / f"test_{stem}.py"
+    return normalize_path(str(candidate.relative_to(repo_root))) if candidate.is_file() else None
+
+
+def targeted_validation_candidates(repo_root: Path, changed_paths: list[str]) -> list[dict[str, Any]]:
+    normalized_paths = [normalize_path(path) for path in changed_paths]
+    changed_tests = sorted(
+        {
+            path
+            for path in normalized_paths
+            if path.startswith(".github/scripts/tests/test_") and path.endswith(".py")
+        }
+    )
+    changed_scripts = sorted(
+        {
+            path
+            for path in normalized_paths
+            if path.startswith(".github/scripts/")
+            and path.endswith(".py")
+            and not path.startswith(".github/scripts/tests/")
+        }
+    )
+    docs_only = all(
+        classify_path(path) in {"docs", "config", "other"}
+        and not path.startswith(".github/scripts/")
+        and not path.startswith(".github/workflows/")
+        for path in normalized_paths
+    )
+    if docs_only:
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    seen_commands: set[str] = set()
+    for test_path in changed_tests:
+        command = (
+            f'python -m unittest discover -s .github/scripts/tests -p "{Path(test_path).name}"'
+        )
+        if command not in seen_commands:
+            candidates.append(
+                {
+                    "command": command,
+                    "reason": f"Changed test file {test_path}.",
+                    "paths": [test_path],
+                }
+            )
+            seen_commands.add(command)
+
+    if not changed_tests and changed_scripts:
+        mapped_tests = [tracked_test_for_script(repo_root, path) for path in changed_scripts]
+        if all(mapped_tests):
+            for script_path, test_path in zip(changed_scripts, mapped_tests):
+                command = (
+                    f'python -m unittest discover -s .github/scripts/tests -p "{Path(str(test_path)).name}"'
+                )
+                if command in seen_commands:
+                    continue
+                candidates.append(
+                    {
+                        "command": command,
+                        "reason": f"Changed script {script_path} with matching test {test_path}.",
+                        "paths": [script_path, str(test_path)],
+                    }
+                )
+                seen_commands.add(command)
+        else:
+            command = 'python -m unittest discover -s .github/scripts/tests -p "test_*.py"'
+            candidates.append(
+                {
+                    "command": command,
+                    "reason": "Changed .github/scripts Python code without a complete one-to-one test mapping.",
+                    "paths": changed_scripts,
+                }
+            )
+            seen_commands.add(command)
+
+    if not candidates and any(path.startswith(".github/workflows/") for path in normalized_paths):
+        command = 'python -m unittest discover -s .github/scripts/tests -p "test_*.py"'
+        candidates.append(
+            {
+                "command": command,
+                "reason": "Changed GitHub workflow files that orchestrate automation tests.",
+                "paths": [path for path in normalized_paths if path.startswith(".github/workflows/")],
+            }
+        )
+
+    return candidates
+
+
+def build_file_entry(repo_root: Path, record: dict[str, Any]) -> dict[str, Any]:
+    path = normalize_path(str(record["path"]))
+    absolute_path = repo_root / Path(path)
+    change_kind = classify_change_kind(record)
+    tracked = change_kind != "untracked"
+    diff_text = raw_diff_against_head(repo_root, path) if tracked else ""
+    insertions, deletions, binary_from_numstat = numstat_against_head(repo_root, path) if tracked else (None, None, False)
+    binary = binary_from_numstat or (change_kind == "untracked" and is_probably_binary(absolute_path))
+
+    entry: dict[str, Any] = {
+        "path": path,
+        "original_path": record.get("original_path"),
+        "xy": record["xy"],
+        "staged_status": record["staged_status"],
+        "unstaged_status": record["unstaged_status"],
+        "change_kind": change_kind,
+        "tracked": tracked,
+        "area": classify_path(path),
+        "generated": is_generated_file(path),
+        "binary": binary,
+        "path_tokens": path_tokens(path),
+        "file_fingerprint": "",
+        "split_eligible": False,
+        "hunks": [],
+    }
+
+    if tracked:
+        entry["insertions"] = insertions
+        entry["deletions"] = deletions
+        entry["file_fingerprint"] = "sha256:" + sha256_text("\n".join([path, record["xy"], diff_text]))
+    else:
+        payload = absolute_path.read_bytes() if absolute_path.is_file() else b""
+        entry["file_fingerprint"] = "sha256:" + sha256_bytes(payload)
+        entry["size_bytes"] = len(payload)
+
+    if tracked and change_kind == "modified" and not binary and diff_text.strip():
+        hunks = parse_patch_hunks(path, diff_text)
+        entry["hunks"] = hunks
+        entry["split_eligible"] = bool(hunks)
+        entry["diff_header_text"] = diff_header_text(diff_text)
+    else:
+        entry["diff_header_text"] = ""
+    return entry
+
+
+def parse_shortstat(shortstat: str | None) -> dict[str, int]:
+    if not shortstat:
+        return {"files_changed": 0, "insertions": 0, "deletions": 0, "churn": 0}
+    files = re.search(r"(\d+)\s+files?\s+changed", shortstat)
+    insertions = re.search(r"(\d+)\s+insertions?\(\+\)", shortstat)
+    deletions = re.search(r"(\d+)\s+deletions?\(-\)", shortstat)
+    changed = int(files.group(1)) if files else 0
+    added = int(insertions.group(1)) if insertions else 0
+    removed = int(deletions.group(1)) if deletions else 0
+    return {
+        "files_changed": changed,
+        "insertions": added,
+        "deletions": removed,
+        "churn": added + removed,
+    }
+
+
+def build_worktree_fingerprint(head_commit: str, files: list[dict[str, Any]]) -> str:
+    parts = [head_commit]
+    for entry in sorted(files, key=lambda item: str(item["path"])):
+        parts.append(str(entry["path"]))
+        parts.append(str(entry["xy"]))
+        parts.append(str(entry["file_fingerprint"]))
+    return "sha256:" + sha256_text("\n".join(parts))
+
+
+def build_worktree_context(repo: Path, pathspecs: list[str] | None = None) -> dict[str, Any]:
+    repo_root = resolve_repo_root(repo)
+    selected_pathspecs = [normalize_path(path) for path in (pathspecs or [])]
+    branch_info = branch_state(repo_root)
+    records, branch_line = parse_status(repo_root, selected_pathspecs)
+    files = [build_file_entry(repo_root, record) for record in records]
+    files.sort(key=lambda item: str(item["path"]))
+
+    changed_paths = [str(item["path"]) for item in files]
+    head_commit = run_git(repo_root, ["rev-parse", "HEAD"]).strip()
+    diff_shortstat = run_git(
+        repo_root,
+        ["diff", "--shortstat", "HEAD", "--", *selected_pathspecs] if selected_pathspecs else ["diff", "--shortstat", "HEAD"],
+        check=False,
+    ).strip()
+    diff_stat = run_git(
+        repo_root,
+        ["diff", "--stat", "HEAD", "--", *selected_pathspecs] if selected_pathspecs else ["diff", "--stat", "HEAD"],
+        check=False,
+    ).strip()
+
+    worktree_fingerprint = build_worktree_fingerprint(head_commit, files)
+    validation_candidates = targeted_validation_candidates(repo_root, changed_paths)
+
+    validation_commands = [
+        {
+            "command": item["command"],
+            "reason": item["reason"],
+            "paths": item.get("paths", []),
+            "confidence": "high",
+        }
+        for item in validation_candidates
+    ]
+
+    return {
+        "repo_root": str(repo_root),
+        "input_scope": "all-local-changes",
+        "pathspecs": selected_pathspecs,
+        "head_commit": head_commit,
+        "head": head_commit,
+        "branch": branch_info["branch"],
+        "detached_head": branch_info["detached_head"],
+        "upstream_branch": branch_info["upstream_branch"],
+        "ahead_count": branch_info["ahead_count"],
+        "behind_count": branch_info["behind_count"],
+        "status_branch_line": branch_line or branch_info["status_branch_line"],
+        "branch_state": branch_info,
+        "active_operation": detect_operation(repo_root),
+        "worktree_fingerprint": worktree_fingerprint,
+        "changed_paths": changed_paths,
+        "changed_file_groups": summarize_groups(changed_paths),
+        "diff_shortstat": diff_shortstat or None,
+        "diff_stat": diff_stat or None,
+        "validation_candidates": validation_candidates,
+        "validation_commands": validation_commands,
+        "shortstat": parse_shortstat(diff_shortstat),
+        "files": files,
+    }
+
+
+def build_context(repo: Path, pathspecs: list[str] | None = None) -> dict[str, Any]:
+    return build_worktree_context(repo, pathspecs)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect the current working-tree state into a JSON artifact."
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository path. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the JSON artifact. Prints JSON to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--pathspec",
+        action="append",
+        default=[],
+        help="Optional Git pathspec to limit the collected worktree surface. May be repeated.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        repo_root = Path(args.repo).resolve()
+        profile_path = resolve_profile_path(args.profile, repo_root)
+        repo_profile = load_repo_profile(profile_path)
+        payload = build_worktree_context(args.repo, args.pathspec)
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(f"collect_worktree_context.py: {exc}", file=sys.stderr)
+        return 1
+    payload["repo_profile_name"] = repo_profile.get("name")
+    payload["repo_profile_path"] = profile_path.as_posix()
+    payload["repo_profile_summary"] = repo_profile.get("summary")
+    payload["repo_profile"] = repo_profile
+    payload["builder_compatibility"] = build_builder_compatibility(repo_profile)
+    if payload["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(payload["builder_compatibility"]), file=sys.stderr)
+
+    serialized = json.dumps(payload, indent=2, ensure_ascii=True) + "\n"
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+        print(f"Wrote worktree context to {args.output}")
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/commit_packet_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/commit_packet_contract.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Shared packet contracts and helpers for git-split-and-commit."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+ORCHESTRATOR_PROFILE = "standard"
+DECISION_READY_PACKETS = True
+WORKER_RETURN_CONTRACT = "classification-oriented"
+WORKER_OUTPUT_SHAPE = "hierarchical"
+
+PACKET_NAMES = {
+    "global": "global_packet.json",
+    "rules": "rules_packet.json",
+    "worktree": "worktree_packet.json",
+}
+
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["repo_mapper", "docs_verifier"],
+    "candidate_producers": ["evidence_summarizer", "large_diff_auditor", "log_triager"],
+    "verifiers": ["docs_verifier"],
+}
+
+WORKER_SELECTION_GUIDANCE = {
+    "routing_authority": "packet_worker_map",
+    "notes": "packet_worker_map is the concrete routing source; preferred_worker_families is explanatory metadata.",
+    "agent_type_guidance": {
+        "docs_verifier": "Use for hard commit-message constraints, scope rules, and repo defaults.",
+        "repo_mapper": "Use for worktree surface mapping, touched-area summary, and validation-candidate coverage.",
+        "evidence_summarizer": "Use for logical commit-bucket summaries and proposal-grade scope/type recommendations.",
+        "large_diff_auditor": "Use for split-file adjudication and QA on risky commit boundaries.",
+        "log_triager": "Use only when targeted validation or automation blockers need narrow triage.",
+    },
+}
+
+RAW_REREAD_ALLOWED_REASONS = [
+    "conflicting_signals",
+    "missing_required_evidence",
+    "schema_mismatch",
+    "insufficient_excerpt_quality",
+    "stale_worktree_fingerprint",
+    "ambiguous_hunk_match",
+]
+
+XHIGH_REREAD_POLICY = (
+    "Packet-first local adjudication is required on the common path; raw diff rereads are only allowed for explicit exception reasons."
+)
+
+COMMON_PATH_CONTRACT = {
+    "shared_packets": ["rules_packet.json", "worktree_packet.json"],
+    "focused_packet_mode": "read one candidate-batch or split-file packet at a time while keeping the shared packets in view",
+    "goal": "Draft commit-plan.json without raw diff rereads on the common path.",
+}
+
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+
+
+def packet_basename(name: str) -> str:
+    return name.removesuffix(".json")
+
+
+def packet_basenames(names: list[str]) -> list[str]:
+    return [packet_basename(name) for name in names]
+
+
+def build_task_packet_names(candidate_batch_names: list[str], split_packet_names: list[str]) -> list[str]:
+    return [
+        packet_basename(PACKET_NAMES["rules"]),
+        packet_basename(PACKET_NAMES["worktree"]),
+        *packet_basenames(candidate_batch_names),
+        *packet_basenames(split_packet_names),
+    ]
+
+
+def build_packet_worker_map(candidate_batch_names: list[str], split_packet_names: list[str]) -> dict[str, list[str]]:
+    return {
+        packet_basename(PACKET_NAMES["rules"]): ["docs_verifier"],
+        packet_basename(PACKET_NAMES["worktree"]): ["repo_mapper"],
+        **{name: ["evidence_summarizer"] for name in packet_basenames(candidate_batch_names)},
+        **{name: ["large_diff_auditor"] for name in packet_basenames(split_packet_names)},
+    }
+
+
+def dedupe_preserve(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def json_bytes(payload: Any) -> int:
+    return len(json.dumps(payload, ensure_ascii=True, sort_keys=True).encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return max(1, int(round(byte_count / 4.0)))
+
+
+def compute_packet_metrics(
+    packet_payloads: dict[str, Any],
+    *,
+    local_only_sources: dict[str, Any],
+    shared_packets: list[str] | None = None,
+) -> dict[str, int]:
+    shared_packet_names = shared_packets or [PACKET_NAMES["rules"], PACKET_NAMES["worktree"]]
+    packet_sizes = {
+        name: json_bytes(payload)
+        for name, payload in packet_payloads.items()
+    }
+    total_packet_bytes = sum(packet_sizes.values())
+    largest_sizes = sorted(packet_sizes.values(), reverse=True)
+    focused_sizes = [
+        size
+        for name, size in packet_sizes.items()
+        if name.startswith("candidate-batch-") or name.startswith("split-file-")
+    ]
+    common_path_packet_bytes = sum(packet_sizes.get(name, 0) for name in shared_packet_names)
+    if focused_sizes:
+        common_path_packet_bytes += max(focused_sizes)
+    local_only_bytes = sum(json_bytes(payload) for payload in local_only_sources.values())
+    estimated_local_only_tokens = estimate_tokens_from_bytes(local_only_bytes)
+    estimated_packet_tokens = estimate_tokens_from_bytes(common_path_packet_bytes)
+    return {
+        "packet_count": len(packet_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "largest_packet_bytes": largest_sizes[0] if largest_sizes else 0,
+        "largest_two_packets_bytes": sum(largest_sizes[:2]),
+        "estimated_local_only_tokens": estimated_local_only_tokens,
+        "estimated_packet_tokens": estimated_packet_tokens,
+        "estimated_delegation_savings": max(0, estimated_local_only_tokens - estimated_packet_tokens),
+    }

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/smoke_git_split_and_commit.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/smoke_git_split_and_commit.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Smoke-test git-split-and-commit on a temp repository."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def run_python(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"python {' '.join(args)} failed")
+    return result
+
+
+def run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+    return result
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def create_repo(repo_root: Path) -> None:
+    run_git(repo_root, ["init"])
+    run_git(repo_root, ["config", "user.name", "Smoke Test"])
+    run_git(repo_root, ["config", "user.email", "smoke@example.test"])
+
+    write_text(
+        repo_root / ".github" / "instructions" / "commit-message.instructions.md",
+        "\n".join(
+            [
+                "## Format",
+                "- Use `<type>(<scope>): <subject>`.",
+                "",
+                "## Types",
+                "- `fix`",
+                "- `docs`",
+                "",
+                "## Scopes",
+                "- `core`",
+            ]
+        )
+        + "\n",
+    )
+    write_text(repo_root / "src" / "app.py", "print('before')\n")
+    write_text(repo_root / "docs" / "notes.md", "# Notes\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "fix(core): seed repo"])
+
+    write_text(repo_root / "src" / "app.py", "print('after')\n")
+
+
+def build_plan(worktree: dict) -> dict:
+    return {
+        "repo_root": worktree["repo_root"],
+        "base_head": worktree["head_commit"],
+        "worktree_fingerprint": worktree["worktree_fingerprint"],
+        "input_scope": worktree["input_scope"],
+        "overall_confidence": "high",
+        "validation_commands": [],
+        "omitted_paths": [],
+        "stop_reasons": [],
+        "commits": [
+            {
+                "commit_index": 1,
+                "intent_summary": "Update app output.",
+                "type": "fix",
+                "scope": "core",
+                "subject": "update app output",
+                "body": ["- update the tracked runtime file"],
+                "whole_file_paths": ["src/app.py"],
+                "untracked_paths": [],
+                "split_paths": [],
+                "selected_hunk_ids": [],
+                "supporting_paths": [],
+                "targeted_checks": [],
+                "confidence": "high",
+            }
+        ],
+    }
+
+
+def main() -> int:
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "git-split-and-commit"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-") as tmp_dir:
+        root = Path(tmp_dir)
+        repo_root = root / "repo"
+        repo_root.mkdir()
+        create_repo(repo_root)
+
+        rules_path = root / "rules.json"
+        worktree_path = root / "worktree.json"
+        packet_dir = root / "packets"
+        build_result_path = root / "build-result.json"
+        plan_path = root / "commit-plan.json"
+        validation_path = root / "validation.json"
+        apply_result_path = root / "apply-result.json"
+        eval_log_path = root / "eval-log.json"
+
+        run_python(
+            [
+                str(SCRIPT_DIR / "collect_commit_rules.py"),
+                "--repo",
+                str(repo_root),
+                "--output",
+                str(rules_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "collect_worktree_context.py"),
+                "--repo",
+                str(repo_root),
+                "--output",
+                str(worktree_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "build_commit_packets.py"),
+                "--rules",
+                str(rules_path),
+                "--worktree",
+                str(worktree_path),
+                "--output-dir",
+                str(packet_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "init",
+                "--context",
+                str(worktree_path),
+                "--orchestrator",
+                str(packet_dir / "orchestrator.json"),
+                "--output",
+                str(eval_log_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "build",
+                "--result",
+                str(build_result_path),
+            ]
+        )
+
+        worktree = load_json(worktree_path)
+        plan_path.write_text(json.dumps(build_plan(worktree), indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+        run_python(
+            [
+                str(SCRIPT_DIR / "validate_commit_plan.py"),
+                "--worktree",
+                str(worktree_path),
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(validation_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "validate",
+                "--result",
+                str(validation_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "apply_commit_plan.py"),
+                "--worktree",
+                str(worktree_path),
+                "--validation",
+                str(validation_path),
+                "--dry-run",
+                "--result-output",
+                str(apply_result_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "apply",
+                "--result",
+                str(apply_result_path),
+            ]
+        )
+
+        build_result = load_json(build_result_path)
+        eval_log = load_json(eval_log_path)
+        packet_metrics = load_json(packet_dir / "packet_metrics.json")
+        if not build_result.get("common_path_sufficient"):
+            raise RuntimeError("Smoke fixture should be common-path sufficient.")
+        if build_result.get("raw_reread_count") != 0:
+            raise RuntimeError("Smoke fixture unexpectedly requires raw rereads.")
+        if packet_metrics.get("estimated_packet_tokens", 0) >= packet_metrics.get("estimated_local_only_tokens", 0):
+            raise RuntimeError("Packet tokens should remain below local-only tokens for the smoke fixture.")
+
+        summary = {
+            "common_path_sufficient": build_result.get("common_path_sufficient"),
+            "raw_reread_count": build_result.get("raw_reread_count"),
+            "raw_reread_reasons": build_result.get("raw_reread_reasons"),
+            "packet_metrics": packet_metrics,
+            "evaluation_log": {
+                "result_status": (eval_log.get("quality") or {}).get("result_status"),
+                "common_path_sufficient": ((eval_log.get("skill_specific") or {}).get("data") or {}).get("common_path_sufficient"),
+                "estimated_delegation_savings": (eval_log.get("baseline") or {}).get("estimated_delegation_savings"),
+            },
+        }
+        print(json.dumps(summary, indent=2, ensure_ascii=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/validate_commit_plan.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/validate_commit_plan.py
@@ -1,0 +1,1133 @@
+#!/usr/bin/env python3
+"""Validate and normalize a commit plan against a collected worktree snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from collect_worktree_context import build_worktree_context
+
+
+PLAN_PHASE_FIELD_TABLES = {
+    "draft_plan": {
+        "top_level": {
+            "required": [
+                "repo_root",
+                "base_head",
+                "worktree_fingerprint",
+                "input_scope",
+                "overall_confidence",
+                "validation_commands",
+                "omitted_paths",
+                "stop_reasons",
+                "commits",
+            ],
+            "allowed": [],
+            "ignored": [],
+        },
+        "commit": {
+            "required": [
+                "commit_index",
+                "intent_summary",
+                "type",
+                "scope",
+                "subject",
+                "body",
+                "whole_file_paths",
+                "untracked_paths",
+                "split_paths",
+                "selected_hunk_ids",
+                "supporting_paths",
+                "targeted_checks",
+                "confidence",
+            ],
+            "allowed": [],
+            "ignored": [],
+        },
+    },
+    "normalized_plan": {
+        "top_level": {
+            "required": [
+                "repo_root",
+                "base_head",
+                "worktree_fingerprint",
+                "input_scope",
+                "overall_confidence",
+                "validation_commands",
+                "omitted_paths",
+                "stop_reasons",
+                "commits",
+            ],
+            "allowed": [],
+            "ignored": [],
+        },
+        "commit": {
+            "required": [
+                "commit_index",
+                "intent_summary",
+                "type",
+                "scope",
+                "subject",
+                "body",
+                "whole_file_paths",
+                "untracked_paths",
+                "split_paths",
+                "selected_hunk_ids",
+                "supporting_paths",
+                "targeted_checks",
+                "confidence",
+            ],
+            "allowed": [],
+            "ignored": [],
+        },
+    },
+}
+
+VALIDATION_ERROR_CODES = {
+    "missing_field": "E_PLAN_MISSING_FIELD",
+    "empty_commits": "E_PLAN_EMPTY_COMMITS",
+    "head_changed": "E_PLAN_HEAD_CHANGED",
+    "fingerprint_changed": "E_PLAN_FINGERPRINT_CHANGED",
+    "active_git_operation": "E_PLAN_ACTIVE_GIT_OPERATION",
+    "repo_root_mismatch": "E_PLAN_REPO_ROOT_MISMATCH",
+    "base_head_mismatch": "E_PLAN_BASE_HEAD_MISMATCH",
+    "worktree_fingerprint_mismatch": "E_PLAN_WORKTREE_FINGERPRINT_MISMATCH",
+    "duplicate_validation_command": "E_PLAN_DUPLICATE_VALIDATION_COMMAND",
+    "commit_not_object": "E_PLAN_COMMIT_NOT_OBJECT",
+    "unknown_path": "E_PLAN_UNKNOWN_PATH",
+    "invalid_untracked_path": "E_PLAN_INVALID_UNTRACKED_PATH",
+    "invalid_split_path": "E_PLAN_INVALID_SPLIT_PATH",
+    "partial_split_unsupported": "E_PLAN_PARTIAL_SPLIT_UNSUPPORTED",
+    "unknown_hunk": "E_PLAN_UNKNOWN_HUNK",
+    "path_assignment_mismatch": "E_PLAN_PATH_ASSIGNMENT_MISMATCH",
+    "hunk_assignment_mismatch": "E_PLAN_HUNK_ASSIGNMENT_MISMATCH",
+    "ambiguous_split_rematch": "E_PLAN_AMBIGUOUS_SPLIT_REMATCH",
+    "adjacent_split_hunks": "E_PLAN_ADJACENT_SPLIT_HUNKS",
+    "targeted_check_unavailable": "E_PLAN_TARGETED_CHECK_UNAVAILABLE",
+}
+
+VALIDATION_WARNING_CODES = {
+    "unknown_top_level_field": "W_PLAN_UNKNOWN_TOP_LEVEL_FIELD",
+    "unknown_commit_field": "W_PLAN_UNKNOWN_COMMIT_FIELD",
+    "body_string_normalized": "W_PLAN_BODY_STRING_NORMALIZED",
+    "commit_index_non_sequential": "W_PLAN_COMMIT_INDEX_NON_SEQUENTIAL",
+    "empty_scope": "W_PLAN_EMPTY_SCOPE",
+    "non_bullet_body": "W_PLAN_NON_BULLET_BODY",
+    "targeted_check_missing_from_plan": "W_PLAN_TARGETED_CHECK_MISSING_FROM_PLAN",
+}
+
+VALIDATOR_COVERED_STOP_CATEGORIES = [
+    "active_git_operation",
+    "ambiguous_split_rematch",
+    "low_confidence",
+    "partial_split_unsupported",
+    "stale_context",
+    "targeted_check_unavailable",
+    "validator_mismatch",
+    "unresolved_stop_reason",
+]
+
+LOCAL_HARD_STOP_CATEGORIES = [
+    "active_git_operation",
+    "ambiguous_split_rematch",
+    "commit_creation_failed",
+    "partial_split_unsupported",
+    "rollback_failed",
+    "targeted_check_failed",
+    "targeted_check_unavailable",
+    "validator_mismatch",
+]
+
+NON_APPLICABLE_STOP_CATEGORIES = [
+    "missing_auth",
+    "missing_required_evidence",
+]
+
+WINDOWS_SHELL_BUILTINS = {
+    "assoc",
+    "break",
+    "call",
+    "cd",
+    "chcp",
+    "cls",
+    "copy",
+    "date",
+    "del",
+    "dir",
+    "echo",
+    "endlocal",
+    "erase",
+    "exit",
+    "for",
+    "ftype",
+    "if",
+    "md",
+    "mkdir",
+    "mklink",
+    "move",
+    "path",
+    "pause",
+    "popd",
+    "prompt",
+    "pushd",
+    "rd",
+    "rem",
+    "ren",
+    "rename",
+    "rmdir",
+    "set",
+    "setlocal",
+    "shift",
+    "start",
+    "time",
+    "title",
+    "type",
+    "ver",
+    "verify",
+    "vol",
+}
+
+POSIX_SHELL_BUILTINS = {
+    ".",
+    ":",
+    "alias",
+    "bg",
+    "break",
+    "cd",
+    "command",
+    "continue",
+    "echo",
+    "eval",
+    "exec",
+    "exit",
+    "export",
+    "false",
+    "fg",
+    "getopts",
+    "hash",
+    "jobs",
+    "pwd",
+    "read",
+    "readonly",
+    "return",
+    "set",
+    "shift",
+    "test",
+    "times",
+    "trap",
+    "true",
+    "type",
+    "ulimit",
+    "umask",
+    "unalias",
+    "unset",
+    "wait",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def command_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        result: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                command = str(item.get("command", "")).strip()
+            else:
+                command = str(item).strip()
+            if command:
+                result.append(command)
+        return result
+    if isinstance(value, dict):
+        command = str(value.get("command", "")).strip()
+        return [command] if command else []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    return []
+
+
+def normalize_body(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [line for line in value.splitlines() if line.strip()]
+    return [str(value)]
+
+
+def normalize_path_string(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return os.path.normcase(os.path.normpath(text))
+
+
+def safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def dedupe_preserve(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        text = str(value).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+def command_head_token(command: str) -> str | None:
+    match = re.match(r'\s*(?:"([^"]+)"|\'([^\']+)\'|([^\s]+))', command or "")
+    if not match:
+        return None
+    for group in match.groups():
+        if group:
+            return group
+    return None
+
+
+def builtin_command_names() -> set[str]:
+    return WINDOWS_SHELL_BUILTINS if os.name == "nt" else POSIX_SHELL_BUILTINS
+
+
+def resolve_command_executable(repo_root: Path, token: str) -> str | None:
+    candidate = str(token).strip()
+    if not candidate:
+        return None
+    lowered = candidate.lower()
+    if lowered in builtin_command_names():
+        return candidate
+
+    path_candidate = Path(candidate)
+    if path_candidate.is_absolute() or any(separator in candidate for separator in ("/", "\\")):
+        base_path = path_candidate if path_candidate.is_absolute() else (repo_root / path_candidate)
+        candidates = [base_path]
+        if os.name == "nt" and not base_path.suffix:
+            for extension in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";"):
+                extension = extension.strip()
+                if extension:
+                    candidates.append(Path(str(base_path) + extension))
+        for resolved in candidates:
+            if resolved.is_file():
+                return str(resolved)
+        return None
+
+    located = shutil.which(candidate)
+    if located:
+        return located
+    if os.name == "nt" and not path_candidate.suffix:
+        for extension in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";"):
+            extension = extension.strip()
+            if not extension:
+                continue
+            located = shutil.which(candidate + extension)
+            if located:
+                return located
+    return None
+
+
+def command_feasibility_issues(repo_root: Path, commands: list[str]) -> list[dict[str, str]]:
+    issues: list[dict[str, str]] = []
+    for command in dedupe_preserve(commands):
+        token = command_head_token(command)
+        if token is None:
+            issues.append(
+                {
+                    "command": command,
+                    "detail": "command is empty or does not expose a launch token",
+                }
+            )
+            continue
+        if resolve_command_executable(repo_root, token) is None:
+            issues.append(
+                {
+                    "command": command,
+                    "detail": f"command executable `{token}` is unavailable on PATH or at the referenced path",
+                }
+            )
+    return issues
+
+
+def json_fingerprint(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def push_issue(
+    messages: list[str],
+    details: list[dict[str, Any]],
+    *,
+    code: str,
+    message: str,
+    field: str | None = None,
+    commit_index: int | None = None,
+    path: str | None = None,
+    hunk_id: str | None = None,
+    stop_category: str | None = None,
+    command: str | None = None,
+) -> None:
+    messages.append(message)
+    detail = {"code": code, "message": message}
+    if field is not None:
+        detail["field"] = field
+    if commit_index is not None:
+        detail["commit_index"] = commit_index
+    if path is not None:
+        detail["path"] = path
+    if hunk_id is not None:
+        detail["hunk_id"] = hunk_id
+    if stop_category is not None:
+        detail["stop_category"] = stop_category
+    if command is not None:
+        detail["command"] = command
+    details.append(detail)
+
+
+def required_keys(
+    payload: dict[str, Any],
+    keys: list[str],
+    errors: list[str],
+    error_details: list[dict[str, Any]],
+    prefix: str,
+    *,
+    commit_index: int | None = None,
+) -> None:
+    for key in keys:
+        if key not in payload:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_field"],
+                message=f"{prefix} missing required field `{key}`.",
+                field=key,
+                commit_index=commit_index,
+            )
+
+
+def unknown_fields(
+    payload: dict[str, Any],
+    *,
+    phase: str,
+    scope: str,
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+    commit_index: int | None = None,
+) -> None:
+    rules = PLAN_PHASE_FIELD_TABLES[phase][scope]
+    allowed = set(rules["required"]) | set(rules["allowed"]) | set(rules["ignored"])
+    code = (
+        VALIDATION_WARNING_CODES["unknown_top_level_field"]
+        if scope == "top_level"
+        else VALIDATION_WARNING_CODES["unknown_commit_field"]
+    )
+    for field in sorted(set(payload) - allowed):
+        push_issue(
+            warnings,
+            warning_details,
+            code=code,
+            message=f"Removed unknown {scope.replace('_', ' ')} field `{field}` during normalization.",
+            field=field,
+            commit_index=commit_index,
+        )
+
+
+def normalize_commit(
+    commit: dict[str, Any],
+    expected_index: int,
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+) -> dict[str, Any]:
+    commit_index = safe_int(commit.get("commit_index"), expected_index)
+    unknown_fields(
+        commit,
+        phase="draft_plan",
+        scope="commit",
+        warnings=warnings,
+        warning_details=warning_details,
+        commit_index=commit_index,
+    )
+    normalized = {
+        "commit_index": commit_index,
+        "intent_summary": str(commit.get("intent_summary", "")).strip(),
+        "type": str(commit.get("type", "")).strip(),
+        "scope": str(commit.get("scope", "")).strip(),
+        "subject": str(commit.get("subject", "")).strip(),
+        "body": normalize_body(commit.get("body")),
+        "whole_file_paths": string_list(commit.get("whole_file_paths")),
+        "untracked_paths": string_list(commit.get("untracked_paths")),
+        "split_paths": string_list(commit.get("split_paths")),
+        "selected_hunk_ids": string_list(commit.get("selected_hunk_ids")),
+        "supporting_paths": string_list(commit.get("supporting_paths")),
+        "targeted_checks": string_list(commit.get("targeted_checks")),
+        "confidence": str(commit.get("confidence", "")).strip().lower(),
+    }
+    if isinstance(commit.get("body"), str):
+        push_issue(
+            warnings,
+            warning_details,
+            code=VALIDATION_WARNING_CODES["body_string_normalized"],
+            message=f"Commit {commit_index} normalized string `body` into bullet lines.",
+            field="body",
+            commit_index=commit_index,
+        )
+    return normalized
+
+
+def normalize_plan(
+    plan: dict[str, Any],
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+) -> dict[str, Any]:
+    unknown_fields(
+        plan,
+        phase="draft_plan",
+        scope="top_level",
+        warnings=warnings,
+        warning_details=warning_details,
+    )
+    normalized_commits: list[dict[str, Any]] = []
+    if isinstance(plan.get("commits"), list):
+        for expected_index, commit in enumerate(plan["commits"], start=1):
+            if isinstance(commit, dict):
+                normalized_commits.append(normalize_commit(commit, expected_index, warnings, warning_details))
+    return {
+        "repo_root": str(plan.get("repo_root", "")).strip(),
+        "base_head": str(plan.get("base_head", "")).strip(),
+        "worktree_fingerprint": str(plan.get("worktree_fingerprint", "")).strip(),
+        "input_scope": str(plan.get("input_scope", "")).strip(),
+        "overall_confidence": str(plan.get("overall_confidence", "")).strip().lower(),
+        "validation_commands": command_strings(plan.get("validation_commands")),
+        "omitted_paths": string_list(plan.get("omitted_paths")),
+        "stop_reasons": string_list(plan.get("stop_reasons")),
+        "commits": normalized_commits,
+    }
+
+
+def build_apply_gate_status(current_stop_categories: list[str], can_apply: bool) -> dict[str, Any]:
+    return {
+        "status": "pass" if can_apply else "fail",
+        "applicable_stop_categories": VALIDATOR_COVERED_STOP_CATEGORIES,
+        "covered_stop_categories": VALIDATOR_COVERED_STOP_CATEGORIES,
+        "uncovered_stop_categories": [],
+        "not_applicable_stop_categories": NON_APPLICABLE_STOP_CATEGORIES,
+        "local_hard_stop_categories": LOCAL_HARD_STOP_CATEGORIES,
+        "current_stop_categories": current_stop_categories,
+    }
+
+
+def validate_plan_against_worktree(worktree: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[dict[str, Any]] = []
+    warning_details: list[dict[str, Any]] = []
+
+    required_keys(
+        plan,
+        PLAN_PHASE_FIELD_TABLES["draft_plan"]["top_level"]["required"],
+        errors,
+        error_details,
+        "plan",
+    )
+    commits = plan.get("commits", [])
+    if not isinstance(commits, list) or not commits:
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["empty_commits"],
+            message="plan must contain a non-empty `commits` list.",
+            field="commits",
+        )
+        commits = []
+    for expected_index, commit in enumerate(commits, start=1):
+        if not isinstance(commit, dict):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["commit_not_object"],
+                message=f"plan commit entry {expected_index} is not an object.",
+                commit_index=expected_index,
+            )
+            continue
+        required_keys(
+            commit,
+            PLAN_PHASE_FIELD_TABLES["draft_plan"]["commit"]["required"],
+            errors,
+            error_details,
+            f"commit {expected_index}",
+            commit_index=expected_index,
+        )
+
+    normalized_plan = normalize_plan(plan, warnings, warning_details)
+    normalized_plan_fingerprint = json_fingerprint(normalized_plan)
+    repo_root = Path(str(worktree.get("repo_root", "")))
+    current_worktree = build_worktree_context(repo_root, list(worktree.get("pathspecs", [])))
+    active_operation = str(current_worktree.get("active_operation") or worktree.get("active_operation") or "").strip()
+    if active_operation:
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["active_git_operation"],
+            message=f"Active git operation `{active_operation}` is in progress; stop and resume after it completes.",
+            field="active_operation",
+            stop_category="active_git_operation",
+        )
+    if current_worktree.get("head_commit") != worktree.get("head_commit"):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["head_changed"],
+            message="HEAD changed since worktree collection; regenerate the worktree snapshot.",
+            field="base_head",
+            stop_category="stale_context",
+        )
+    if current_worktree.get("worktree_fingerprint") != worktree.get("worktree_fingerprint"):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["fingerprint_changed"],
+            message="Current worktree fingerprint no longer matches the collected snapshot.",
+            field="worktree_fingerprint",
+            stop_category="stale_context",
+        )
+    if normalize_path_string(normalized_plan.get("repo_root")) != normalize_path_string(worktree.get("repo_root")):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["repo_root_mismatch"],
+            message="plan `repo_root` does not match the collected worktree repo_root.",
+            field="repo_root",
+            stop_category="validator_mismatch",
+        )
+    if str(normalized_plan.get("base_head", "")) != str(worktree.get("head_commit", "")):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["base_head_mismatch"],
+            message="plan `base_head` does not match the collected worktree HEAD.",
+            field="base_head",
+            stop_category="validator_mismatch",
+        )
+    if str(normalized_plan.get("worktree_fingerprint", "")) != str(worktree.get("worktree_fingerprint", "")):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["worktree_fingerprint_mismatch"],
+            message="plan `worktree_fingerprint` does not match the collected worktree fingerprint.",
+            field="worktree_fingerprint",
+            stop_category="validator_mismatch",
+        )
+
+    worktree_files = {str(entry["path"]): entry for entry in worktree.get("files", [])}
+    hunk_to_path: dict[str, str] = {}
+    for path, entry in worktree_files.items():
+        for hunk in entry.get("hunks", []):
+            hunk_id = str(hunk["hunk_id"])
+            if hunk_id in hunk_to_path:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["hunk_assignment_mismatch"],
+                    message=f"Hunk id `{hunk_id}` is duplicated in the collected worktree snapshot.",
+                    path=path,
+                    hunk_id=hunk_id,
+                )
+            hunk_to_path[hunk_id] = path
+
+    omitted_paths = set(normalized_plan.get("omitted_paths", []))
+    path_assignments: dict[str, int] = {}
+    split_hunk_assignments: dict[str, int] = {}
+    split_path_to_commits: dict[str, set[int]] = {}
+    union_targeted_checks: list[str] = []
+    plan_validation_commands = command_strings(normalized_plan.get("validation_commands"))
+    if len(plan_validation_commands) != len(dict.fromkeys(plan_validation_commands)):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["duplicate_validation_command"],
+            message="plan `validation_commands` contains duplicates.",
+            field="validation_commands",
+        )
+
+    for expected_index, commit in enumerate(normalized_plan.get("commits", []), start=1):
+        commit_index = int(commit.get("commit_index", expected_index))
+        if commit_index != expected_index:
+            push_issue(
+                warnings,
+                warning_details,
+                code=VALIDATION_WARNING_CODES["commit_index_non_sequential"],
+                message=f"Commit indexes are not sequential at position {expected_index}.",
+                field="commit_index",
+                commit_index=commit_index,
+            )
+        whole_file_paths = string_list(commit.get("whole_file_paths"))
+        untracked_paths = string_list(commit.get("untracked_paths"))
+        split_paths = string_list(commit.get("split_paths"))
+        selected_hunk_ids = string_list(commit.get("selected_hunk_ids"))
+        supporting_paths = string_list(commit.get("supporting_paths"))
+        targeted_checks = string_list(commit.get("targeted_checks"))
+        body_lines = normalize_body(commit.get("body"))
+
+        for command in targeted_checks:
+            if command not in union_targeted_checks:
+                union_targeted_checks.append(command)
+            if command not in plan_validation_commands:
+                push_issue(
+                    warnings,
+                    warning_details,
+                    code=VALIDATION_WARNING_CODES["targeted_check_missing_from_plan"],
+                    message=f"Commit {commit_index} targeted check is missing from plan `validation_commands`: {command}",
+                    field="targeted_checks",
+                    commit_index=commit_index,
+                )
+
+        for path in whole_file_paths + supporting_paths:
+            if path in omitted_paths:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+                    message=f"Path `{path}` is both omitted and committed as whole-file.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+            if path not in worktree_files:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["unknown_path"],
+                    message=f"Commit {commit_index} references unknown path `{path}`.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+                continue
+            path_assignments[path] = path_assignments.get(path, 0) + 1
+            entry = worktree_files[path]
+            if entry.get("change_kind") == "untracked":
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["invalid_untracked_path"],
+                    message=f"Commit {commit_index} puts untracked path `{path}` in `whole_file_paths`; use `untracked_paths`.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+            if path in split_paths:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["invalid_split_path"],
+                    message=f"Commit {commit_index} references `{path}` as both whole-file and split.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+
+        for path in untracked_paths:
+            if path in omitted_paths:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+                    message=f"Path `{path}` is both omitted and committed as untracked.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+            if path not in worktree_files:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["unknown_path"],
+                    message=f"Commit {commit_index} references unknown untracked path `{path}`.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+                continue
+            path_assignments[path] = path_assignments.get(path, 0) + 1
+            entry = worktree_files[path]
+            if entry.get("change_kind") != "untracked":
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["invalid_untracked_path"],
+                    message=f"Commit {commit_index} lists tracked path `{path}` in `untracked_paths`.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+            if path in split_paths:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["invalid_split_path"],
+                    message=f"Commit {commit_index} references `{path}` as both untracked and split.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+
+        split_hunks_by_path: dict[str, list[str]] = {}
+        for hunk_id in selected_hunk_ids:
+            path = hunk_to_path.get(hunk_id)
+            if path is None:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["unknown_hunk"],
+                    message=f"Commit {commit_index} references unknown hunk id `{hunk_id}`.",
+                    commit_index=commit_index,
+                    hunk_id=hunk_id,
+                )
+                continue
+            split_hunk_assignments[hunk_id] = split_hunk_assignments.get(hunk_id, 0) + 1
+            split_hunks_by_path.setdefault(path, []).append(hunk_id)
+
+        for path in split_paths:
+            if path in omitted_paths:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+                    message=f"Path `{path}` is both omitted and committed as split.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+            if path not in worktree_files:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["unknown_path"],
+                    message=f"Commit {commit_index} references unknown split path `{path}`.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+                continue
+            entry = worktree_files[path]
+            split_path_to_commits.setdefault(path, set()).add(commit_index)
+            if not entry.get("split_eligible"):
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["partial_split_unsupported"],
+                    message=f"Commit {commit_index} uses non-split-eligible path `{path}` in `split_paths`; partial splits are unsupported for this file.",
+                    path=path,
+                    commit_index=commit_index,
+                    stop_category="partial_split_unsupported",
+                )
+            if entry.get("binary"):
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["partial_split_unsupported"],
+                    message=f"Commit {commit_index} uses binary path `{path}` in `split_paths`; partial splits are unsupported for binary files.",
+                    path=path,
+                    commit_index=commit_index,
+                    stop_category="partial_split_unsupported",
+                )
+            if entry.get("change_kind") != "modified":
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["partial_split_unsupported"],
+                    message=f"Commit {commit_index} uses `{path}` in `split_paths`, but only tracked modified text files may be partially split.",
+                    path=path,
+                    commit_index=commit_index,
+                    stop_category="partial_split_unsupported",
+                )
+            if path_assignments.get(path, 0):
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+                    message=f"Commit {commit_index} mixes split and whole-file handling for `{path}`.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+            if path not in split_hunks_by_path:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["hunk_assignment_mismatch"],
+                    message=f"Commit {commit_index} lists split path `{path}` but assigns no hunks from it.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+
+        if not whole_file_paths and not supporting_paths and not untracked_paths and not split_paths:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+                message=f"Commit {commit_index} does not cover any paths.",
+                commit_index=commit_index,
+            )
+        if not str(commit.get("subject", "")).strip():
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_field"],
+                message=f"Commit {commit_index} is missing `subject`.",
+                field="subject",
+                commit_index=commit_index,
+            )
+        if not str(commit.get("type", "")).strip():
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_field"],
+                message=f"Commit {commit_index} is missing `type`.",
+                field="type",
+                commit_index=commit_index,
+            )
+        if not str(commit.get("scope", "")).strip():
+            push_issue(
+                warnings,
+                warning_details,
+                code=VALIDATION_WARNING_CODES["empty_scope"],
+                message=f"Commit {commit_index} has an empty `scope`.",
+                field="scope",
+                commit_index=commit_index,
+            )
+        if body_lines and not all(line.lstrip().startswith("- ") for line in body_lines):
+            push_issue(
+                warnings,
+                warning_details,
+                code=VALIDATION_WARNING_CODES["non_bullet_body"],
+                message=f"Commit {commit_index} body contains non-bullet lines.",
+                field="body",
+                commit_index=commit_index,
+            )
+
+    changed_paths = set(worktree_files)
+    covered_paths = set(path_assignments) | set(split_path_to_commits) | omitted_paths
+    for path in sorted(changed_paths - covered_paths):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+            message=f"Changed path `{path}` is neither committed nor omitted.",
+            path=path,
+        )
+    for path in sorted(covered_paths - changed_paths):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["unknown_path"],
+            message=f"Plan references path `{path}` that is not in the collected worktree.",
+            path=path,
+        )
+
+    for path, count in sorted(path_assignments.items()):
+        if count != 1:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+                message=f"Path `{path}` is assigned {count} times; expected exactly once.",
+                path=path,
+            )
+
+    for hunk_id, count in sorted(split_hunk_assignments.items()):
+        if count != 1:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["hunk_assignment_mismatch"],
+                message=f"Hunk `{hunk_id}` is assigned {count} times; expected exactly once.",
+                hunk_id=hunk_id,
+            )
+
+    for path, _commit_ids in sorted(split_path_to_commits.items()):
+        entry = worktree_files[path]
+        hunks = list(entry.get("hunks", []))
+        all_hunk_ids = {str(hunk["hunk_id"]) for hunk in hunks}
+        assigned_hunk_ids = {
+            hunk_id
+            for hunk_id, owning_path in hunk_to_path.items()
+            if owning_path == path and split_hunk_assignments.get(hunk_id)
+        }
+        if assigned_hunk_ids != all_hunk_ids:
+            missing = sorted(all_hunk_ids - assigned_hunk_ids)
+            extra = sorted(assigned_hunk_ids - all_hunk_ids)
+            if missing:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["hunk_assignment_mismatch"],
+                    message=f"Split path `{path}` has unassigned hunks: {', '.join(missing)}",
+                    path=path,
+                )
+            if extra:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["hunk_assignment_mismatch"],
+                    message=f"Split path `{path}` has unexpected assigned hunks: {', '.join(extra)}",
+                    path=path,
+                )
+
+        digest_pairs = [(str(hunk["removed_digest"]), str(hunk["added_digest"])) for hunk in hunks]
+        if len(digest_pairs) != len(set(digest_pairs)):
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["ambiguous_split_rematch"],
+                message=f"Split path `{path}` has duplicate digest pairs; current-diff rematch would be ambiguous.",
+                path=path,
+                stop_category="ambiguous_split_rematch",
+            )
+
+        ordered_hunks = sorted(hunks, key=lambda item: (int(item["old_start"]), int(item["new_start"])))
+        hunk_commit_lookup = {}
+        for commit in normalized_plan.get("commits", []):
+            commit_index = int(commit.get("commit_index", 0))
+            for hunk_id in string_list(commit.get("selected_hunk_ids")):
+                if hunk_to_path.get(hunk_id) == path:
+                    hunk_commit_lookup[hunk_id] = commit_index
+        for left, right in zip(ordered_hunks, ordered_hunks[1:]):
+            left_commit = hunk_commit_lookup.get(str(left["hunk_id"]))
+            right_commit = hunk_commit_lookup.get(str(right["hunk_id"]))
+            if left_commit is None or right_commit is None or left_commit == right_commit:
+                continue
+            left_old_end = int(left["old_start"]) + max(int(left["old_count"]), 1) - 1
+            right_old_gap = int(right["old_start"]) - left_old_end - 1
+            left_new_end = int(left["new_start"]) + max(int(left["new_count"]), 1) - 1
+            right_new_gap = int(right["new_start"]) - left_new_end - 1
+            if right_old_gap <= 0 or right_new_gap <= 0:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["adjacent_split_hunks"],
+                    message=(
+                        f"Split path `{path}` assigns adjacent or overlapping hunks to different commits "
+                        f"({left['hunk_id']} -> commit {left_commit}, {right['hunk_id']} -> commit {right_commit})."
+                    ),
+                    path=path,
+                    stop_category="partial_split_unsupported",
+                )
+
+    for path in sorted(omitted_paths):
+        if path not in worktree_files:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["unknown_path"],
+                message=f"Omitted path `{path}` is not present in the collected worktree.",
+                path=path,
+            )
+
+    deduped_validation_commands = dedupe_preserve(plan_validation_commands or union_targeted_checks)
+    feasibility_commands = dedupe_preserve(plan_validation_commands + union_targeted_checks)
+    for issue in command_feasibility_issues(repo_root, feasibility_commands):
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["targeted_check_unavailable"],
+            message=f"Targeted check `{issue['command']}` is not feasible locally: {issue['detail']}.",
+            field="validation_commands",
+            command=issue["command"],
+            stop_category="targeted_check_unavailable",
+        )
+
+    confidence = str(normalized_plan.get("overall_confidence", "")).strip().lower()
+    current_stop_categories = dedupe_preserve(
+        [
+            str(detail.get("stop_category"))
+            for detail in error_details
+            if str(detail.get("stop_category", "")).strip()
+        ]
+    )
+    stop_reasons = list(errors)
+    if normalized_plan.get("stop_reasons"):
+        current_stop_categories = dedupe_preserve([*current_stop_categories, "unresolved_stop_reason"])
+        for reason in string_list(normalized_plan.get("stop_reasons")):
+            if reason not in stop_reasons:
+                stop_reasons.append(reason)
+    if confidence != "high":
+        current_stop_categories = dedupe_preserve([*current_stop_categories, "low_confidence"])
+        low_confidence_reason = (
+            "overall_confidence must be `high` before apply may proceed."
+        )
+        if low_confidence_reason not in stop_reasons:
+            stop_reasons.append(low_confidence_reason)
+
+    can_apply = (
+        not errors
+        and confidence == "high"
+        and not normalized_plan.get("stop_reasons")
+    )
+    apply_gate_status = build_apply_gate_status(current_stop_categories, can_apply)
+    return {
+        "valid": not errors,
+        "can_apply": can_apply,
+        "errors": errors,
+        "warnings": warnings,
+        "error_details": error_details,
+        "warning_details": warning_details,
+        "stop_reasons": stop_reasons,
+        "stop_categories": current_stop_categories,
+        "deduped_validation_commands": deduped_validation_commands,
+        "path_count": len(worktree_files),
+        "commit_count": len([commit for commit in normalized_plan.get("commits", []) if isinstance(commit, dict)]),
+        "current_worktree_fingerprint": current_worktree.get("worktree_fingerprint"),
+        "expected_worktree_fingerprint": worktree.get("worktree_fingerprint"),
+        "normalized_plan": normalized_plan,
+        "normalized_plan_fingerprint": normalized_plan_fingerprint,
+        "validated_head_commit": current_worktree.get("head_commit"),
+        "apply_gate_status": apply_gate_status,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate a commit plan against a worktree snapshot.")
+    parser.add_argument("--worktree", type=Path, required=True, help="Path to worktree JSON from collect_worktree_context.py")
+    parser.add_argument("--plan", type=Path, required=True, help="Path to drafted commit-plan JSON")
+    parser.add_argument("--output", type=Path, help="Optional path to write validation JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        worktree = load_json(args.worktree)
+        plan = load_json(args.plan)
+        payload = validate_plan_against_worktree(worktree, plan)
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(f"validate_commit_plan.py: {exc}", file=sys.stderr)
+        return 1
+
+    serialized = json.dumps(payload, indent=2, ensure_ascii=True) + "\n"
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+        print(f"Wrote validation result to {args.output}")
+    else:
+        sys.stdout.write(serialized)
+    return 0 if payload.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/validate_commit_plan.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/validate_commit_plan.py
@@ -708,7 +708,7 @@ def validate_plan_against_worktree(worktree: dict[str, Any], plan: dict[str, Any
                     commit_index=commit_index,
                 )
 
-        for path in whole_file_paths + supporting_paths:
+        for path in whole_file_paths:
             if path in omitted_paths:
                 push_issue(
                     errors,
@@ -745,6 +745,19 @@ def validate_plan_against_worktree(worktree: dict[str, Any], plan: dict[str, Any
                     error_details,
                     code=VALIDATION_ERROR_CODES["invalid_split_path"],
                     message=f"Commit {commit_index} references `{path}` as both whole-file and split.",
+                    path=path,
+                    commit_index=commit_index,
+                )
+
+        # Supporting paths are evidence-only references. Validate that they resolve to
+        # known changed paths, but do not count them toward path ownership.
+        for path in supporting_paths:
+            if path not in worktree_files:
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["unknown_path"],
+                    message=f"Commit {commit_index} references unknown supporting path `{path}`.",
                     path=path,
                     commit_index=commit_index,
                 )
@@ -877,12 +890,12 @@ def validate_plan_against_worktree(worktree: dict[str, Any], plan: dict[str, Any
                     commit_index=commit_index,
                 )
 
-        if not whole_file_paths and not supporting_paths and not untracked_paths and not split_paths:
+        if not whole_file_paths and not untracked_paths and not split_paths:
             push_issue(
                 errors,
                 error_details,
                 code=VALIDATION_ERROR_CODES["path_assignment_mismatch"],
-                message=f"Commit {commit_index} does not cover any paths.",
+                message=f"Commit {commit_index} does not cover any owned paths.",
                 commit_index=commit_index,
             )
         if not str(commit.get("subject", "")).strip():

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/write_evaluation_log.py
@@ -1,0 +1,1073 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    raw = orchestrator.get("packet_files")
+    if not isinstance(raw, list):
+        raw = orchestrator.get("packet_order")
+    return [str(item) for item in raw or [] if str(item).strip()]
+
+
+def is_batch_packet(name: str) -> bool:
+    lowered = name.lower()
+    return "batch-packet" in lowered or lowered.startswith("batch-") or lowered.startswith("candidate-batch-")
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or is_batch_packet(lowered):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if is_batch_packet(name)
+    )
+
+
+def packet_count_hint(orchestrator: dict[str, Any]) -> int | None:
+    for key in ("candidate_batch_count", "commit_packet_count"):
+        detected = safe_int(orchestrator.get(key))
+        if detected is not None:
+            return detected
+    return None
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    for key in ("active_packet_count", "active_areas"):
+        detected = safe_int(counts.get(key))
+        if detected is not None:
+            return detected
+    detected = safe_int(orchestrator.get("active_packet_count"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commit_packet_count": safe_int(orchestrator.get("commit_packet_count")) or (len(commits) if isinstance(commits, list) else 0),
+            "decision_ready_packets": to_bool(orchestrator.get("decision_ready_packets")),
+            "worker_return_contract": orchestrator.get("worker_return_contract"),
+            "worker_output_shape": orchestrator.get("worker_output_shape"),
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": safe_int(orchestrator.get("candidate_batch_count")) or 0,
+            "commit_buckets_applied": None,
+            "split_file_count": safe_int(orchestrator.get("split_file_count")) or sum(
+                1 for name in packet_files(orchestrator) if "split-file" in name.lower()
+            ),
+            "decision_ready_packets": to_bool(orchestrator.get("decision_ready_packets")),
+            "worker_return_contract": orchestrator.get("worker_return_contract"),
+            "worker_output_shape": orchestrator.get("worker_output_shape"),
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+            "stop_categories": [],
+            "rollback_status": None,
+            "common_path_sufficient": to_bool(orchestrator.get("common_path_sufficient")),
+            "raw_reread_count": len(list_of_strings(orchestrator.get("raw_reread_reasons"))),
+            "raw_reread_reasons": list_of_strings(orchestrator.get("raw_reread_reasons")),
+            "packet_count": None,
+            "estimated_packet_tokens": None,
+            "estimated_delegation_savings": None,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": packet_count_hint(orchestrator) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        if isinstance(result.get("recommended_workers"), list):
+            orchestration["worker_roles"] = worker_roles({"recommended_workers": result.get("recommended_workers")})
+        override_signals = result.get("applied_override_signals")
+        if isinstance(override_signals, list):
+            orchestration["override_signals"] = list_of_strings(override_signals)
+        active_packet_count = safe_int(result.get("active_packet_count"))
+        if active_packet_count is not None:
+            log.setdefault("input_size", {})["active_areas"] = active_packet_count
+        candidate_batch_count = safe_int(result.get("candidate_batch_count"))
+        if candidate_batch_count is not None:
+            log.setdefault("input_size", {})["candidate_batches"] = candidate_batch_count
+            log.setdefault("skill_specific", {}).setdefault("data", {})["commit_buckets_planned"] = candidate_batch_count
+        split_file_count = safe_int(result.get("split_file_count"))
+        if split_file_count is not None:
+            log.setdefault("input_size", {})["split_file_packets"] = split_file_count
+            log.setdefault("skill_specific", {}).setdefault("data", {})["split_file_count"] = split_file_count
+            log.setdefault("skill_specific", {}).setdefault("data", {})["hunk_splits_attempted"] = split_file_count
+        common_path_sufficient = to_bool(result.get("common_path_sufficient"))
+        if common_path_sufficient is not None:
+            log.setdefault("skill_specific", {}).setdefault("data", {})["common_path_sufficient"] = common_path_sufficient
+        raw_reread_reasons = list_of_strings(result.get("raw_reread_reasons"))
+        if raw_reread_reasons:
+            orchestration["raw_reread_required"] = True
+            orchestration["raw_reread_reason"] = raw_reread_reasons[0]
+        log.setdefault("skill_specific", {}).setdefault("data", {})["raw_reread_count"] = safe_int(result.get("raw_reread_count")) or len(raw_reread_reasons)
+        log.setdefault("skill_specific", {}).setdefault("data", {})["raw_reread_reasons"] = raw_reread_reasons
+        packet_metrics = result.get("packet_metrics")
+        if isinstance(packet_metrics, dict):
+            skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+            skill_specific["packet_count"] = safe_int(packet_metrics.get("packet_count"))
+            skill_specific["estimated_packet_tokens"] = safe_int(packet_metrics.get("estimated_packet_tokens"))
+            skill_specific["estimated_delegation_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            baseline = log.setdefault("baseline", {})
+            baseline["estimated_local_only_tokens"] = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+            baseline["estimated_token_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            baseline["estimated_delegation_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            log.setdefault("measurement", {})["efficiency_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        stop_categories = result.get("stop_categories") or []
+        if isinstance(stop_categories, list) and stop_categories:
+            existing_categories = list(skill_specific.get("stop_categories") or [])
+            for category in stop_categories:
+                if isinstance(category, str) and category not in existing_categories:
+                    existing_categories.append(category)
+            skill_specific["stop_categories"] = existing_categories
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+        apply_status = result.get("apply_status") or {}
+        if isinstance(apply_status, dict):
+            rollback_status = apply_status.get("rollback_status")
+            if rollback_status:
+                skill_specific["rollback_status"] = rollback_status
+            stop_category = apply_status.get("stop_category")
+            if isinstance(stop_category, str) and stop_category.strip():
+                existing_categories = list(skill_specific.get("stop_categories") or [])
+                if stop_category not in existing_categories:
+                    existing_categories.append(stop_category)
+                skill_specific["stop_categories"] = existing_categories
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_apply_commit_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_apply_commit_plan_contract.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from subprocess import CompletedProcess
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import apply_commit_plan as apply_commit  # noqa: E402
+import validate_commit_plan as validator  # noqa: E402
+
+
+def sample_worktree() -> dict[str, object]:
+    return {
+        "repo_root": "C:/repo",
+        "pathspecs": [],
+        "head_commit": "abc123",
+        "worktree_fingerprint": "sha256:worktree",
+        "files": [],
+    }
+
+
+def sample_validation_payload() -> dict[str, object]:
+    normalized_plan = {
+        "repo_root": "C:/repo",
+        "base_head": "abc123",
+        "worktree_fingerprint": "sha256:worktree",
+        "input_scope": "all-local-changes",
+        "overall_confidence": "high",
+        "validation_commands": ["python -m unittest"],
+        "omitted_paths": [],
+        "stop_reasons": [],
+        "commits": [
+            {
+                "commit_index": 1,
+                "intent_summary": "Update app behavior.",
+                "type": "fix",
+                "scope": "core",
+                "subject": "normalized subject",
+                "body": ["- keep normalized output"],
+                "whole_file_paths": ["src/app.py"],
+                "untracked_paths": [],
+                "split_paths": [],
+                "selected_hunk_ids": [],
+                "supporting_paths": [],
+                "targeted_checks": ["python -m unittest"],
+                "confidence": "high",
+            }
+        ],
+    }
+    return {
+        "valid": True,
+        "can_apply": True,
+        "normalized_plan": normalized_plan,
+        "normalized_plan_fingerprint": validator.json_fingerprint(normalized_plan),
+        "apply_gate_status": {
+            "status": "pass",
+            "applicable_stop_categories": ["stale_context", "validator_mismatch", "unresolved_stop_reason"],
+            "covered_stop_categories": ["stale_context", "validator_mismatch", "unresolved_stop_reason"],
+            "uncovered_stop_categories": [],
+            "not_applicable_stop_categories": ["missing_auth", "missing_required_evidence"],
+        },
+    }
+
+
+def sample_multi_commit_validation_payload() -> dict[str, object]:
+    payload = sample_validation_payload()
+    payload["normalized_plan"] = {
+        **payload["normalized_plan"],
+        "commits": [
+            payload["normalized_plan"]["commits"][0],
+            {
+                "commit_index": 2,
+                "intent_summary": "Follow-up change.",
+                "type": "fix",
+                "scope": "core",
+                "subject": "second normalized subject",
+                "body": ["- follow up"],
+                "whole_file_paths": ["src/other.py"],
+                "untracked_paths": [],
+                "split_paths": [],
+                "selected_hunk_ids": [],
+                "supporting_paths": [],
+                "targeted_checks": ["python -m unittest"],
+                "confidence": "high",
+            },
+        ],
+    }
+    payload["normalized_plan_fingerprint"] = validator.json_fingerprint(payload["normalized_plan"])
+    return payload
+
+
+class ApplyCommitPlanContractTests(unittest.TestCase):
+    def test_dry_run_consumes_validator_normalized_plan_only(self) -> None:
+        worktree = sample_worktree()
+        validation_payload = sample_validation_payload()
+
+        def fake_validate(worktree_arg: dict[str, object], plan_arg: dict[str, object]) -> dict[str, object]:
+            self.assertEqual(plan_arg["commits"][0]["subject"], "normalized subject")
+            return {
+                "valid": True,
+                "can_apply": True,
+                "deduped_validation_commands": ["python -m unittest"],
+                "normalized_plan_fingerprint": validation_payload["normalized_plan_fingerprint"],
+            }
+
+        with (
+            patch.object(apply_commit, "validate_plan_against_worktree", side_effect=fake_validate),
+            patch.object(apply_commit, "detect_operation", return_value=None),
+            patch.object(
+                apply_commit,
+                "run_git",
+                return_value=CompletedProcess(["git", "rev-parse", "HEAD"], 0, stdout="abc123\n", stderr=""),
+            ),
+        ):
+            payload = apply_commit.apply_validated_plan(worktree, validation_payload, dry_run=True)
+
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["validation_source"], "validator_normalized_plan")
+        self.assertEqual(payload["commits"][0]["subject"], "fix(core): normalized subject")
+        self.assertEqual(payload["apply_status"]["status"], "dry_run")
+        self.assertIsNone(payload["apply_status"]["stop_category"])
+
+    def test_apply_rejects_mismatched_normalized_plan_fingerprint(self) -> None:
+        worktree = sample_worktree()
+        validation_payload = sample_validation_payload()
+        validation_payload["normalized_plan_fingerprint"] = "sha256:not-the-same"
+
+        with self.assertRaisesRegex(RuntimeError, "normalized-plan fingerprint"):
+            apply_commit.apply_validated_plan(worktree, validation_payload, dry_run=True)
+
+    def test_apply_rejects_active_git_operation_with_explicit_category(self) -> None:
+        worktree = sample_worktree()
+        validation_payload = sample_validation_payload()
+
+        with (
+            patch.object(apply_commit, "validate_plan_against_worktree", return_value={
+                "valid": True,
+                "can_apply": True,
+                "deduped_validation_commands": [],
+                "normalized_plan_fingerprint": validation_payload["normalized_plan_fingerprint"],
+            }),
+            patch.object(apply_commit, "detect_operation", return_value="rebase"),
+        ):
+            with self.assertRaises(apply_commit.ApplyHardStop) as caught:
+                apply_commit.apply_validated_plan(worktree, validation_payload, dry_run=True)
+
+        self.assertEqual(caught.exception.category, "active_git_operation")
+        self.assertEqual(caught.exception.payload["apply_status"]["stop_category"], "active_git_operation")
+
+    def test_run_targeted_checks_rejects_unavailable_command_before_execution(self) -> None:
+        with patch.object(apply_commit, "command_feasibility_issues", return_value=[{
+            "command": "missing-tool --version",
+            "detail": "command executable `missing-tool` is unavailable on PATH",
+        }]):
+            with self.assertRaises(apply_commit.ApplyHardStop) as caught:
+                apply_commit.run_targeted_checks(Path("C:/repo"), ["missing-tool --version"])
+
+        self.assertEqual(caught.exception.category, "targeted_check_unavailable")
+
+    def test_current_hunk_match_raises_ambiguous_split_rematch(self) -> None:
+        original_hunk = {"hunk_id": "H1", "removed_digest": "same-old", "added_digest": "same-new"}
+        current_hunks = [
+            {"hunk_id": "A", "removed_digest": "same-old", "added_digest": "same-new"},
+            {"hunk_id": "B", "removed_digest": "same-old", "added_digest": "same-new"},
+        ]
+
+        with self.assertRaises(apply_commit.ApplyHardStop) as caught:
+            apply_commit.current_hunk_match("src/app.py", original_hunk, current_hunks)
+
+        self.assertEqual(caught.exception.category, "ambiguous_split_rematch")
+
+    def test_apply_rolls_back_created_commits_when_later_step_fails(self) -> None:
+        worktree = sample_worktree()
+        validation_payload = sample_multi_commit_validation_payload()
+
+        def fake_validate(worktree_arg: dict[str, object], plan_arg: dict[str, object]) -> dict[str, object]:
+            self.assertEqual(len(plan_arg["commits"]), 2)
+            return {
+                "valid": True,
+                "can_apply": True,
+                "deduped_validation_commands": ["python -m unittest"],
+                "normalized_plan_fingerprint": validation_payload["normalized_plan_fingerprint"],
+            }
+
+        def fake_run_git(repo: Path, args: list[str], **_: object) -> CompletedProcess[str]:
+            if args == ["rev-parse", "HEAD"]:
+                return CompletedProcess(["git", *args], 0, stdout="abc123\n", stderr="")
+            if args == ["diff", "--cached", "--name-only"]:
+                return CompletedProcess(["git", *args], 0, stdout="src/app.py\n", stderr="")
+            if args[:2] == ["commit", "--no-gpg-sign"]:
+                return CompletedProcess(["git", *args], 0, stdout="", stderr="")
+            if args[:2] == ["reset", "--mixed"]:
+                return CompletedProcess(["git", *args], 0, stdout="", stderr="")
+            return CompletedProcess(["git", *args], 0, stdout="", stderr="")
+
+        with (
+            patch.object(apply_commit, "validate_plan_against_worktree", side_effect=fake_validate),
+            patch.object(apply_commit, "detect_operation", return_value=None),
+            patch.object(apply_commit, "run_targeted_checks", return_value=None),
+            patch.object(apply_commit, "reset_index", return_value=None),
+            patch.object(apply_commit, "build_hunk_lookup", return_value={}),
+            patch.object(apply_commit, "created_commit_hash", return_value="commit-1"),
+            patch.object(apply_commit, "run_git", side_effect=fake_run_git),
+            patch.object(apply_commit, "stage_commit", side_effect=[None, RuntimeError("second commit failed")]),
+            patch.object(apply_commit, "rollback_created_commits") as mocked_rollback,
+        ):
+            with self.assertRaisesRegex(apply_commit.ApplyHardStop, "second commit failed"):
+                apply_commit.apply_validated_plan(worktree, validation_payload, dry_run=False)
+
+        mocked_rollback.assert_called_once_with(Path("C:/repo"), "abc123")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_apply_commit_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_apply_commit_plan_contract.py
@@ -215,6 +215,26 @@ class ApplyCommitPlanContractTests(unittest.TestCase):
 
         mocked_rollback.assert_called_once_with(Path("C:/repo"), "abc123")
 
+    def test_stage_commit_does_not_stage_supporting_paths(self) -> None:
+        commit = {
+            "whole_file_paths": ["src/app.py"],
+            "untracked_paths": ["src/new_file.py"],
+            "supporting_paths": ["docs/context.md"],
+            "selected_hunk_ids": [],
+            "split_paths": [],
+        }
+
+        with patch.object(apply_commit, "run_git") as mocked_run_git:
+            apply_commit.stage_commit(Path("C:/repo"), commit, {})
+
+        self.assertEqual(
+            [call.args[1] for call in mocked_run_git.call_args_list],
+            [
+                ["add", "--all", "--", "src/app.py"],
+                ["add", "--all", "--", "src/new_file.py"],
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_build_commit_packets_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_build_commit_packets_contract.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_commit_packets  # type: ignore  # noqa: E402
+
+
+class BuildCommitPacketsContractTest(unittest.TestCase):
+    def run_script(self, rules: dict, worktree: dict) -> tuple[int, Path, dict, dict]:
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        tmp_path = Path(tmpdir.name)
+        rules_path = tmp_path / "rules.json"
+        worktree_path = tmp_path / "worktree.json"
+        output_dir = tmp_path / "packets"
+        result_path = tmp_path / "build-result.json"
+        rules_path.write_text(json.dumps(rules), encoding="utf-8")
+        worktree_path.write_text(json.dumps(worktree), encoding="utf-8")
+
+        stdout = io.StringIO()
+        argv = [
+            "build_commit_packets.py",
+            "--rules",
+            str(rules_path),
+            "--worktree",
+            str(worktree_path),
+            "--output-dir",
+            str(output_dir),
+            "--result-output",
+            str(result_path),
+        ]
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(stdout):
+            exit_code = build_commit_packets.main()
+
+        orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        return exit_code, output_dir, orchestrator, result
+
+    def test_split_file_packet_escalates_review_mode_and_routes_workers(self) -> None:
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix", "chore", "docs"],
+                "scope_required": True,
+                "subject_length_limit": 72,
+                "scope_suggestions": ["infra"],
+            },
+            "recent_scope_vocabulary": ["infra"],
+            "instruction_snippets": {},
+        }
+        worktree = {
+            "repo_root": "C:/tmp/repo",
+            "head_commit": "abc123",
+            "branch": "main",
+            "worktree_fingerprint": "sha256:deadbeef",
+            "active_operation": None,
+            "input_scope": "all-local-changes",
+            "diff_shortstat": "1 file changed, 12 insertions(+), 12 deletions(-)",
+            "changed_file_groups": {},
+            "diff_stat": [],
+            "validation_candidates": [
+                {
+                    "label": "unit-tests",
+                    "paths": ["src/app.py"],
+                    "command": "python -m unittest",
+                }
+            ],
+            "files": [
+                {
+                    "path": "src/app.py",
+                    "area": "runtime",
+                    "generated": False,
+                    "split_eligible": True,
+                    "change_kind": "modified",
+                    "path_tokens": ["app", "runtime"],
+                    "hunks": [
+                        {
+                            "hunk_id": "H1",
+                            "header": "@@ -1,2 +1,2 @@",
+                            "old_start": 1,
+                            "new_start": 1,
+                            "tokens": ["alpha", "beta"],
+                            "raw_body_lines": ["-old_alpha()", "+new_alpha()"],
+                            "raw_patch": "@@ -1,2 +1,2 @@\n-old_alpha()\n+new_alpha()\n",
+                            "removed_digest": "same-digest",
+                            "added_digest": "same-digest",
+                        },
+                        {
+                            "hunk_id": "H2",
+                            "header": "@@ -40,2 +40,2 @@",
+                            "old_start": 40,
+                            "new_start": 40,
+                            "tokens": ["gamma", "delta"],
+                            "raw_body_lines": ["-old_gamma()", "+new_gamma()"],
+                            "raw_patch": "@@ -40,2 +40,2 @@\n-old_gamma()\n+new_gamma()\n",
+                            "removed_digest": "same-digest",
+                            "added_digest": "same-digest",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        exit_code, output_dir, orchestrator, result = self.run_script(rules, worktree)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(orchestrator["review_mode"], "targeted-delegation")
+        self.assertEqual(orchestrator["orchestrator_profile"], "standard")
+        self.assertTrue(orchestrator["decision_ready_packets"])
+        self.assertEqual(orchestrator["worker_return_contract"], "classification-oriented")
+        self.assertEqual(orchestrator["worker_output_shape"], "hierarchical")
+        self.assertEqual(
+            orchestrator["task_packet_names"],
+            ["rules_packet", "worktree_packet", "candidate-batch-01", "split-file-01"],
+        )
+        self.assertEqual(
+            orchestrator["packet_worker_map"],
+            {
+                "rules_packet": ["docs_verifier"],
+                "worktree_packet": ["repo_mapper"],
+                "candidate-batch-01": ["evidence_summarizer"],
+                "split-file-01": ["large_diff_auditor"],
+            },
+        )
+        self.assertEqual(
+            orchestrator["packet_order"],
+            ["global_packet.json", "rules_packet.json", "worktree_packet.json", "candidate-batch-01.json", "split-file-01.json"],
+        )
+        self.assertEqual(orchestrator["candidate_batch_map"], {"candidate-batch-01": ["src/app.py"]})
+        self.assertEqual(orchestrator["split_candidate_paths"], ["src/app.py"])
+        self.assertEqual(
+            orchestrator["common_path_contract"]["shared_packets"],
+            ["rules_packet.json", "worktree_packet.json"],
+        )
+        self.assertNotIn("packet_metrics", orchestrator)
+
+        global_packet = json.loads((output_dir / "global_packet.json").read_text(encoding="utf-8"))
+        self.assertTrue(global_packet["decision_ready_packets"])
+        self.assertEqual(global_packet["packet_worker_map"], orchestrator["packet_worker_map"])
+        self.assertEqual(global_packet["task_packet_names"], orchestrator["task_packet_names"])
+        self.assertEqual(global_packet["worker_footer_fields"], ["packet_ids", "candidate_ids", "primary_outcome", "overall_confidence", "coverage_gaps", "overall_risk"])
+        self.assertEqual([bundle["name"] for bundle in global_packet["candidate_field_bundles"]], ["candidate"])
+        self.assertEqual(
+            global_packet["candidate_field_bundles"][0]["fields"],
+            [
+                "fact_summary",
+                "proposal_classification",
+                "classification_rationale",
+                "supporting_references",
+                "ambiguity",
+                "confidence",
+                "reread_control",
+            ],
+        )
+        self.assertEqual(global_packet["domain_overlay"]["proposal_enum_values"], ["commit_bucket", "split_file", "reference_only", "ignore"])
+        self.assertEqual(
+            global_packet["domain_overlay"]["candidate_field_aliases"],
+            {
+                "fact_summary": "intent_summary",
+                "proposal_classification": "recommended_type",
+                "supporting_references": "supporting_paths",
+                "ambiguity": "open_ambiguity",
+                "reread_control": "raw_reread_reason",
+            },
+        )
+        self.assertEqual(
+            global_packet["domain_overlay"]["alias_notes"],
+            {"supporting_paths": "Current domain aliases assume file/path-oriented evidence first."},
+        )
+        self.assertEqual(global_packet["common_path_contract"]["goal"], "Draft commit-plan.json without raw diff rereads on the common path.")
+
+        split_packet = json.loads((output_dir / "split-file-01.json").read_text(encoding="utf-8"))
+        self.assertEqual(split_packet["file"]["path"], "src/app.py")
+        self.assertTrue(split_packet["file"]["reason"]["duplicate_digest_pairs"])
+        self.assertEqual(len(split_packet["file"]["hunks"]), 2)
+        self.assertEqual(split_packet["file"]["hunks"][0]["hunk_id"], "H1")
+        self.assertEqual(split_packet["file"]["hunks"][1]["hunk_id"], "H2")
+        self.assertIn("split_decision_basis", split_packet)
+        self.assertIn("rematch_risk", split_packet)
+        self.assertIn("whole_file_fallback_guidance", split_packet)
+
+        batch_packet = json.loads((output_dir / "candidate-batch-01.json").read_text(encoding="utf-8"))
+        self.assertEqual(batch_packet["recommended_type"], "fix")
+        self.assertTrue(batch_packet["body_needed"])
+        self.assertEqual(batch_packet["validation_candidates"], [{"label": "unit-tests", "paths": ["src/app.py"], "command": "python -m unittest"}])
+        self.assertIn("cohesion_basis", batch_packet)
+        self.assertIn("boundary_risks", batch_packet)
+        self.assertIn("whole_file_recommendation", batch_packet)
+        self.assertIn("coverage_gaps", batch_packet)
+        self.assertIn("quality_escape_hints", batch_packet)
+        self.assertIn("change_synopsis", batch_packet["files"][0])
+        self.assertIn("validation_candidates", batch_packet["files"][0])
+
+        worktree_packet = json.loads((output_dir / "worktree_packet.json").read_text(encoding="utf-8"))
+        self.assertEqual(worktree_packet["candidate_batch_order"], ["candidate-batch-01.json"])
+        self.assertEqual(worktree_packet["raw_reread_reasons"], [])
+        self.assertTrue(worktree_packet["common_path_sufficient"])
+
+        packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+        self.assertGreater(packet_metrics["packet_count"], 0)
+        self.assertGreater(packet_metrics["estimated_local_only_tokens"], 0)
+        self.assertGreater(packet_metrics["estimated_packet_tokens"], 0)
+
+        self.assertTrue(result["common_path_sufficient"])
+        self.assertEqual(result["raw_reread_count"], 0)
+        self.assertEqual(result["active_packets"], ["rules_packet.json", "worktree_packet.json", "candidate-batch-01.json", "split-file-01.json"])
+        self.assertIn("packet_metrics", result)
+
+    def test_edge_case_build_result_uses_explicit_reread_reason(self) -> None:
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix"],
+                "scope_required": True,
+                "subject_length_limit": 72,
+                "scope_suggestions": ["core"],
+            },
+            "recent_scope_vocabulary": ["core"],
+            "instruction_snippets": {},
+        }
+        worktree = {
+            "repo_root": "C:/tmp/repo",
+            "head_commit": "abc123",
+            "branch": "main",
+            "worktree_fingerprint": "sha256:deadbeef",
+            "active_operation": None,
+            "input_scope": "all-local-changes",
+            "diff_shortstat": "1 file changed, 4 insertions(+), 4 deletions(-)",
+            "changed_file_groups": {},
+            "diff_stat": [],
+            "validation_candidates": [],
+            "files": [
+                {
+                    "path": "src/app.py",
+                    "area": "runtime",
+                    "generated": False,
+                    "binary": False,
+                    "split_eligible": True,
+                    "change_kind": "modified",
+                    "path_tokens": ["app"],
+                    "hunks": [
+                        {
+                            "hunk_id": "H1",
+                            "header": "@@ -1,2 +1,2 @@",
+                            "old_start": 1,
+                            "new_start": 1,
+                            "tokens": [],
+                            "raw_body_lines": ["-   ", "+   "],
+                            "removed_digest": "same-digest",
+                            "added_digest": "same-digest",
+                        },
+                        {
+                            "hunk_id": "H2",
+                            "header": "@@ -40,2 +40,2 @@",
+                            "old_start": 40,
+                            "new_start": 40,
+                            "tokens": [],
+                            "raw_body_lines": ["-   ", "+   "],
+                            "removed_digest": "same-digest",
+                            "added_digest": "same-digest",
+                        },
+                    ],
+                }
+            ],
+        }
+
+        exit_code, output_dir, _orchestrator, result = self.run_script(rules, worktree)
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse(result["common_path_sufficient"])
+        self.assertEqual(result["raw_reread_reasons"], ["insufficient_excerpt_quality"])
+        worktree_packet = json.loads((output_dir / "worktree_packet.json").read_text(encoding="utf-8"))
+        self.assertEqual(worktree_packet["raw_reread_reasons"], ["insufficient_excerpt_quality"])
+        self.assertEqual(worktree_packet["quality_escape_hints"][0]["reason"], "insufficient_excerpt_quality")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_build_commit_packets_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_build_commit_packets_contract.py
@@ -178,7 +178,12 @@ class BuildCommitPacketsContractTest(unittest.TestCase):
         )
         self.assertEqual(
             global_packet["domain_overlay"]["alias_notes"],
-            {"supporting_paths": "Current domain aliases assume file/path-oriented evidence first."},
+            {
+                "supporting_paths": (
+                    "Current domain aliases assume file/path-oriented evidence first; "
+                    "`supporting_paths` is evidence-only and does not claim path ownership."
+                )
+            },
         )
         self.assertEqual(global_packet["common_path_contract"]["goal"], "Draft commit-plan.json without raw diff rereads on the common path.")
 

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_git_split_and_commit_integration.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_git_split_and_commit_integration.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+
+
+def run_command(args: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed ({result.returncode}): {' '.join(args)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+class GitSplitAndCommitIntegrationTests(unittest.TestCase):
+    def init_repo(self, root: Path) -> None:
+        run_command(["git", "init"], cwd=root)
+        run_command(["git", "config", "user.name", "Codex Test"], cwd=root)
+        run_command(["git", "config", "user.email", "codex@example.com"], cwd=root)
+
+    def commit_all(self, root: Path, message: str) -> None:
+        run_command(["git", "add", "--all"], cwd=root)
+        run_command(["git", "commit", "-m", message], cwd=root)
+
+    def script_path(self, name: str) -> str:
+        return str(SCRIPTS_DIR / name)
+
+    def test_smoke_collect_build_validate_and_apply_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo = tmp / "repo"
+            artifacts = tmp / "artifacts"
+            repo.mkdir()
+            artifacts.mkdir()
+            self.init_repo(repo)
+
+            write_text(
+                repo / ".github" / "instructions" / "commit-message.instructions.md",
+                "\n".join(
+                    [
+                        "## Format",
+                        "- Use `<type>(<scope>): <subject>`.",
+                        "",
+                        "## Types",
+                        "- `fix`",
+                        "- `docs`",
+                        "",
+                        "## Scopes",
+                        "- `core`",
+                    ]
+                )
+                + "\n",
+            )
+            write_text(repo / "src" / "app.py", "print('before')\n")
+            self.commit_all(repo, "fix(core): seed repo")
+
+            write_text(repo / "src" / "app.py", "print('after')\n")
+
+            rules_path = artifacts / "rules.json"
+            worktree_path = artifacts / "worktree.json"
+            packet_dir = artifacts / "packets"
+            build_result_path = artifacts / "build-result.json"
+            plan_path = artifacts / "commit-plan.json"
+            validation_path = artifacts / "validation.json"
+            apply_path = artifacts / "apply.json"
+
+            run_command(
+                [sys.executable, self.script_path("collect_commit_rules.py"), "--repo", str(repo), "--output", str(rules_path)],
+                cwd=SKILL_ROOT,
+            )
+            run_command(
+                [sys.executable, self.script_path("collect_worktree_context.py"), "--repo", str(repo), "--output", str(worktree_path)],
+                cwd=SKILL_ROOT,
+            )
+            run_command(
+                [
+                    sys.executable,
+                    self.script_path("build_commit_packets.py"),
+                    "--rules",
+                    str(rules_path),
+                    "--worktree",
+                    str(worktree_path),
+                    "--output-dir",
+                    str(packet_dir),
+                    "--result-output",
+                    str(build_result_path),
+                ],
+                cwd=SKILL_ROOT,
+            )
+
+            worktree = json.loads(worktree_path.read_text(encoding="utf-8"))
+            plan = {
+                "repo_root": worktree["repo_root"],
+                "base_head": worktree["head_commit"],
+                "worktree_fingerprint": worktree["worktree_fingerprint"],
+                "input_scope": worktree["input_scope"],
+                "overall_confidence": "high",
+                "validation_commands": [],
+                "omitted_paths": [],
+                "stop_reasons": [],
+                "commits": [
+                    {
+                        "commit_index": 1,
+                        "intent_summary": "Update app output.",
+                        "type": "fix",
+                        "scope": "core",
+                        "subject": "update app output",
+                        "body": ["- update the tracked runtime file"],
+                        "whole_file_paths": ["src/app.py"],
+                        "untracked_paths": [],
+                        "split_paths": [],
+                        "selected_hunk_ids": [],
+                        "supporting_paths": [],
+                        "targeted_checks": [],
+                        "confidence": "high",
+                    }
+                ],
+            }
+            plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+            validate_result = run_command(
+                [
+                    sys.executable,
+                    self.script_path("validate_commit_plan.py"),
+                    "--worktree",
+                    str(worktree_path),
+                    "--plan",
+                    str(plan_path),
+                    "--output",
+                    str(validation_path),
+                ],
+                cwd=SKILL_ROOT,
+            )
+            self.assertEqual(validate_result.returncode, 0)
+
+            apply_result = run_command(
+                [
+                    sys.executable,
+                    self.script_path("apply_commit_plan.py"),
+                    "--worktree",
+                    str(worktree_path),
+                    "--validation",
+                    str(validation_path),
+                    "--dry-run",
+                    "--result-output",
+                    str(apply_path),
+                ],
+                cwd=SKILL_ROOT,
+            )
+            payload = json.loads(apply_path.read_text(encoding="utf-8"))
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+            self.assertEqual(apply_result.returncode, 0)
+            self.assertTrue(payload["dry_run"])
+            self.assertEqual(payload["apply_status"]["status"], "dry_run")
+            self.assertEqual(payload["commits"][0]["subject"], "fix(core): update app output")
+            self.assertEqual(payload["created_hashes"], [])
+            self.assertTrue((packet_dir / "orchestrator.json").is_file())
+            self.assertTrue((packet_dir / "packet_metrics.json").is_file())
+            self.assertTrue(build_result["common_path_sufficient"])
+            self.assertEqual(build_result["raw_reread_count"], 0)
+
+    def test_apply_rolls_back_created_commits_and_preserves_worktree_edits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            repo = tmp / "repo"
+            artifacts = tmp / "artifacts"
+            repo.mkdir()
+            artifacts.mkdir()
+            self.init_repo(repo)
+
+            write_text(repo / "src" / "one.txt", "one\n")
+            write_text(repo / "src" / "two.txt", "two\n")
+            self.commit_all(repo, "fix(core): seed repo")
+            original_head = run_command(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
+
+            write_text(repo / "src" / "one.txt", "one updated\n")
+            write_text(repo / "src" / "two.txt", "two updated\n")
+
+            hook_path = repo / ".git" / "hooks" / "pre-commit"
+            write_text(
+                hook_path,
+                "\n".join(
+                    [
+                        "#!/bin/sh",
+                        "for path in $(git diff --cached --name-only); do",
+                        '  if [ \"$path\" = \"src/two.txt\" ]; then',
+                        '    echo \"block second commit\" >&2',
+                        "    exit 1",
+                        "  fi",
+                        "done",
+                        "exit 0",
+                    ]
+                )
+                + "\n",
+            )
+            try:
+                os.chmod(hook_path, 0o755)
+            except PermissionError:
+                pass
+
+            worktree_path = artifacts / "worktree.json"
+            plan_path = artifacts / "commit-plan.json"
+            validation_path = artifacts / "validation.json"
+            apply_path = artifacts / "apply.json"
+
+            run_command(
+                [sys.executable, self.script_path("collect_worktree_context.py"), "--repo", str(repo), "--output", str(worktree_path)],
+                cwd=SKILL_ROOT,
+            )
+
+            worktree = json.loads(worktree_path.read_text(encoding="utf-8"))
+            plan = {
+                "repo_root": worktree["repo_root"],
+                "base_head": worktree["head_commit"],
+                "worktree_fingerprint": worktree["worktree_fingerprint"],
+                "input_scope": worktree["input_scope"],
+                "overall_confidence": "high",
+                "validation_commands": [],
+                "omitted_paths": [],
+                "stop_reasons": [],
+                "commits": [
+                    {
+                        "commit_index": 1,
+                        "intent_summary": "Update first file.",
+                        "type": "fix",
+                        "scope": "core",
+                        "subject": "update first file",
+                        "body": ["- update src/one.txt"],
+                        "whole_file_paths": ["src/one.txt"],
+                        "untracked_paths": [],
+                        "split_paths": [],
+                        "selected_hunk_ids": [],
+                        "supporting_paths": [],
+                        "targeted_checks": [],
+                        "confidence": "high",
+                    },
+                    {
+                        "commit_index": 2,
+                        "intent_summary": "Update second file.",
+                        "type": "fix",
+                        "scope": "core",
+                        "subject": "update second file",
+                        "body": ["- update src/two.txt"],
+                        "whole_file_paths": ["src/two.txt"],
+                        "untracked_paths": [],
+                        "split_paths": [],
+                        "selected_hunk_ids": [],
+                        "supporting_paths": [],
+                        "targeted_checks": [],
+                        "confidence": "high",
+                    },
+                ],
+            }
+            plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+            run_command(
+                [
+                    sys.executable,
+                    self.script_path("validate_commit_plan.py"),
+                    "--worktree",
+                    str(worktree_path),
+                    "--plan",
+                    str(plan_path),
+                    "--output",
+                    str(validation_path),
+                ],
+                cwd=SKILL_ROOT,
+            )
+
+            apply_result = run_command(
+                [
+                    sys.executable,
+                    self.script_path("apply_commit_plan.py"),
+                    "--worktree",
+                    str(worktree_path),
+                    "--validation",
+                    str(validation_path),
+                    "--result-output",
+                    str(apply_path),
+                ],
+                cwd=SKILL_ROOT,
+                check=False,
+            )
+            payload = json.loads(apply_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(apply_result.returncode, 1)
+            self.assertEqual(payload["apply_status"]["status"], "hard_stop")
+            self.assertEqual(payload["apply_status"]["stop_category"], "commit_creation_failed")
+            self.assertTrue(payload["apply_status"]["rollback_performed"])
+            self.assertEqual(payload["apply_status"]["rollback_status"], "success")
+            self.assertEqual(len(payload["created_hashes"]), 1)
+
+            current_head = run_command(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
+            unstaged = {
+                line.strip()
+                for line in run_command(["git", "diff", "--name-only"], cwd=repo).stdout.splitlines()
+                if line.strip()
+            }
+            staged = {
+                line.strip()
+                for line in run_command(["git", "diff", "--cached", "--name-only"], cwd=repo).stdout.splitlines()
+                if line.strip()
+            }
+
+            self.assertEqual(current_head, original_head)
+            self.assertEqual(unstaged, {"src/one.txt", "src/two.txt"})
+            self.assertEqual(staged, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_validate_commit_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_validate_commit_plan_contract.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import validate_commit_plan as validator  # noqa: E402
+
+
+def sample_worktree() -> dict[str, object]:
+    return {
+        "repo_root": "C:/repo",
+        "pathspecs": [],
+        "head_commit": "abc123",
+        "worktree_fingerprint": "sha256:worktree",
+        "files": [
+            {
+                "path": "src/app.py",
+                "change_kind": "modified",
+                "split_eligible": True,
+                "hunks": [
+                    {
+                        "hunk_id": "H1",
+                        "old_start": 1,
+                        "old_count": 1,
+                        "new_start": 1,
+                        "new_count": 1,
+                        "removed_digest": "old",
+                        "added_digest": "new",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def sample_plan() -> dict[str, object]:
+    return {
+        "repo_root": "C:/repo",
+        "base_head": "abc123",
+        "worktree_fingerprint": "sha256:worktree",
+        "input_scope": "all-local-changes",
+        "overall_confidence": "high",
+        "validation_commands": ["python -m unittest"],
+        "omitted_paths": [],
+        "stop_reasons": [],
+        "extra_field": "ignored",
+        "commits": [
+            {
+                "commit_index": 1,
+                "intent_summary": "Update app behavior.",
+                "type": "fix",
+                "scope": "core",
+                "subject": "update app behavior",
+                "body": "- update the app behavior\n- keep tests green",
+                "whole_file_paths": ["src/app.py"],
+                "untracked_paths": [],
+                "split_paths": [],
+                "selected_hunk_ids": [],
+                "supporting_paths": [],
+                "targeted_checks": ["python -m unittest"],
+                "confidence": "high",
+                "extra_commit_field": "ignored",
+            }
+        ],
+    }
+
+
+class ValidateCommitPlanContractTests(unittest.TestCase):
+    def test_validator_normalizes_unknown_fields_and_emits_fixed_warning_codes(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        with patch.object(validator, "build_worktree_context", return_value=worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["can_apply"])
+        warning_codes = {item["code"] for item in payload["warning_details"]}
+        self.assertIn(validator.VALIDATION_WARNING_CODES["unknown_top_level_field"], warning_codes)
+        self.assertIn(validator.VALIDATION_WARNING_CODES["unknown_commit_field"], warning_codes)
+        self.assertIn(validator.VALIDATION_WARNING_CODES["body_string_normalized"], warning_codes)
+        self.assertNotIn("extra_field", payload["normalized_plan"])
+        self.assertNotIn("extra_commit_field", payload["normalized_plan"]["commits"][0])
+        self.assertTrue(str(payload["normalized_plan_fingerprint"]).startswith("sha256:"))
+        self.assertEqual(
+            payload["apply_gate_status"]["covered_stop_categories"],
+            [
+                "active_git_operation",
+                "ambiguous_split_rematch",
+                "low_confidence",
+                "partial_split_unsupported",
+                "stale_context",
+                "targeted_check_unavailable",
+                "validator_mismatch",
+                "unresolved_stop_reason",
+            ],
+        )
+        self.assertEqual(
+            payload["apply_gate_status"]["local_hard_stop_categories"],
+            [
+                "active_git_operation",
+                "ambiguous_split_rematch",
+                "commit_creation_failed",
+                "partial_split_unsupported",
+                "rollback_failed",
+                "targeted_check_failed",
+                "targeted_check_unavailable",
+                "validator_mismatch",
+            ],
+        )
+        self.assertEqual(payload["stop_categories"], [])
+
+    def test_validator_reports_stale_context_with_fixed_error_code(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        current_worktree = dict(worktree)
+        current_worktree["worktree_fingerprint"] = "sha256:changed"
+        with patch.object(validator, "build_worktree_context", return_value=current_worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["fingerprint_changed"], error_codes)
+        self.assertEqual(payload["apply_gate_status"]["status"], "fail")
+        self.assertIn("stale_context", payload["stop_categories"])
+
+    def test_validator_rejects_active_git_operation_with_explicit_stop_category(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        current_worktree = dict(worktree)
+        current_worktree["active_operation"] = "rebase"
+        with patch.object(validator, "build_worktree_context", return_value=current_worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["active_git_operation"], error_codes)
+        self.assertIn("active_git_operation", payload["stop_categories"])
+
+    def test_validator_rejects_partial_split_unsupported_with_explicit_stop_category(self) -> None:
+        worktree = sample_worktree()
+        worktree["files"][0]["change_kind"] = "added"
+        plan = sample_plan()
+        plan["commits"][0]["whole_file_paths"] = []
+        plan["commits"][0]["split_paths"] = ["src/app.py"]
+        plan["commits"][0]["selected_hunk_ids"] = ["H1"]
+        with patch.object(validator, "build_worktree_context", return_value=worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["partial_split_unsupported"], error_codes)
+        self.assertIn("partial_split_unsupported", payload["stop_categories"])
+
+    def test_validator_rejects_ambiguous_split_rematch_with_explicit_stop_category(self) -> None:
+        worktree = sample_worktree()
+        worktree["files"][0]["hunks"] = [
+            {
+                "hunk_id": "H1",
+                "old_start": 1,
+                "old_count": 1,
+                "new_start": 1,
+                "new_count": 1,
+                "removed_digest": "same-old",
+                "added_digest": "same-new",
+            },
+            {
+                "hunk_id": "H2",
+                "old_start": 10,
+                "old_count": 1,
+                "new_start": 10,
+                "new_count": 1,
+                "removed_digest": "same-old",
+                "added_digest": "same-new",
+            },
+        ]
+        plan = sample_plan()
+        plan["commits"][0]["whole_file_paths"] = []
+        plan["commits"][0]["split_paths"] = ["src/app.py"]
+        plan["commits"][0]["selected_hunk_ids"] = ["H1", "H2"]
+        with patch.object(validator, "build_worktree_context", return_value=worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["ambiguous_split_rematch"], error_codes)
+        self.assertIn("ambiguous_split_rematch", payload["stop_categories"])
+
+    def test_validator_rejects_targeted_check_when_command_is_unavailable(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        plan["validation_commands"] = ["missing-tool --version"]
+        plan["commits"][0]["targeted_checks"] = ["missing-tool --version"]
+        with (
+            patch.object(validator, "build_worktree_context", return_value=worktree),
+            patch.object(validator, "resolve_command_executable", return_value=None),
+        ):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["targeted_check_unavailable"], error_codes)
+        self.assertIn("targeted_check_unavailable", payload["stop_categories"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_validate_commit_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_validate_commit_plan_contract.py
@@ -208,6 +208,49 @@ class ValidateCommitPlanContractTests(unittest.TestCase):
         self.assertIn(validator.VALIDATION_ERROR_CODES["targeted_check_unavailable"], error_codes)
         self.assertIn("targeted_check_unavailable", payload["stop_categories"])
 
+    def test_validator_allows_supporting_paths_to_overlap_owned_paths(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        plan["commits"][0]["supporting_paths"] = ["src/app.py"]
+
+        with patch.object(validator, "build_worktree_context", return_value=worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertTrue(payload["valid"])
+        self.assertEqual(
+            [item["code"] for item in payload["error_details"]],
+            [],
+        )
+
+    def test_validator_rejects_commit_that_only_lists_supporting_paths(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        plan["commits"][0]["whole_file_paths"] = []
+        plan["commits"][0]["supporting_paths"] = ["src/app.py"]
+
+        with patch.object(validator, "build_worktree_context", return_value=worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        self.assertIn(
+            validator.VALIDATION_ERROR_CODES["path_assignment_mismatch"],
+            {item["code"] for item in payload["error_details"]},
+        )
+
+    def test_validator_rejects_unknown_supporting_paths(self) -> None:
+        worktree = sample_worktree()
+        plan = sample_plan()
+        plan["commits"][0]["supporting_paths"] = ["docs/notes.md"]
+
+        with patch.object(validator, "build_worktree_context", return_value=worktree):
+            payload = validator.validate_plan_against_worktree(worktree, plan)
+
+        self.assertFalse(payload["valid"])
+        self.assertIn(
+            "Commit 1 references unknown supporting path `docs/notes.md`.",
+            payload["errors"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_write_evaluation_log_git_split_and_commit.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_write_evaluation_log_git_split_and_commit.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) in sys.path:
+    sys.path.remove(str(SCRIPT_DIR))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # noqa: E402
+
+
+class GitSplitAndCommitEvaluationLogTests(unittest.TestCase):
+    def test_skill_specific_data_includes_common_path_and_packet_metrics_fields(self) -> None:
+        orchestrator = {
+            "candidate_batch_count": 2,
+            "split_file_count": 1,
+            "decision_ready_packets": True,
+            "worker_return_contract": "classification-oriented",
+            "worker_output_shape": "hierarchical",
+            "packet_order": [
+                "global_packet.json",
+                "rules_packet.json",
+                "worktree_packet.json",
+                "candidate-batch-01.json",
+                "split-file-01.json",
+            ],
+            "common_path_sufficient": True,
+            "raw_reread_reasons": [],
+        }
+
+        payload = eval_log.skill_specific_data("git-split-and-commit", {}, orchestrator, None)
+
+        self.assertEqual(payload["commit_buckets_planned"], 2)
+        self.assertEqual(payload["split_file_count"], 1)
+        self.assertTrue(payload["decision_ready_packets"])
+        self.assertEqual(payload["raw_reread_count"], 0)
+        self.assertTrue(payload["common_path_sufficient"])
+        self.assertIsNone(payload["packet_count"])
+
+    def test_build_phase_merges_packet_metrics_and_reread_signals(self) -> None:
+        log = {
+            "measurement": {},
+            "baseline": {},
+            "orchestration": {},
+            "input_size": {},
+            "skill_specific": {"data": {}},
+        }
+        result = {
+            "review_mode": "targeted-delegation",
+            "recommended_worker_count": 2,
+            "recommended_workers": [{"agent_type": "docs_verifier"}, {"agent_type": "repo_mapper"}],
+            "active_packets": [
+                "rules_packet.json",
+                "worktree_packet.json",
+                "candidate-batch-01.json",
+            ],
+            "active_packet_count": 3,
+            "candidate_batch_count": 1,
+            "split_file_count": 0,
+            "applied_override_signals": ["diff_stat_threshold"],
+            "common_path_sufficient": True,
+            "raw_reread_count": 0,
+            "raw_reread_reasons": [],
+            "packet_metrics": {
+                "packet_count": 5,
+                "packet_size_bytes": 1024,
+                "largest_packet_bytes": 420,
+                "largest_two_packets_bytes": 700,
+                "estimated_local_only_tokens": 500,
+                "estimated_packet_tokens": 250,
+                "estimated_delegation_savings": 250,
+            },
+        }
+
+        eval_log.apply_phase_update(log, "build", result, 1.5)
+
+        self.assertEqual(log["orchestration"]["review_mode"], "targeted-delegation")
+        self.assertEqual(log["orchestration"]["worker_count"], 2)
+        self.assertEqual(log["orchestration"]["override_signals"], ["diff_stat_threshold"])
+        self.assertEqual(log["input_size"]["active_areas"], 3)
+        self.assertEqual(log["input_size"]["candidate_batches"], 1)
+        self.assertEqual(log["skill_specific"]["data"]["packet_count"], 5)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_packet_tokens"], 250)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_delegation_savings"], 250)
+        self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 500)
+        self.assertEqual(log["baseline"]["estimated_delegation_savings"], 250)
+        self.assertEqual(log["measurement"]["efficiency_source"], "estimated")
+
+    def test_candidate_batch_packet_names_are_counted_as_batches(self) -> None:
+        orchestrator = {
+            "packet_order": [
+                "global_packet.json",
+                "rules_packet.json",
+                "worktree_packet.json",
+                "candidate-batch-01.json",
+                "split-file-01.json",
+            ]
+        }
+
+        self.assertEqual(eval_log.batch_packet_count(orchestrator), 1)
+        self.assertEqual(eval_log.item_packet_count(orchestrator), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/public-docs-sync/SKILL.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: public-docs-sync
+description: Audit and synchronize public repository docs against tracked runtime metadata, selected GitHub evidence, and validator-normalized deterministic edits. Use when Codex must detect public-doc drift, propose scoped fixes, and update marker state without embedding repo-specific governance policy in the retained kernel.
+---
+
+# Public Docs Sync
+
+Use this skill to audit public docs with scoped packet analysis and validator-normalized deterministic sync actions.
+
+This is a packet-driven repo workflow skill:
+- keep orchestration, final synthesis, and mutation local
+- use deterministic scripts to collect context before reading raw artifacts broadly
+- use `gpt-5.4-mini` workers only for narrow packet analysis
+- stop on low confidence, stale snapshots, or ambiguous ownership instead of guessing
+- keep generic packet rules in `references/core-contract.md` and repo-specific layout assumptions in `profiles/default/profile.json`
+- keep repo profiles data-only: paths, globs, doc lists, booleans, and notes only; executable logic stays in scripts and contracts
+- Orchestrator profile: `standard`.
+- Keep runtime metadata focused on routing, authority, stop conditions, and adjudication support only.
+- Default repo profile scaffold: `profiles/default/profile.json`.
+- Keep repo-specific paths, packet review docs, and deterministic lint toggles in the repo profile instead of hardcoding them into the generic core templates.
+- Keep the repo profile data-only: paths, globs, doc lists, booleans, and notes only. Do not add executable hooks, prompt text, or worker-routing logic there.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/public-docs-sync/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/public-docs-sync/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/public-docs-sync/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Collect structured context.
+- Review `references/core-contract.md` before changing shared packet semantics.
+- Review `profiles/default/profile.json` before trusting repo-specific path bindings, review-doc lists, or deterministic lint toggles.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_public_docs_sync_context.py --repo-root <repo-root> --output <context-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/lint_public_docs_sync.py --context <context-json> --output <lint-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_public_docs_sync_packets.py --context <context-json> --lint <lint-json> --output-dir <packet-dir>`.
+- - Optional: add `--result-output <build-result-json>` when you want a machine-readable build summary for smoke runs or evaluation logging.
+- Read `<packet-dir>/orchestrator.json` first.
+- Keep `<packet-dir>/global_packet.json` in view before reading any focused packet.
+- This scaffold does not add an orchestrator-profile-level common-path drafting packet.
+
+2. Follow the review mode.
+- `local-only`: keep the work local.
+- `targeted-delegation`: use 1-2 `gpt-5.4-mini` workers on narrow packets.
+- `broad-delegation`: use 3-4 `gpt-5.4-mini` workers and add QA only when findings conflict.
+- Escalate to the next larger mode when churn is high, core runtime/config/process files span groups, or generated files are not the majority.
+
+3. Keep packet analysis narrow.
+- Treat `references/core-contract.md` as the generic workflow contract and `profiles/default/profile.json` as the repo-specific overlay.
+- Read `references/public-docs-sync-contract.md` before drafting domain outputs.
+- Read `references/delegation-playbook.md` only when `review_mode` is not `local-only`.
+- Worker return contract for this skill: `generic`.
+- Worker output shape for this skill: `flat`.
+- Decision-ready packets enabled: `false`.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Keep final adjudication local.
+- Keep worker outputs narrow and use them as inputs to local synthesis, not as final decisions.
+- Recompute final plan confidence locally during synthesis from packet evidence, worker outputs, unresolved reread exceptions, and authority conflicts.
+- Use the named context/findings worker family when delegation is needed and keep candidate-producing workers optional unless the workflow becomes adjudication-heavy.
+- Preferred worker families for this skill:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+- Use `worker_selection_guidance` as explanatory family guidance only. When configured, `packet_worker_map` owns concrete packet routing.
+- Focus packet set for this skill:
+- `claims_packet.json`
+- `reporting_packet.json`
+- `workflow_packet.json`
+- `forms_batch_packet.json`
+- No additional orchestrator-profile-specific runtime packet is required.
+- This scaffold defaults to singleton focused packets only.
+
+4. Respect authority and stop conditions.
+- Authority order for this skill:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+- No optional local helper is configured for this scaffold.
+- Packet-first adjudication guidance:
+- Start from packetized evidence first and only widen to raw artifact rereads when the reread policy is triggered.
+- Stop and report instead of mutating when:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+5. Validate before mutating.
+- Run `<python-bin> -B <skill-dir>/scripts/validate_public_docs_sync.py --context <context-json> --plan <plan-json> --output <validation-json>`.
+- Stop if validation reports errors, stale context, low-confidence findings, or an apply-gate failure.
+
+6. Apply only after local verification.
+- Run `<python-bin> -B <skill-dir>/scripts/apply_public_docs_sync.py --validation <validation-json>` after the validation output is locally reviewed.
+- Apply must consume validator-normalized output only; do not wire raw plan JSON directly into the mutation step.
+- If the user asked for `dry-run`, keep the same validation path and stop before any external mutation.
+
+## Evaluation
+
+- Use `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>` after packet generation.
+- No orchestrator-profile-specific evaluation sidecar is required.
+- Use `phase` updates for deterministic lint, validate, and apply results when those outputs exist.
+- Use `finalize` after the run to merge token usage, actual worker mix, final usability, outputs, and notes.
+- Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
+- Keep packet artifacts and other helper temp files under the fixed gitignored `.codex/tmp/packet-workflow/` root.
+- Read `references/evaluation-log-contract.md` for the shared envelope and `references/public_docs_sync-evaluation-contract.md` for workflow-specific fields.
+
+## Scripts
+
+- `scripts/collect_public_docs_sync_context.py`
+  - Collect the structured inputs and repo artifacts for this workflow, including the active repo profile.
+- `scripts/lint_public_docs_sync.py`
+  - Run deterministic checks and emit warnings, errors, and override signals.
+- `scripts/build_public_docs_sync_packets.py`
+  - Build `orchestrator.json`, `global_packet.json`, and focused packets for local synthesis and optional mini-worker analysis.
+- `scripts/write_evaluation_log.py`
+  - Emit and update the shared evaluation log for efficiency, quality, and safety tracking.
+- `scripts/validate_public_docs_sync.py`
+  - Validate the planned actions against the collected context, normalize the plan, and emit apply-gate status before apply.
+- `scripts/apply_public_docs_sync.py`
+  - Dry-run or apply only from validator-normalized output after local verification.
+
+## Output
+
+- Tell the user which packets drove the decision.
+- Tell the user whether the run stayed local or used mini workers.
+- Tell the user which repo profile was active when repo-specific bindings mattered.
+- Tell the user whether final plan confidence was recomputed locally or a reread exception blocked that conclusion.
+- Tell the user whether the run stopped at planning, validation, or apply.

--- a/builders/packet-workflow/retained-skills/public-docs-sync/SKILL.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/SKILL.md
@@ -109,7 +109,7 @@ This is a packet-driven repo workflow skill:
 - Use `phase` updates for deterministic lint, validate, and apply results when those outputs exist.
 - Use `finalize` after the run to merge token usage, actual worker mix, final usability, outputs, and notes.
 - Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
-- Keep packet artifacts and other helper temp files under the fixed gitignored `.codex/tmp/packet-workflow/` root.
+- Keep any repo-local temporary, helper, scratch, or ad hoc input file under the fixed gitignored `.codex/tmp/` tree; packet artifacts stay under `.codex/tmp/packet-workflow/`.
 - Read `references/evaluation-log-contract.md` for the shared envelope and `references/public_docs_sync-evaluation-contract.md` for workflow-specific fields.
 
 ## Scripts

--- a/builders/packet-workflow/retained-skills/public-docs-sync/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Public Docs Sync"
+  short_description: "audit public docs with scoped packet analysis and..."
+  default_prompt: "audit public docs with scoped packet analysis and validator-normalized deterministic sync actions"

--- a/builders/packet-workflow/retained-skills/public-docs-sync/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/builder-spec.json
@@ -1,0 +1,159 @@
+{
+    "skill_name":  "public-docs-sync",
+    "description":  "Audit and synchronize public repository docs against tracked runtime metadata, selected GitHub evidence, and validator-normalized deterministic edits. Use when Codex must detect public-doc drift, propose scoped fixes, and update marker state without embedding repo-specific governance policy in the retained kernel.",
+    "domain_slug":  "public_docs_sync",
+    "workflow_family":  "repo-audit",
+    "archetype":  "audit-and-apply",
+    "primary_goal":  "audit public docs with scoped packet analysis and validator-normalized deterministic sync actions",
+    "trigger_phrases":  [
+                            "sync public docs",
+                            "audit public documentation drift",
+                            "repair public docs metadata",
+                            "update public workflow docs"
+                        ],
+    "task_packet_names":  [
+                              "claims_packet",
+                              "reporting_packet",
+                              "workflow_packet",
+                              "forms_batch_packet"
+                          ],
+    "orchestrator_profile":  "standard",
+    "needs_lint":  true,
+    "needs_validate":  true,
+    "needs_apply":  true,
+    "worker_return_contract":  "generic",
+    "worker_output_shape":  "flat",
+    "packet_worker_map":  {
+                              "claims_packet":  [
+                                                    "docs_verifier"
+                                                ],
+                              "reporting_packet":  [
+                                                       "evidence_summarizer"
+                                                   ],
+                              "workflow_packet":  [
+                                                      "packet_explorer"
+                                                  ],
+                              "forms_batch_packet":  [
+                                                         "docs_verifier"
+                                                     ]
+                          },
+    "repo_profile":  {
+                         "name":  "default",
+                         "summary":  "Neutral reusable profile scaffold for public-doc drift auditing. Add audited doc inventory, packet ownership, and marker metadata in project-local profiles when vendored.",
+                         "repo_match":  {
+                                            "root_markers":  [
+                                                                 ".git",
+                                                                 "README.md"
+                                                             ],
+                                            "remote_patterns":  [
+
+                                                                ]
+                                        },
+                         "bindings":  {
+                                          "primary_readme_path":  "README.md",
+                                          "settings_source_path":  null,
+                                          "publish_config_path":  null
+                                      },
+                         "packet_defaults":  {
+                                                 "review_docs":  {
+                                                                     "claims_packet":  [
+                                                                                           "README.md"
+                                                                                       ],
+                                                                     "reporting_packet":  [
+                                                                                              "LOG_REPORTING.md",
+                                                                                              "PERF_REPORTING.md",
+                                                                                              ".github/software-evidence-schema.md",
+                                                                                              ".github/software-investigation-workflow.md"
+                                                                                          ],
+                                                                     "workflow_packet":  [
+                                                                                             "CONTRIBUTING.md",
+                                                                                             "MAINTAINING.md",
+                                                                                             ".github/pull_request_template.md",
+                                                                                             ".github/workflows/release.yml"
+                                                                                         ],
+                                                                     "forms_batch_packet":  [
+                                                                                                ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                                                                                ".github/ISSUE_TEMPLATE/bug_report.yml",
+                                                                                                ".github/ISSUE_TEMPLATE/feature_request.yml",
+                                                                                                ".github/ISSUE_TEMPLATE/investigation.yml"
+                                                                                            ]
+                                                                 },
+                                                 "source_path_globs":  {
+                                                                           "claims_packet":  [
+                                                                                                 "README.md",
+                                                                                                 "**/PublishConfiguration.xml",
+                                                                                                 "**/Setting.cs"
+                                                                                             ],
+                                                                           "reporting_packet":  [
+                                                                                                    "LOG_REPORTING.md",
+                                                                                                    "PERF_REPORTING.md",
+                                                                                                    ".github/software-*.md"
+                                                                                                ],
+                                                                           "workflow_packet":  [
+                                                                                                   "CONTRIBUTING.md",
+                                                                                                   "MAINTAINING.md",
+                                                                                                   ".github/pull_request_template.md",
+                                                                                                   ".github/workflows/*.yml"
+                                                                                               ],
+                                                                           "forms_batch_packet":  [
+                                                                                                      ".github/ISSUE_TEMPLATE/*.yml"
+                                                                                                  ]
+                                                                       }
+                                             },
+                         "lint_rules":  {
+                                            "require_readme_settings_table":  true,
+                                            "missing_review_docs_are_errors":  false
+                                        },
+                         "extra":  {
+                                       "public_docs_sync":  {
+                                                                "audited_public_doc_inventory":  [
+                                                                                                     "README.md",
+                                                                                                     "LOG_REPORTING.md",
+                                                                                                     "PERF_REPORTING.md",
+                                                                                                     "CONTRIBUTING.md",
+                                                                                                     "MAINTAINING.md",
+                                                                                                     ".github/pull_request_template.md",
+                                                                                                     ".github/software-evidence-schema.md",
+                                                                                                     ".github/software-investigation-workflow.md",
+                                                                                                     ".github/workflows/release.yml"
+                                                                                                 ],
+                                                                "issue_template_groups":  {
+                                                                                              "reporting":  [
+                                                                                                                "performance_telemetry_report.yml",
+                                                                                                                "raw_log_report.yml",
+                                                                                                                "software_evidence.yml",
+                                                                                                                "software_investigation.yml"
+                                                                                                            ],
+                                                                                              "workflow":  [
+                                                                                                               "bug_report.yml",
+                                                                                                               "feature_request.yml",
+                                                                                                               "investigation.yml",
+                                                                                                               "release_checklist.yml"
+                                                                                                           ]
+                                                                                          },
+                                                                "public_workflow_doc_paths":  [
+                                                                                                  ".github/pull_request_template.md",
+                                                                                                  ".github/software-evidence-schema.md",
+                                                                                                  ".github/software-investigation-workflow.md",
+                                                                                                  ".github/workflows/release.yml"
+                                                                                              ],
+                                                                "state":  {
+                                                                              "namespace":  "public-docs-sync",
+                                                                              "marker_path":  ".codex/state/public-docs-sync-last-success.json"
+                                                                          }
+                                                            }
+                                   },
+                         "notes":  [
+                                       "Keep narrative completion thresholds, evidence-strength wording, and governance-linked completion policy in the consumer-local wrapper.",
+                                       "Do not encode validator or apply behavior in this profile.",
+                                       "The retained default scaffold keeps repo-specific bindings null; add them in a project-local override when the workflow needs runtime-source coupling."
+                                   ]
+                     },
+    "builder_versioning":  {
+                               "builder_family":  "packet-workflow",
+                               "builder_semver":  "0.1.0",
+                               "compatibility_epoch":  1,
+                               "builder_spec_schema_version":  1,
+                               "repo_profile_schema_version":  1
+                           }
+}

--- a/builders/packet-workflow/retained-skills/public-docs-sync/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/migration-worksheet.md
@@ -1,0 +1,6 @@
+# Migration Worksheet: public-docs-sync
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/public-docs-sync/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/profiles/default/profile.json
@@ -1,0 +1,121 @@
+{
+    "bindings":  {
+                     "primary_readme_path":  "README.md",
+                     "publish_config_path":  null,
+                     "settings_source_path":  null
+                 },
+    "extra":  {
+                  "public_docs_sync":  {
+                                           "audited_public_doc_inventory":  [
+                                                                                "README.md",
+                                                                                "LOG_REPORTING.md",
+                                                                                "PERF_REPORTING.md",
+                                                                                "CONTRIBUTING.md",
+                                                                                "MAINTAINING.md",
+                                                                                ".github/pull_request_template.md",
+                                                                                ".github/software-evidence-schema.md",
+                                                                                ".github/software-investigation-workflow.md",
+                                                                                ".github/workflows/release.yml"
+                                                                            ],
+                                           "issue_template_groups":  {
+                                                                         "reporting":  [
+                                                                                           "performance_telemetry_report.yml",
+                                                                                           "raw_log_report.yml",
+                                                                                           "software_evidence.yml",
+                                                                                           "software_investigation.yml"
+                                                                                       ],
+                                                                         "workflow":  [
+                                                                                          "bug_report.yml",
+                                                                                          "feature_request.yml",
+                                                                                          "investigation.yml",
+                                                                                          "release_checklist.yml"
+                                                                                      ]
+                                                                     },
+                                           "public_workflow_doc_paths":  [
+                                                                             ".github/pull_request_template.md",
+                                                                             ".github/software-evidence-schema.md",
+                                                                             ".github/software-investigation-workflow.md",
+                                                                             ".github/workflows/release.yml"
+                                                                         ],
+                                           "state":  {
+                                                         "marker_path":  ".codex/state/public-docs-sync-last-success.json",
+                                                         "namespace":  "public-docs-sync"
+                                                     }
+                                       }
+              },
+    "lint_rules":  {
+                       "missing_review_docs_are_errors":  false,
+                       "require_readme_settings_table":  true
+                   },
+    "name":  "default",
+    "notes":  [
+                  "Keep narrative completion thresholds, evidence-strength wording, and governance-linked completion policy in the consumer-local wrapper.",
+                  "Do not encode validator or apply behavior in this profile.",
+                  "The retained default scaffold keeps repo-specific bindings null; add them in a project-local override when the workflow needs runtime-source coupling."
+              ],
+    "packet_defaults":  {
+                            "review_docs":  {
+                                                "claims_packet":  [
+                                                                      "README.md"
+                                                                  ],
+                                                "forms_batch_packet":  [
+                                                                           ".github/ISSUE_TEMPLATE/release_checklist.yml",
+                                                                           ".github/ISSUE_TEMPLATE/bug_report.yml",
+                                                                           ".github/ISSUE_TEMPLATE/feature_request.yml",
+                                                                           ".github/ISSUE_TEMPLATE/investigation.yml"
+                                                                       ],
+                                                "reporting_packet":  [
+                                                                         "LOG_REPORTING.md",
+                                                                         "PERF_REPORTING.md",
+                                                                         ".github/software-evidence-schema.md",
+                                                                         ".github/software-investigation-workflow.md"
+                                                                     ],
+                                                "workflow_packet":  [
+                                                                        "CONTRIBUTING.md",
+                                                                        "MAINTAINING.md",
+                                                                        ".github/pull_request_template.md",
+                                                                        ".github/workflows/release.yml"
+                                                                    ]
+                                            },
+                            "source_path_globs":  {
+                                                      "claims_packet":  [
+                                                                            "README.md",
+                                                                            "**/PublishConfiguration.xml",
+                                                                            "**/Setting.cs"
+                                                                        ],
+                                                      "forms_batch_packet":  [
+                                                                                 ".github/ISSUE_TEMPLATE/*.yml"
+                                                                             ],
+                                                      "reporting_packet":  [
+                                                                               "LOG_REPORTING.md",
+                                                                               "PERF_REPORTING.md",
+                                                                               ".github/software-*.md"
+                                                                           ],
+                                                      "workflow_packet":  [
+                                                                              "CONTRIBUTING.md",
+                                                                              "MAINTAINING.md",
+                                                                              ".github/pull_request_template.md",
+                                                                              ".github/workflows/*.yml"
+                                                                          ]
+                                                  }
+                        },
+    "profile_path":  "profiles/default/profile.json",
+    "repo_match":  {
+                       "remote_patterns":  [
+
+                                           ],
+                       "root_markers":  [
+                                            ".git",
+                                            "README.md"
+                                        ]
+                   },
+    "summary":  "Neutral reusable profile scaffold for public-doc drift auditing. Add audited doc inventory, packet ownership, and marker metadata in project-local profiles when vendored.",
+    "metadata":  {
+                     "versioning":  {
+                                        "builder_family":  "packet-workflow",
+                                        "builder_semver":  "0.1.0",
+                                        "compatibility_epoch":  1,
+                                        "repo_profile_schema_version":  1
+                                    }
+                 }
+}

--- a/builders/packet-workflow/retained-skills/public-docs-sync/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/references/core-contract.md
@@ -1,0 +1,148 @@
+﻿# Public Docs Sync Core Contract
+
+This file captures the reusable packet-workflow core for the generated `public-docs-sync` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+
+## Core Metadata
+
+- `workflow_family`: `repo-audit`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `claims_packet.json`
+- `reporting_packet.json`
+- `workflow_packet.json`
+- `forms_batch_packet.json`
+- No additional orchestrator-profile-specific runtime packet is required.
+
+Review mode overrides inherited by default:
+- diff churn exceeds a configured threshold
+- core runtime, config, or process files span multiple groups
+- generated files are present but are not the majority of the change
+
+Authority order:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+## Generic Worker Contract
+
+## Generic Adjudication Structure
+
+- This scaffold uses the `generic` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Generic flat mode does not require hierarchical `candidates[]` plus `footer` worker output.
+
+## Worker Families
+
+- The builder keeps worker-family structure generic and reusable across packet-driven workflows.
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+
+- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:
+- `repo_mapper`
+- `packet_explorer`
+- `docs_verifier`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `claims_packet`
+  - `docs_verifier`
+- `reporting_packet`
+  - `evidence_summarizer`
+- `workflow_packet`
+  - `packet_explorer`
+- `forms_batch_packet`
+  - `docs_verifier`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Summary: Neutral reusable profile scaffold for public-doc drift auditing. Add audited doc inventory, packet ownership, and marker metadata in project-local profiles when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `claims_packet`
+    - `README.md`
+  - `reporting_packet`
+    - `LOG_REPORTING.md`
+    - `PERF_REPORTING.md`
+    - `.github/software-evidence-schema.md`
+    - `.github/software-investigation-workflow.md`
+  - `workflow_packet`
+    - `CONTRIBUTING.md`
+    - `MAINTAINING.md`
+    - `.github/pull_request_template.md`
+    - `.github/workflows/release.yml`
+  - `forms_batch_packet`
+    - `.github/ISSUE_TEMPLATE/release_checklist.yml`
+    - `.github/ISSUE_TEMPLATE/bug_report.yml`
+    - `.github/ISSUE_TEMPLATE/feature_request.yml`
+    - `.github/ISSUE_TEMPLATE/investigation.yml`
+- source path globs:
+  - `claims_packet`
+    - `README.md`
+    - `**/PublishConfiguration.xml`
+    - `**/Setting.cs`
+  - `reporting_packet`
+    - `LOG_REPORTING.md`
+    - `PERF_REPORTING.md`
+    - `.github/software-*.md`
+  - `workflow_packet`
+    - `CONTRIBUTING.md`
+    - `MAINTAINING.md`
+    - `.github/pull_request_template.md`
+    - `.github/workflows/*.yml`
+  - `forms_batch_packet`
+    - `.github/ISSUE_TEMPLATE/*.yml`
+- Default lint rules:
+- `require_readme_settings_table`: true
+- `missing_review_docs_are_errors`: false
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes`r`n`r`n- Optional local helpers remain non-authoritative even when collected.`r`n- Final plan confidence is recomputed locally even when worker confidence signals are present.`r`n- The retained default scaffold keeps repo-specific bindings null and should be specialized by a project-local override when runtime-source coupling matters.
+
+
+
+
+

--- a/builders/packet-workflow/retained-skills/public-docs-sync/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/references/core-contract.md
@@ -137,6 +137,7 @@ Stop conditions:
 
 - Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/public-docs-sync/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/references/delegation-playbook.md
@@ -1,0 +1,122 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`: no workers
+- `targeted-delegation`: 1-2 analysis workers
+- `broad-delegation`: 3-4 analysis workers
+- Optional QA worker: only when packet findings conflict or broad mutation needs a final coverage pass
+
+## Packet Order
+
+- Every worker reads `global_packet.json` first.
+- Prefer `batch-packet-*.json` when it exists and the orchestrator points to grouped work.
+- Read singleton focused packets only for work not covered by a batch.
+- Keep each worker on one small packet slice.
+
+## Shared Context
+
+`global_packet.json` keeps all workers aligned on:
+- workflow family
+- primary goal
+- authority order
+- stop conditions
+- review mode overrides
+- preferred worker families
+- packet worker map when configured
+- worker selection guidance
+- worker return contract
+- worker output shape
+- xHigh reread policy
+- candidate field bundles when decision-ready packets are enabled
+- worker footer fields when hierarchical output is enabled
+- reread reason values when decision-ready packets are enabled
+- domain overlay semantics when configured
+- optional local helper policy
+
+## Worker Return Modes
+
+- `generic`
+  - Use for simple workflows where the local orchestrator mainly needs a narrow outcome and evidence pointers.
+- `classification-oriented`
+  - Use for adjudication-heavy workflows where final adjudication stays local but workers must return proposal-grade candidate records.
+  - Prefer hierarchical `candidates[] + footer` output.
+
+## Worker Families
+
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+- Surfaced optional worker list below is the delegated-mode exposed list after stable dedupe and after subtracting explicitly mapped recommended worker types:
+- `repo_mapper`
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `claims_packet`
+  - `docs_verifier`
+- `reporting_packet`
+  - `evidence_summarizer`
+- `workflow_packet`
+  - `packet_explorer`
+- `forms_batch_packet`
+  - `docs_verifier`
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Analysis Worker Contract
+
+Prefer the named worker families above before falling back to an unspecified narrow `gpt-5.4-mini` worker.
+
+- Active worker return contract: `generic`.
+- Active worker output shape: `flat`.
+- Return exactly:
+  - `packet ids`
+  - `primary outcome`
+  - `evidence files`
+  - `recommended next step`
+  - `risk`
+  - `tests or checks`
+
+Do not draft the final user-facing response in worker output. The main agent owns final synthesis.
+Final plan confidence is recomputed locally even when worker confidence signals are present.
+
+## Mutation Guardrails
+
+- Keep final mutation local unless the generated skill explicitly narrows a safe worker-owned edit slice.
+- If the skill handles repo or remote mutations, do not ask a worker to own the whole mutation path from scratch.
+- If findings conflict, keep the result local and add QA instead of widening worker scope.
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $public-docs-sync to analyze packet-driven workflow inputs.
+
+Read only:
+- <global-packet>
+- <focused-packet-or-batch-packet>
+- <specific file slice if needed>
+
+Return exactly:
+- packet ids
+- primary outcome
+- evidence files
+- recommended next step
+- risk
+- tests or checks
+```
+
+Keep each worker narrow. Do not ask a worker to rediscover the whole repo state from scratch.

--- a/builders/packet-workflow/retained-skills/public-docs-sync/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/references/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/builders/packet-workflow/retained-skills/public-docs-sync/references/public-docs-sync-contract.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/references/public-docs-sync-contract.md
@@ -1,0 +1,321 @@
+# Repo Public Docs Sync Contract
+
+This file defines the packet, plan, and apply contract for `public-docs-sync`.
+
+`scripts/public_docs_sync_contract.py` is the authoritative source for packet names, worker routing, reread policy, fixed validation codes, deterministic action aliases, marker stop categories, and packet-metrics helpers. Keep docs and tests aligned to that file instead of restating divergent values.
+
+## Builder Metadata
+
+- `workflow_family`: `repo-audit`
+- `archetype`: `audit-and-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+- trigger phrases:
+  - public docs sync
+  - audit public docs drift
+  - refresh docs after repo changes
+  - update the last-success marker
+
+## Packet Set
+
+Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `claims_packet.json`
+- `reporting_packet.json`
+- `workflow_packet.json`
+- `forms_batch_packet.json`
+- `packet_metrics.json` for evaluation and regression only
+
+Optional grouped packet:
+- `batch-packet-01.json` when multiple public issue forms should be reviewed together
+
+## Public Surface
+
+The current repo-facing public surface is:
+- release and player-facing copy: `README.md`, `PublishConfiguration.xml`
+- diagnostics and telemetry docs: `LOG_REPORTING.md`, `PERF_REPORTING.md`
+- contributor and maintainer public workflow docs: `CONTRIBUTING.md`, `MAINTAINING.md`, `.github/pull_request_template.md`, `.github/workflows/release.yml`
+- public investigation docs and public issue forms under `.github/`
+
+## Ownership Rules
+
+Packet ownership is:
+- `claims_packet`
+  - runtime defaults, shipped behavior, README status, publish copy
+- `reporting_packet`
+  - diagnostics contract, performance telemetry, evidence schema/workflow docs
+- `workflow_packet`
+  - contributor, maintainer, PR, and release workflow docs
+- `forms_batch_packet`
+  - public issue templates, especially reporting or release intake forms
+
+When source changes are broad, prefer activating one packet per concern instead of letting one packet absorb unrelated doc review.
+
+Each packet may also carry a `github_evidence_slice` narrowed to its owned surface:
+- `claims_packet`
+  - shipped behavior, naming, defaults, release copy, and linked PR or issue evidence
+- `reporting_packet`
+  - diagnostics, telemetry, investigation workflow, and reporting-form evidence
+- `workflow_packet`
+  - contributor, maintainer, PR, and release workflow evidence
+- `forms_batch_packet`
+  - public issue-template wording or metadata evidence
+
+## Worker Routing Metadata
+
+Preferred worker families:
+- `context_findings`
+  - `repo_mapper`
+  - `docs_verifier`
+- `candidate_producers`
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `verifiers`
+  - `docs_verifier`
+
+Concrete routing uses `packet_worker_map`:
+- `claims_packet -> large_diff_auditor, repo_mapper`
+- `reporting_packet -> evidence_summarizer`
+- `workflow_packet -> docs_verifier`
+- `forms_batch_packet -> docs_verifier`
+- `batch-packet-01 -> docs_verifier` when grouped forms review is active
+
+Rules:
+- `packet_worker_map` is the routing authority
+- `worker_selection_guidance` is explanatory only
+- routed worker budgets still follow `local-only`, `targeted-delegation`, and `broad-delegation`
+- runtime packets stay lean; token and size counters belong in `packet_metrics.json` or evaluation logs, not in `orchestrator.json`
+
+## Ref Discovery And Remote Evidence
+
+Collector ref discovery precedence is:
+- explicit `--since-ref`
+- reusable saved marker range
+- current HEAD merge commit for `Merge pull request #N ...`
+- current branch open PR
+- current branch versus upstream/default branch merge-base
+- full audit fallback
+
+When the selected relevant ref is PR-backed and the repo has a GitHub remote:
+- `gh auth status` must succeed before the run continues
+- the collector fails closed on invalid auth instead of running with partial remote evidence
+- evidence scope stays narrow:
+  - primary PR only
+  - linked issues that the PR closes
+  - repository discussions directly referenced from the PR or linked issues
+  - recent top-level comments and review summaries stored as digests
+
+## Deterministic Findings
+
+The lint step emits only these classifications:
+- `hard_drift`
+  - deterministic default mismatch, missing expected review doc, or similar direct mismatch
+- `review_required`
+  - mapped code or workflow surfaces changed without corresponding public-doc changes since the baseline, including docs-relevant GitHub evidence tied to the selected change unit
+- `link_error`
+  - broken relative links in public docs or public forms
+- `stale_baseline`
+  - saved marker could not be reused safely; the collector may still auto-discover a narrower relevant ref before falling back to a full audit
+
+Focused packet outputs must make the common path decision-ready:
+- `ownership_summary`
+- `deterministic_action_candidates`
+- `manual_review_residuals`
+- `marker_gate_signals`
+- `github_evidence_slice`
+
+These fields should be sufficient for common-path local review. Raw reread is allowed only for explicit edge cases, not as compensation for thin packet content.
+
+## Plan Contract
+
+The local plan file passed to `apply_public_docs_sync.py` must contain:
+- `context_id`
+- `context_fingerprint`
+- `overall_confidence`
+- `doc_update_status`
+  - allowed marker-update values: `completed` or `noop`
+- `allow_marker_update`
+- `actions`
+- `stop_reasons`
+
+Recommended optional fields:
+- `marker_reason`
+- `selected_packets`
+- `remaining_manual_reviews`
+
+Action intent is validator-owned:
+- every action is classified as either `deterministic-edit` or `manual-only-review`
+- only the deterministic-edit subset can reach apply
+- manual-only-review actions and `remaining_manual_reviews` block marker updates but do not automatically block deterministic edits
+- action `details` must stay narrowly scoped enough for deterministic execution
+
+## Phase Field Tables
+
+### Draft Plan
+
+Top-level fields:
+- required
+  - `context_id`
+  - `context_fingerprint`
+  - `overall_confidence`
+  - `doc_update_status`
+  - `allow_marker_update`
+  - `actions`
+  - `stop_reasons`
+- allowed
+  - `marker_reason`
+  - `selected_packets`
+  - `remaining_manual_reviews`
+- ignored
+  - none
+
+Action-entry fields:
+- required
+  - `type`
+  - `summary`
+- allowed
+  - `path`
+  - `details`
+- ignored
+  - none
+
+### Validator Output
+
+`validate_public_docs_sync.py` must emit:
+
+- `valid`
+- `can_apply`
+- `can_update_marker`
+- `errors`
+- `warnings`
+- `error_details`
+- `warning_details`
+- `stop_reasons`
+- `normalized_plan`
+- `normalized_plan_fingerprint`
+- `context_file_fingerprint`
+- `apply_context_snapshot`
+- `apply_context_snapshot_fingerprint`
+- `deterministic_actions`
+- `manual_review_actions`
+- `action_summary`
+- `apply_gate_status`
+
+Unknown extra plan fields must be removed during normalization and surfaced through fixed warning codes.
+
+`apply_context_snapshot` must stay minimal. It exists only to let apply recheck HEAD and write the marker without reopening the full collected context. It should include:
+- `repo_root`
+- `state_file`
+- `context_id`
+- `context_fingerprint`
+- `head_commit`
+- `repo_hash`
+- `repo_slug`
+- `branch`
+- `baseline_commit`
+- `relevant_ref`
+- `primary_pr_number`
+- `primary_pr_url`
+- `github_evidence_digest`
+- `ref_selection_source`
+- `audited_doc_paths`
+
+`apply_gate_status` must distinguish:
+- deterministic-edit safety
+- marker-update safety
+- explicit local hard stop categories, including:
+  - `narrative_drift_remaining`
+  - `deterministic_scope_exceeded`
+  - `marker_update_without_doc_completion`
+  - `stale_marker_context`
+
+## Apply Contract
+
+`scripts/apply_public_docs_sync.py` applies deterministic public-doc edits first, then persists the last-success marker only when the marker gate is clear.
+
+- Apply consumes validator output, not raw plan JSON.
+- Apply consumes `--validation` only. It does not reopen the collected context JSON.
+- `--dry-run` follows the same rule and must read the validator-produced `normalized_plan`.
+- Apply must compare the validator fingerprints and the current repo HEAD before writing repo files or the marker.
+- Apply must consume the validator-classified deterministic-edit subset only.
+- Apply must never perform manual-only-review or narrative actions.
+
+It must refuse deterministic edits when:
+- the plan fingerprint does not match the collected context
+- the validator marks the deterministic edit gate as failed
+- the validator reports `deterministic_scope_exceeded`
+- the validator reports `stale_marker_context`
+- required GitHub evidence is missing for the selected change unit
+
+It must refuse marker updates when:
+- deterministic edits failed
+- `allow_marker_update` is not true
+- `doc_update_status` is not `completed` or `noop`
+- `overall_confidence` is `low`
+- any manual-only-review or narrative residual remains
+- the validator reports `marker_update_without_doc_completion`
+- the validator reports `narrative_drift_remaining`
+
+The written marker should capture:
+- repo identity
+- repo slug
+- branch
+- baseline commit
+- current head commit
+- selected relevant ref
+- primary PR number and URL when present
+- GitHub evidence digest
+- ref-selection source
+- context fingerprint
+- audited doc paths
+- active packets
+- save timestamp
+
+## Evaluation-Side Metrics
+
+`packet_metrics.json` is evaluation-only and should contain:
+- `packet_count`
+- `packet_size_bytes`
+- `largest_packet_bytes`
+- `largest_two_packets_bytes`
+- `estimated_local_only_tokens`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+
+These numbers support regression tracking. They are not runtime branching inputs.
+
+## Apply Boundaries
+
+Allowed deterministic apply categories:
+- settings-table default sync
+- relative-link fixes
+- simple public doc list or reference sync
+- issue-template metadata sync
+
+Do not treat these as deterministic:
+- release status claims
+- investigation conclusions
+- evidence-strength or experiment-status prose
+
+## Fixed Codes
+
+Validator warning codes:
+
+- `W_PLAN_UNKNOWN_TOP_LEVEL_FIELD`
+- `W_PLAN_UNKNOWN_ACTION_FIELD`
+- `W_PLAN_ACTION_STRING_NORMALIZED`
+
+Validator error codes:
+
+- `E_PLAN_MISSING_FIELD`
+- `E_PLAN_CONTEXT_ID_MISMATCH`
+- `E_PLAN_CONTEXT_FINGERPRINT_MISMATCH`
+- `E_PLAN_HEAD_CHANGED`
+- `E_PLAN_AMBIGUOUS_SELECTED_PACKET`
+- `E_PLAN_MISSING_REQUIRED_EVIDENCE`
+- `E_PLAN_DETERMINISTIC_SCOPE_EXCEEDED`
+- `E_PLAN_STALE_MARKER_CONTEXT`

--- a/builders/packet-workflow/retained-skills/public-docs-sync/references/public-docs-sync-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/references/public-docs-sync-evaluation-contract.md
@@ -1,0 +1,55 @@
+# Repo Public Docs Sync Evaluation Contract
+
+Use the shared envelope in `references/evaluation-log-contract.md` and keep public-docs-specific metrics under `skill_specific.data`.
+
+## Skill-Specific Focus
+
+Record the signals that matter for recurring public-doc audits:
+- baseline mode and fallback reason
+- review mode and packet mix
+- active packet count and names
+- deterministic finding counts by classification
+- auto-apply candidate count
+- deterministic edit count versus manual-review count
+- marker write status
+- packet metrics and estimated delegation savings
+
+## Skill-Specific Data
+
+Keep these values when they are available:
+- `baseline_mode`
+- `baseline_fallback_reason`
+- `review_mode`
+- `selected_packets`
+- `active_packets`
+- `worker_count`
+- `worker_mix`
+- `hard_drift_count`
+- `review_required_count`
+- `link_error_count`
+- `stale_baseline_count`
+- `auto_apply_candidate_count`
+- `deterministic_edit_count`
+- `manual_review_count`
+- `plan_overall_confidence`
+- `allow_marker_update`
+- `marker_update_attempted`
+- `marker_update_written`
+- `marker_written`
+- `stop_reasons`
+- `packet_count`
+- `packet_size_bytes`
+- `largest_packet_bytes`
+- `largest_two_packets_bytes`
+- `estimated_local_only_tokens`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+
+## Phase Guidance
+
+- `init`
+  - capture the collected context, selected baseline, and packet orchestration snapshot
+- `phase`
+  - record lint results, build-result packet metrics, and any apply dry-run or marker-write results
+- `finalize`
+  - record final packet usage, marker status, and observed versus estimated savings when available

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/apply_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/apply_public_docs_sync.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Apply validated deterministic public-doc fixes and then persist the last-success marker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from validate_public_docs_sync import json_fingerprint, load_json
+
+SKILL_VERSION = "0.5.0"
+README_SETTINGS_HEADER = "| Setting | Default | Purpose |"
+README_SETTINGS_ROW_RE = re.compile(
+    r"^\|\s*`(?P<name>[^`]+)`\s*\|\s*`?(?P<default>[^|`]*)`?\s*\|\s*(?P<purpose>.+?)\s*\|\s*$"
+)
+MARKDOWN_LINK_TARGET_RE = r"(\[[^\]]+\]\()(?P<target>{target})(\))"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--validation", required=True, help="Validator output JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Report the marker update without mutating.")
+    parser.add_argument("--state-file", help="Optional override for the last-success marker JSON path.")
+    parser.add_argument("--result-output", help="Optional machine-readable apply result JSON.")
+    return parser.parse_args()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def run_git(repo_root: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
+def normalize_relpath(path: str) -> str:
+    return str(path).replace("\\", "/")
+
+
+def newline_style(text: str) -> str:
+    return "\r\n" if "\r\n" in text else "\n"
+
+
+def quote_yaml_scalar(value: str) -> str:
+    return json.dumps(value)
+
+
+def render_issue_template_value(field: str, value: Any) -> str:
+    if field == "labels":
+        items = [quote_yaml_scalar(str(item)) for item in value]
+        return "[" + ", ".join(items) + "]"
+    return quote_yaml_scalar(str(value))
+
+
+def relpath_to_abs(repo_root: Path, relpath: str) -> Path:
+    return (repo_root / Path(relpath)).resolve()
+
+
+def load_file_text(
+    repo_root: Path,
+    relpath: str,
+    original_text: dict[str, str],
+    current_text: dict[str, str],
+) -> str:
+    relpath = normalize_relpath(relpath)
+    if relpath in current_text:
+        return current_text[relpath]
+    absolute_path = relpath_to_abs(repo_root, relpath)
+    if not absolute_path.is_file():
+        raise RuntimeError(f"deterministic apply target does not exist: {relpath}")
+    text = absolute_path.read_text(encoding="utf-8", errors="replace")
+    original_text[relpath] = text
+    current_text[relpath] = text
+    return text
+
+
+def store_file_text(relpath: str, text: str, current_text: dict[str, str]) -> None:
+    current_text[normalize_relpath(relpath)] = text
+
+
+def render_settings_row(setting: str, default: str, purpose: str) -> str:
+    safe_purpose = purpose.replace("|", "\\|").strip()
+    return f"| `{setting}` | `{default}` | {safe_purpose} |"
+
+
+def apply_settings_table_default_sync(text: str, action: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    lines = text.splitlines(keepends=True)
+    table_start = None
+    for index, line in enumerate(lines):
+        if line.strip() == README_SETTINGS_HEADER:
+            table_start = index
+            break
+    if table_start is None:
+        raise RuntimeError("README settings table header was not found.")
+
+    separator_index = table_start + 1
+    if separator_index >= len(lines):
+        raise RuntimeError("README settings table is missing its separator row.")
+
+    table_end = separator_index + 1
+    while table_end < len(lines) and lines[table_end].lstrip().startswith("|"):
+        table_end += 1
+
+    details = action.get("details", {})
+    setting = str(details.get("setting") or "").strip()
+    expected_default = str(details.get("expected_default") or "").strip()
+    fallback_purpose = (
+        str(details.get("documented_purpose") or "").strip()
+        or str(details.get("setting_description") or "").strip()
+        or str(details.get("setting_label") or "").strip()
+        or setting
+    )
+    line_ending = newline_style(text)
+
+    for row_index in range(separator_index + 1, table_end):
+        raw_line = lines[row_index].rstrip("\r\n")
+        match = README_SETTINGS_ROW_RE.match(raw_line)
+        if not match or match.group("name") != setting:
+            continue
+        purpose = match.group("purpose").strip() or fallback_purpose
+        replacement = render_settings_row(setting, expected_default, purpose)
+        if replacement == raw_line:
+            return text, {
+                "index": action.get("index"),
+                "type": action.get("canonical_type"),
+                "path": action.get("path"),
+                "summary": action.get("summary"),
+                "changed": False,
+                "change_kind": "noop",
+            }
+        lines[row_index] = replacement + line_ending
+        return "".join(lines), {
+            "index": action.get("index"),
+            "type": action.get("canonical_type"),
+            "path": action.get("path"),
+            "summary": action.get("summary"),
+            "changed": True,
+            "change_kind": "update",
+        }
+
+    insertion = render_settings_row(setting, expected_default, fallback_purpose) + line_ending
+    lines.insert(table_end, insertion)
+    return "".join(lines), {
+        "index": action.get("index"),
+        "type": action.get("canonical_type"),
+        "path": action.get("path"),
+        "summary": action.get("summary"),
+        "changed": True,
+        "change_kind": "insert",
+    }
+
+
+def apply_relative_link_fix(text: str, action: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    details = action.get("details", {})
+    target = re.escape(str(details.get("target") or ""))
+    replacement_target = str(details.get("replacement_target") or "")
+    expected_count = int(details.get("expected_count") or 1)
+    pattern = re.compile(MARKDOWN_LINK_TARGET_RE.format(target=target))
+    count = 0
+
+    def replace(match: re.Match[str]) -> str:
+        nonlocal count
+        count += 1
+        return match.group(1) + replacement_target + match.group(3)
+
+    updated = pattern.sub(replace, text)
+    if count != expected_count:
+        raise RuntimeError(
+            f"expected {expected_count} markdown link target replacement(s) in {action.get('path')}, found {count}"
+        )
+    return updated, {
+        "index": action.get("index"),
+        "type": action.get("canonical_type"),
+        "path": action.get("path"),
+        "summary": action.get("summary"),
+        "changed": updated != text,
+        "change_kind": "replace",
+    }
+
+
+def apply_public_doc_reference_sync(text: str, action: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    details = action.get("details", {})
+    match_text = str(details.get("match_text") or "")
+    replacement_text = str(details.get("replacement_text") or "")
+    expected_count = int(details.get("expected_count") or 1)
+    count = text.count(match_text)
+    if count != expected_count:
+        raise RuntimeError(
+            f"expected {expected_count} reference replacement(s) in {action.get('path')}, found {count}"
+        )
+    updated = text.replace(match_text, replacement_text, expected_count)
+    return updated, {
+        "index": action.get("index"),
+        "type": action.get("canonical_type"),
+        "path": action.get("path"),
+        "summary": action.get("summary"),
+        "changed": updated != text,
+        "change_kind": "replace",
+    }
+
+
+def apply_issue_template_metadata_sync(text: str, action: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    details = action.get("details", {})
+    field = str(details.get("field") or "")
+    rendered = f"{field}: {render_issue_template_value(field, details.get('value'))}"
+    pattern = re.compile(rf"^{re.escape(field)}:\s*.*$", re.MULTILINE)
+    matches = list(pattern.finditer(text))
+    if len(matches) > 1:
+        raise RuntimeError(f"issue-template metadata field `{field}` appears multiple times in {action.get('path')}")
+
+    if matches:
+        updated = pattern.sub(rendered, text, count=1)
+    else:
+        line_ending = newline_style(text)
+        body_match = re.search(r"^body:\s*$", text, flags=re.MULTILINE)
+        if body_match:
+            updated = text[: body_match.start()] + rendered + line_ending + text[body_match.start() :]
+        elif text:
+            suffix = "" if text.endswith(("\n", "\r")) else line_ending
+            updated = text + suffix + rendered + line_ending
+        else:
+            updated = rendered + line_ending
+    return updated, {
+        "index": action.get("index"),
+        "type": action.get("canonical_type"),
+        "path": action.get("path"),
+        "summary": action.get("summary"),
+        "changed": updated != text,
+        "change_kind": "replace" if matches else "insert",
+    }
+
+
+def apply_action_to_text(text: str, action: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    canonical_type = action.get("canonical_type")
+    if canonical_type == "settings_table_default_sync":
+        return apply_settings_table_default_sync(text, action)
+    if canonical_type == "relative_link_fix":
+        return apply_relative_link_fix(text, action)
+    if canonical_type == "public_doc_reference_sync":
+        return apply_public_doc_reference_sync(text, action)
+    if canonical_type == "issue_template_metadata_sync":
+        return apply_issue_template_metadata_sync(text, action)
+    raise RuntimeError(f"unsupported deterministic action type `{canonical_type}` in validator output")
+
+
+def snapshot_from_validation(validation: dict[str, Any]) -> dict[str, Any]:
+    snapshot = validation.get("apply_context_snapshot")
+    if not isinstance(snapshot, dict):
+        raise RuntimeError("validator output is missing `apply_context_snapshot`")
+    snapshot_fingerprint = str(validation.get("apply_context_snapshot_fingerprint", "")).strip()
+    if not snapshot_fingerprint:
+        raise RuntimeError("validator output is missing `apply_context_snapshot_fingerprint`")
+    if json_fingerprint(snapshot) != snapshot_fingerprint:
+        raise RuntimeError("validator output apply-context snapshot fingerprint does not match the embedded snapshot")
+    return snapshot
+
+
+def normalized_plan_from_validation(
+    validation: dict[str, Any],
+) -> tuple[dict[str, Any], str, list[dict[str, Any]], list[dict[str, Any]], bool, dict[str, Any]]:
+    normalized_plan = validation.get("normalized_plan")
+    if not isinstance(normalized_plan, dict):
+        raise RuntimeError("validator output is missing `normalized_plan`")
+    normalized_plan_fingerprint = str(validation.get("normalized_plan_fingerprint", "")).strip()
+    if not normalized_plan_fingerprint:
+        raise RuntimeError("validator output is missing `normalized_plan_fingerprint`")
+    if json_fingerprint(normalized_plan) != normalized_plan_fingerprint:
+        raise RuntimeError("validator output normalized-plan fingerprint does not match the normalized plan")
+    if not validation.get("valid"):
+        raise RuntimeError("refusing to apply validator output marked invalid")
+    if not validation.get("can_apply"):
+        raise RuntimeError("refusing to apply validator output marked not edit-safe")
+    apply_gate_status = validation.get("apply_gate_status") or {}
+    if apply_gate_status.get("apply_edits_status") != "pass":
+        raise RuntimeError("refusing to apply validator output with a failed deterministic edit gate")
+    if apply_gate_status.get("uncovered_stop_categories"):
+        raise RuntimeError("refusing to apply while applicable stop categories remain uncovered")
+    deterministic_actions = validation.get("deterministic_actions")
+    if not isinstance(deterministic_actions, list):
+        deterministic_actions = [
+            action
+            for action in normalized_plan.get("actions", [])
+            if isinstance(action, dict) and action.get("action_mode") == "deterministic-edit"
+        ]
+    manual_review_actions = validation.get("manual_review_actions")
+    if not isinstance(manual_review_actions, list):
+        manual_review_actions = [
+            action
+            for action in normalized_plan.get("actions", [])
+            if isinstance(action, dict) and action.get("action_mode") == "manual-only-review"
+        ]
+    snapshot = snapshot_from_validation(validation)
+    if normalized_plan.get("context_id") != snapshot.get("context_id"):
+        raise RuntimeError("validator mismatch: normalized plan context id does not match the apply snapshot")
+    if normalized_plan.get("context_fingerprint") != snapshot.get("context_fingerprint"):
+        raise RuntimeError("validator mismatch: normalized plan context fingerprint does not match the apply snapshot")
+    return (
+        normalized_plan,
+        normalized_plan_fingerprint,
+        deterministic_actions,
+        manual_review_actions,
+        bool(validation.get("can_update_marker")),
+        snapshot,
+    )
+
+
+def build_marker(snapshot: dict[str, Any], normalized_plan: dict[str, Any], state_file: Path) -> dict[str, Any]:
+    return {
+        "skill_name": "public-docs-sync",
+        "skill_version": SKILL_VERSION,
+        "repo_root": snapshot.get("repo_root"),
+        "repo_hash": snapshot.get("repo_hash"),
+        "repo_slug": snapshot.get("repo_slug"),
+        "branch": snapshot.get("branch"),
+        "baseline_commit": snapshot.get("baseline_commit"),
+        "head_commit": snapshot.get("head_commit"),
+        "context_id": snapshot.get("context_id"),
+        "context_fingerprint": snapshot.get("context_fingerprint"),
+        "audited_doc_paths": snapshot.get("audited_doc_paths", []),
+        "active_packets": normalized_plan.get("selected_packets", []),
+        "relevant_ref": snapshot.get("relevant_ref"),
+        "primary_pr_number": snapshot.get("primary_pr_number"),
+        "primary_pr_url": snapshot.get("primary_pr_url"),
+        "github_evidence_digest": snapshot.get("github_evidence_digest"),
+        "ref_selection_source": snapshot.get("ref_selection_source"),
+        "state_file": str(state_file),
+        "saved_at": datetime.now(timezone.utc).isoformat(),
+        "status": "success",
+        "doc_update_status": normalized_plan.get("doc_update_status"),
+        "marker_reason": normalized_plan.get("marker_reason") or "doc-sync-complete",
+    }
+
+
+def apply_validated_plan(
+    validation: dict[str, Any],
+    *,
+    dry_run: bool,
+    state_file: Path | None = None,
+) -> dict[str, Any]:
+    (
+        normalized_plan,
+        normalized_plan_fingerprint,
+        deterministic_actions,
+        manual_review_actions,
+        can_update_marker,
+        snapshot,
+    ) = normalized_plan_from_validation(validation)
+    repo_root = Path(str(snapshot.get("repo_root", ""))).resolve()
+    expected_head = str(snapshot.get("head_commit", "")).strip()
+    if repo_root.exists() and expected_head:
+        current_head = run_git(repo_root, ["rev-parse", "HEAD"])
+        if current_head != expected_head:
+            raise RuntimeError("stale context: repository HEAD changed since validation snapshot")
+
+    resolved_state_file = state_file or Path(str(snapshot.get("state_file", ""))).resolve()
+    original_text: dict[str, str] = {}
+    current_text: dict[str, str] = {}
+    action_results: list[dict[str, Any]] = []
+    for action in deterministic_actions:
+        relpath = normalize_relpath(str(action.get("path") or ""))
+        text = load_file_text(repo_root, relpath, original_text, current_text)
+        updated, action_result = apply_action_to_text(text, action)
+        store_file_text(relpath, updated, current_text)
+        action_results.append(action_result)
+
+    file_mutations: list[dict[str, Any]] = []
+    changed_doc_paths: list[str] = []
+    for relpath, updated in current_text.items():
+        original = original_text[relpath]
+        if updated == original:
+            continue
+        absolute_path = relpath_to_abs(repo_root, relpath)
+        file_mutations.append({"type": "write", "path": str(absolute_path), "target_kind": "repo-doc"})
+        changed_doc_paths.append(relpath)
+        if not dry_run:
+            absolute_path.write_text(updated, encoding="utf-8")
+
+    marker = build_marker(snapshot, normalized_plan, resolved_state_file) if can_update_marker else None
+    marker_written = False
+    if marker is not None and not dry_run:
+        write_json(resolved_state_file, marker)
+        marker_written = True
+
+    normalized_actions = normalized_plan.get("actions", [])
+    validation_stop_reasons = [str(item) for item in validation.get("stop_reasons", []) if str(item).strip()]
+    mutations = file_mutations[:]
+    if marker is not None and not dry_run:
+        mutations.append({"type": "write", "path": str(resolved_state_file), "target_kind": "last-success-marker"})
+    return {
+        "skill_name": "public-docs-sync",
+        "context_id": snapshot.get("context_id"),
+        "dry_run": dry_run,
+        "validation_source": "validator_normalized_plan",
+        "normalized_plan_fingerprint": normalized_plan_fingerprint,
+        "apply_succeeded": True,
+        "mutation_type": "public-docs-sync",
+        "state_file": str(resolved_state_file),
+        "marker_update_attempted": can_update_marker,
+        "marker_update_written": marker_written,
+        "marker_written": marker_written,
+        "can_update_marker": can_update_marker,
+        "action_count": len(normalized_actions),
+        "deterministic_edit_count": len(deterministic_actions),
+        "manual_review_count": len(manual_review_actions),
+        "doc_edit_count": len(changed_doc_paths),
+        "changed_doc_paths": changed_doc_paths,
+        "mutations": [] if dry_run else mutations,
+        "message": (
+            "Applied validated deterministic public-doc edits and wrote the success marker."
+            if marker_written
+            else "Applied validated deterministic public-doc edits without advancing the success marker."
+        ),
+        "marker_preview": marker,
+        "stop_reasons": validation_stop_reasons,
+        "normalized_actions": normalized_actions,
+        "deterministic_actions": deterministic_actions,
+        "manual_review_actions": manual_review_actions,
+        "action_results": action_results,
+        "apply_context_snapshot": snapshot,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    validation = load_json(Path(args.validation).resolve())
+    state_file = Path(args.state_file).resolve() if args.state_file else None
+    result = apply_validated_plan(validation, dry_run=args.dry_run, state_file=state_file)
+    if args.result_output:
+        write_json(Path(args.result_output).resolve(), result)
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/build_public_docs_sync_packets.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/build_public_docs_sync_packets.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Build focused packets for public-docs-sync from collected context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from public_docs_sync_contract import (
+    ARCHETYPE,
+    DECISION_READY_PACKETS,
+    ORCHESTRATOR_PROFILE,
+    PACKET_NAMES,
+    PACKET_WORKER_MAP,
+    PREFERRED_WORKER_FAMILIES,
+    RAW_REREAD_ALLOWED_REASONS,
+    REVIEW_MODE_OVERRIDES,
+    WORKER_OUTPUT_SHAPE,
+    WORKER_RETURN_CONTRACT,
+    WORKER_SELECTION_GUIDANCE,
+    WORKFLOW_FAMILY,
+    XHIGH_REREAD_POLICY,
+    compute_packet_metrics,
+    dedupe_preserve,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--lint", help="Optional lint findings JSON.")
+    parser.add_argument("--output-dir", required=True, help="Packet output directory.")
+    parser.add_argument("--result-output", help="Optional build result JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def next_mode(mode: str) -> str:
+    order = ["local-only", "targeted-delegation", "broad-delegation"]
+    return order[min(order.index(mode) + 1, len(order) - 1)]
+
+
+def truthy_override_signals(context: dict[str, Any], lint: dict[str, Any]) -> list[str]:
+    signals: list[str] = []
+    for payload in (context.get("override_signals", {}), lint.get("override_signals", {})):
+        if not isinstance(payload, dict):
+            continue
+        for name, value in payload.items():
+            if bool(value):
+                signals.append(str(name))
+    return dedupe_preserve(signals)
+
+
+def compute_review_mode(context: dict[str, Any], lint: dict[str, Any]) -> tuple[str, bool, list[str]]:
+    counts = context.get("counts", {})
+    active_packets = int(counts.get("active_packet_count", 0))
+    changed_files = int(counts.get("changed_files", 0))
+    doc_changes = int(counts.get("doc_changes", 0))
+    code_changes = int(counts.get("code_changes", 0))
+
+    mode = "local-only"
+    if active_packets >= 4 or changed_files > 20:
+        mode = "broad-delegation"
+    elif active_packets >= 2 or (doc_changes > 0 and code_changes > 0):
+        mode = "targeted-delegation"
+
+    applied_signals = truthy_override_signals(context, lint)
+    if applied_signals:
+        mode = next_mode(mode)
+    return mode, bool(applied_signals), applied_signals
+
+
+def routed_packet_names(active_packet_names: list[str], uses_batch_packets: bool) -> list[str]:
+    routed = []
+    for packet_name in active_packet_names:
+        if packet_name == "forms_batch_packet" and uses_batch_packets:
+            routed.append("batch-packet-01")
+        else:
+            routed.append(packet_name)
+    return routed
+
+
+def recommended_workers(
+    packet_names: list[str],
+    review_mode: str,
+) -> list[dict[str, str]]:
+    if review_mode == "local-only":
+        return []
+    max_workers = 2 if review_mode == "targeted-delegation" else 4
+    workers: list[dict[str, str]] = []
+    for packet_name in packet_names[:max_workers]:
+        agent_types = PACKET_WORKER_MAP.get(packet_name) or ["docs_verifier"]
+        agent_type = agent_types[0]
+        workers.append(
+            {
+                "name": packet_name,
+                "agent_type": agent_type,
+                "packet": f"{packet_name}.json",
+                "instruction": "Read global_packet.json first, stay narrow, and return only evidence-backed doc drift or sync gaps.",
+            }
+        )
+    return workers
+
+
+def optional_workers(
+    review_mode: str,
+    recommended: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    if review_mode != "broad-delegation":
+        return []
+    chosen = {item["agent_type"] for item in recommended}
+    remaining = dedupe_preserve(
+        [
+            *PREFERRED_WORKER_FAMILIES["context_findings"],
+            *PREFERRED_WORKER_FAMILIES["candidate_producers"],
+            *PREFERRED_WORKER_FAMILIES["verifiers"],
+        ]
+    )
+    optional: list[dict[str, Any]] = []
+    for agent_type in remaining:
+        if agent_type in chosen:
+            continue
+        optional.append(
+            {
+                "name": agent_type,
+                "agent_type": agent_type,
+                "packets": ["global_packet.json"],
+                "responsibility": WORKER_SELECTION_GUIDANCE["agent_type_guidance"].get(agent_type, ""),
+                "reasoning_effort": "low",
+            }
+        )
+    return optional
+
+
+def lint_issues_for_packet(lint: dict[str, Any], packet_name: str) -> list[dict[str, Any]]:
+    return [
+        issue
+        for issue in lint.get("issues", [])
+        if issue.get("packet") == packet_name
+    ]
+
+
+def doc_summaries(context: dict[str, Any], packet: dict[str, Any]) -> list[dict[str, Any]]:
+    inventory = context.get("public_doc_inventory", {})
+    summaries: list[dict[str, Any]] = []
+    for relpath in packet.get("review_docs", []):
+        entry = inventory.get(relpath, {})
+        summaries.append(
+            {
+                "path": relpath,
+                "exists": entry.get("exists", False),
+                "kind": entry.get("kind"),
+                "sha256": entry.get("sha256"),
+                "headings": entry.get("headings", []),
+                "preview_lines": entry.get("preview_lines", []),
+                "issue_form": entry.get("issue_form"),
+                "publish_configuration": entry.get("publish_configuration"),
+                "settings_table": entry.get("settings_table"),
+            }
+        )
+    return summaries
+
+
+def changed_summaries(context: dict[str, Any], packet: dict[str, Any]) -> list[dict[str, Any]]:
+    inventory = context.get("changed_path_summaries", {})
+    summaries: list[dict[str, Any]] = []
+    for relpath in packet.get("changed_paths", []):
+        entry = inventory.get(relpath, {})
+        summaries.append(
+            {
+                "path": relpath,
+                "kind": entry.get("kind"),
+                "exists": entry.get("exists"),
+                "preview_lines": entry.get("preview_lines", []),
+                "headings": entry.get("headings", []),
+            }
+        )
+    return summaries
+
+
+def github_evidence_slice(context: dict[str, Any], packet_name: str) -> dict[str, Any]:
+    evidence = context.get("github_evidence", {})
+    summary = context.get("evidence_summary", {})
+    artifacts = [
+        artifact
+        for artifact in evidence.get("artifacts", [])
+        if packet_name in artifact.get("packet_hints", [])
+    ]
+    return {
+        "required": bool(context.get("github_evidence_required")),
+        "auth_policy": evidence.get("auth_policy"),
+        "packet_signals": summary.get("packet_signals", {}).get(packet_name, []),
+        "artifacts": artifacts,
+        "evidence_urls": [artifact.get("url") for artifact in artifacts if artifact.get("url")],
+    }
+
+
+def packet_basis(lint: dict[str, Any], packet_name: str) -> dict[str, Any]:
+    basis = (lint.get("packet_basis") or {}).get(packet_name) or {}
+    return {
+        "deterministic_action_candidates": list(basis.get("deterministic_action_candidates") or []),
+        "manual_review_residuals": list(basis.get("manual_review_residuals") or []),
+        "marker_gate_signals": dict(basis.get("marker_gate_signals") or {}),
+    }
+
+
+def ownership_summary(packet_name: str, packet: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "packet": packet_name,
+        "packet_kind": packet.get("packet_kind", "focused"),
+        "review_docs": packet.get("review_docs", []),
+        "changed_paths": packet.get("changed_paths", []),
+        "direct_doc_changes": packet.get("direct_doc_changes", []),
+        "direct_source_changes": packet.get("direct_source_changes", []),
+        "activation_reasons": packet.get("activation_reasons", []),
+    }
+
+
+def build_packet_payload(
+    context: dict[str, Any],
+    lint: dict[str, Any],
+    packet_name: str,
+    packet: dict[str, Any],
+) -> dict[str, Any]:
+    basis = packet_basis(lint, packet_name)
+    marker_gate_signals = basis["marker_gate_signals"] or {
+        "marker_blocked_by_packet": False,
+        "blocking_reasons": [],
+        "manual_review_residual_count": len(basis["manual_review_residuals"]),
+        "deterministic_candidate_count": len(basis["deterministic_action_candidates"]),
+    }
+    return {
+        "packet_id": packet_name,
+        "packet_kind": packet.get("packet_kind", "focused"),
+        "active": bool(packet.get("active")),
+        "context_id": context.get("context_id"),
+        "baseline_mode": context.get("baseline", {}).get("mode"),
+        "relevant_ref": context.get("relevant_ref"),
+        "activation_reasons": packet.get("activation_reasons", []),
+        "ownership_summary": ownership_summary(packet_name, packet),
+        "review_docs": packet.get("review_docs", []),
+        "changed_paths": packet.get("changed_paths", []),
+        "direct_doc_changes": packet.get("direct_doc_changes", []),
+        "direct_source_changes": packet.get("direct_source_changes", []),
+        "doc_summaries": doc_summaries(context, packet),
+        "changed_path_summaries": changed_summaries(context, packet),
+        "github_evidence_slice": github_evidence_slice(context, packet_name),
+        "lint_issues": lint_issues_for_packet(lint, packet_name),
+        "deterministic_action_candidates": basis["deterministic_action_candidates"],
+        "manual_review_residuals": basis["manual_review_residuals"],
+        "marker_gate_signals": marker_gate_signals,
+        "deterministic_apply_boundaries": context.get("deterministic_apply_boundaries", {}),
+    }
+
+
+def build_batch_packet(
+    context: dict[str, Any],
+    lint: dict[str, Any],
+    packet: dict[str, Any],
+) -> dict[str, Any]:
+    basis = packet_basis(lint, "forms_batch_packet")
+    return {
+        "packet_id": "batch-packet-01",
+        "packet_kind": "batch",
+        "active": True,
+        "context_id": context.get("context_id"),
+        "ownership_summary": ownership_summary("forms_batch_packet", packet),
+        "packet_targets": packet.get("review_docs", []),
+        "lint_issues": lint_issues_for_packet(lint, "forms_batch_packet"),
+        "deterministic_action_candidates": basis["deterministic_action_candidates"],
+        "manual_review_residuals": basis["manual_review_residuals"],
+        "marker_gate_signals": basis["marker_gate_signals"],
+        "github_evidence_slice": github_evidence_slice(context, "forms_batch_packet"),
+        "note": "Review affected public issue forms as one grouped docs surface.",
+    }
+
+
+def build_result_payload(
+    *,
+    review_mode: str,
+    applied_override_signals: list[str],
+    active_packet_names: list[str],
+    recommended: list[dict[str, str]],
+    selected_packets: list[str],
+    packet_order: list[str],
+    packet_metrics: dict[str, int],
+    lint: dict[str, Any],
+    uses_batch_packets: bool,
+) -> dict[str, Any]:
+    return {
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended),
+        "recommended_workers": recommended,
+        "selected_packets": selected_packets,
+        "packet_order": packet_order,
+        "active_packets": active_packet_names,
+        "active_packet_count": len(active_packet_names),
+        "uses_batch_packets": uses_batch_packets,
+        "applied_override_signals": applied_override_signals,
+        "auto_apply_candidate_count": len(lint.get("auto_apply_candidates", [])),
+        "packet_metrics": packet_metrics,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    lint = load_json(Path(args.lint).resolve()) if args.lint else {}
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    packet_candidates = context.get("packet_candidates", {})
+    active_packet_names = [
+        name
+        for name in PACKET_NAMES
+        if packet_candidates.get(name, {}).get("active")
+    ]
+    review_mode, override_applied, applied_override_signals = compute_review_mode(context, lint)
+    uses_batch_packets = bool(
+        packet_candidates.get("forms_batch_packet", {}).get("active")
+        and len(packet_candidates.get("forms_batch_packet", {}).get("review_docs", [])) > 1
+    )
+    selected_packets = [f"{name}.json" for name in active_packet_names]
+    if uses_batch_packets:
+        selected_packets.append("batch-packet-01.json")
+
+    routed_packets = routed_packet_names(active_packet_names, uses_batch_packets)
+    recommended = recommended_workers(routed_packets, review_mode)
+    packet_order = ["global_packet.json", *selected_packets]
+
+    orchestrator = {
+        "skill_name": context.get("skill_name"),
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "orchestrator_profile": ORCHESTRATOR_PROFILE,
+        "review_mode": review_mode,
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": PACKET_WORKER_MAP,
+        "worker_selection_guidance": WORKER_SELECTION_GUIDANCE,
+        "uses_batch_packets": uses_batch_packets,
+        "recommended_worker_count": len(recommended),
+        "recommended_workers": recommended,
+        "optional_workers": optional_workers(review_mode, recommended),
+        "local_responsibilities": [
+            "read global_packet.json and active focused packets",
+            "decide deterministic vs manual public-doc drift",
+            "keep marker updates blocked when manual narrative review remains",
+            "respect the fail-closed GitHub evidence policy before using remote claims",
+            "persist the last-success marker only after doc updates are done",
+        ],
+        "shared_packet": "global_packet.json",
+        "packet_order": packet_order,
+        "selected_packets": selected_packets,
+        "applied_override_signals": applied_override_signals,
+        "override_applied": override_applied,
+        "xhigh_reread_policy": XHIGH_REREAD_POLICY,
+        "raw_reread_allowed_reasons": RAW_REREAD_ALLOWED_REASONS,
+    }
+
+    global_packet = {
+        "skill_name": context.get("skill_name"),
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "orchestrator_profile": ORCHESTRATOR_PROFILE,
+        "primary_goal": "Keep public docs synchronized with runtime defaults, shipped metadata, and recent changes.",
+        "authority_order": context.get("authority_order", []),
+        "stop_conditions": context.get("stop_conditions", []),
+        "review_mode_overrides": REVIEW_MODE_OVERRIDES,
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": PACKET_WORKER_MAP,
+        "worker_selection_guidance": WORKER_SELECTION_GUIDANCE,
+        "xhigh_reread_policy": XHIGH_REREAD_POLICY,
+        "raw_reread_allowed_reasons": RAW_REREAD_ALLOWED_REASONS,
+        "context_id": context.get("context_id"),
+        "context_fingerprint": context.get("context_fingerprint"),
+        "repo_root": context.get("repo_root"),
+        "baseline": context.get("baseline"),
+        "relevant_ref": context.get("relevant_ref"),
+        "github_evidence_required": bool(context.get("github_evidence_required")),
+        "github_evidence_urls": context.get("evidence_summary", {}).get("urls", []),
+        "github_auth_policy": context.get("github_evidence", {}).get("auth_policy"),
+        "counts": context.get("counts", {}),
+        "active_packets": active_packet_names,
+        "selected_packets": selected_packets,
+        "lint_summary": {
+            "error_count": len(lint.get("errors", [])),
+            "warning_count": len(lint.get("warnings", [])),
+            "info_count": len(lint.get("infos", [])),
+        },
+        "deterministic_apply_boundaries": context.get("deterministic_apply_boundaries", {}),
+        "last_success_policy": "The last-success marker is baseline-only state; it is never a facts source for the docs narrative.",
+        "notes": context.get("notes", []),
+    }
+
+    packet_payloads: dict[str, dict[str, Any]] = {
+        "orchestrator.json": orchestrator,
+        "global_packet.json": global_packet,
+    }
+    write_json(output_dir / "orchestrator.json", orchestrator)
+    write_json(output_dir / "global_packet.json", global_packet)
+
+    for packet_name in PACKET_NAMES:
+        payload = build_packet_payload(context, lint, packet_name, packet_candidates.get(packet_name, {}))
+        if not payload["active"]:
+            payload["activation_reasons"] = payload.get("activation_reasons", []) + ["packet inactive for this run"]
+        write_json(output_dir / f"{packet_name}.json", payload)
+        if payload["active"]:
+            packet_payloads[f"{packet_name}.json"] = payload
+
+    if uses_batch_packets:
+        batch_payload = build_batch_packet(context, lint, packet_candidates["forms_batch_packet"])
+        write_json(output_dir / "batch-packet-01.json", batch_payload)
+        packet_payloads["batch-packet-01.json"] = batch_payload
+
+    packet_metrics = compute_packet_metrics(
+        packet_payloads,
+        local_only_sources={
+            "context.json": context,
+            "lint.json": lint,
+        },
+    )
+    write_json(output_dir / "packet_metrics.json", packet_metrics)
+
+    if args.result_output:
+        build_result = build_result_payload(
+            review_mode=review_mode,
+            applied_override_signals=applied_override_signals,
+            active_packet_names=active_packet_names,
+            recommended=recommended,
+            selected_packets=selected_packets,
+            packet_order=packet_order,
+            packet_metrics=packet_metrics,
+            lint=lint,
+            uses_batch_packets=uses_batch_packets,
+        )
+        write_json(Path(args.result_output).resolve(), build_result)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/collect_public_docs_sync_context.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/collect_public_docs_sync_context.py
@@ -1,0 +1,2044 @@
+#!/usr/bin/env python3
+"""Collect structured workflow context for public-docs-sync."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+
+SKILL_NAME = "public-docs-sync"
+SKILL_VERSION = "0.2.0"
+WORKFLOW_FAMILY = "repo-audit"
+ARCHETYPE = "audit-and-apply"
+GITHUB_AUTH_POLICY = "fail-closed"
+DEFAULT_AUTHORITY_ORDER = [
+    "tracked runtime and shipped metadata",
+    "tracked public docs and public workflow templates",
+    "selected GitHub PR or discussion evidence for the relevant change unit",
+    "structured workflow packets",
+    "local last-success state",
+]
+DEFAULT_STOP_CONDITIONS = [
+    "low confidence",
+    "stale snapshot or stale context",
+    "ambiguous packet or ownership match",
+    "unreachable saved baseline",
+    "GitHub evidence is required but gh auth is invalid",
+    "narrative-only drift that exceeds deterministic apply boundaries",
+]
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+SETTING_PROPERTY_RE = re.compile(
+    r"public\s+(?P<type>\w+)\s+(?P<name>\w+)\s*\{[^}]*\}(?:\s*=\s*(?P<value>[^;]+)\s*;)?",
+    re.MULTILINE,
+)
+SET_DEFAULTS_BODY_RE = re.compile(
+    r"public\s+override\s+void\s+SetDefaults\(\)\s*\{(?P<body>.*?)\n\s*\}",
+    re.DOTALL,
+)
+SET_DEFAULTS_ASSIGN_RE = re.compile(r"(?P<name>\w+)\s*=\s*(?P<value>[^;]+);")
+LOCALE_TEXT_RE = re.compile(
+    r'GetOption(?P<kind>Label|Desc)LocaleID\(nameof\(Setting\.(?P<name>\w+)\)\),\s*"(?P<text>(?:[^"\\]|\\.)*)"'
+)
+README_TABLE_ROW_RE = re.compile(
+    r"^\|\s*`(?P<name>[^`]+)`\s*\|\s*`?(?P<default>[^|`]+)`?\s*\|\s*(?P<purpose>.+?)\s*\|\s*$"
+)
+GENERATED_PATH_RE = re.compile(
+    r"(^|/)(bin|obj|dist|build|coverage|generated|gen|out|artifacts)/|"
+    r"\.(g|generated)\.[^.]+$|"
+    r"\.designer\.[^.]+$",
+    re.IGNORECASE,
+)
+MERGE_PR_SUBJECT_RE = re.compile(r"^Merge pull request #(?P<number>\d+) from (?P<head>[^\s]+)\s*$")
+DISCUSSION_URL_RE = re.compile(
+    r"https://github\.com/(?P<slug>[^/\s]+/[^/\s]+)/discussions/(?P<number>\d+)",
+    re.IGNORECASE,
+)
+REPO_SLUG_RE = re.compile(r"github\.com[:/](?P<slug>[^/]+/[^/]+?)(?:\.git)?$", re.IGNORECASE)
+PACKET_KEYWORDS = {
+    "claims_packet": [
+        "setting",
+        "default",
+        "compatibility",
+        "behavior",
+        "readme",
+        "release copy",
+        "version",
+        "shipped",
+    ],
+    "reporting_packet": [
+        "telemetry",
+        "diagnostic",
+        "diagnostics",
+        "performance",
+        "perf",
+        "log",
+        "logs",
+        "report",
+        "reporting",
+        "investigation",
+        "evidence",
+        "triage",
+    ],
+    "workflow_packet": [
+        "workflow",
+        "contributing",
+        "maintaining",
+        "pull request",
+        "release",
+        "automation",
+        "checklist",
+        "template",
+    ],
+    "forms_batch_packet": [
+        "issue form",
+        "issue template",
+        "bug report",
+        "feature request",
+        "investigation form",
+        "release checklist",
+    ],
+}
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise SystemExit(f"[ERROR] Missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise SystemExit("[ERROR] Repo profile must be a JSON object.")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def repo_profile_bindings(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    bindings = repo_profile.get("bindings")
+    return bindings if isinstance(bindings, dict) else {}
+
+
+def public_docs_profile_extra(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    extra_root = repo_profile.get("extra")
+    if not isinstance(extra_root, dict):
+        return {}
+    extra = extra_root.get("public_docs_sync")
+    return extra if isinstance(extra, dict) else {}
+
+
+def packet_defaults(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    defaults = repo_profile.get("packet_defaults")
+    return defaults if isinstance(defaults, dict) else {}
+
+
+def packet_review_doc_config(repo_profile: dict[str, Any]) -> dict[str, list[str]]:
+    review_docs = packet_defaults(repo_profile).get("review_docs")
+    if not isinstance(review_docs, dict):
+        return {}
+    return {
+        str(packet): [normalize_path(item) for item in items if str(item or "").strip()]
+        for packet, items in review_docs.items()
+        if isinstance(items, list)
+    }
+
+
+def packet_source_globs(repo_profile: dict[str, Any]) -> dict[str, list[str]]:
+    source_globs = packet_defaults(repo_profile).get("source_path_globs")
+    if not isinstance(source_globs, dict):
+        return {}
+    return {
+        str(packet): [normalize_path(item) for item in items if str(item or "").strip()]
+        for packet, items in source_globs.items()
+        if isinstance(items, list)
+    }
+
+
+def issue_template_groups(repo_profile: dict[str, Any]) -> dict[str, set[str]]:
+    groups = public_docs_profile_extra(repo_profile).get("issue_template_groups")
+    if not isinstance(groups, dict):
+        return {"reporting": set(), "workflow": set()}
+    return {
+        "reporting": {
+            str(name).strip()
+            for name in groups.get("reporting", [])
+            if str(name or "").strip()
+        },
+        "workflow": {
+            str(name).strip()
+            for name in groups.get("workflow", [])
+            if str(name or "").strip()
+        },
+    }
+
+
+def configured_public_doc_inventory(repo_profile: dict[str, Any]) -> list[str]:
+    inventory = public_docs_profile_extra(repo_profile).get("audited_public_doc_inventory")
+    if not isinstance(inventory, list):
+        return []
+    return [normalize_path(item) for item in inventory if str(item or "").strip()]
+
+
+def configured_state_namespace(repo_profile: dict[str, Any]) -> str:
+    state = public_docs_profile_extra(repo_profile).get("state")
+    if not isinstance(state, dict):
+        return SKILL_NAME
+    text = str(state.get("namespace") or "").strip()
+    return text or SKILL_NAME
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True, help="Repository root to inspect.")
+    parser.add_argument("--output", required=True, help="Output JSON path.")
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained neutral scaffold."
+        ),
+    )
+    parser.add_argument("--full", action="store_true", help="Ignore saved state and audit the full public surface.")
+    parser.add_argument(
+        "--since-ref",
+        help="Explicit git ref to diff against for this run. Overrides saved state for the run.",
+    )
+    parser.add_argument(
+        "--state-file",
+        help="Optional override for the last-success marker JSON path.",
+    )
+    return parser.parse_args()
+
+
+def normalize_path(value: str | Path) -> str:
+    return str(value).replace("\\", "/")
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def run_command(
+    args: list[str],
+    cwd: Path,
+    *,
+    check: bool = True,
+    stdin_text: str | None = None,
+) -> str:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        input=stdin_text,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"{args[0]} failed"
+        raise RuntimeError(detail)
+    return result.stdout
+
+
+def run_git(repo_root: Path, args: list[str], *, check: bool = True) -> str:
+    return run_command(["git", *args], repo_root, check=check)
+
+
+def run_gh_json(
+    repo_root: Path,
+    args: list[str],
+    *,
+    stdin_text: str | None = None,
+) -> Any:
+    output = run_command(["gh", *args], repo_root, stdin_text=stdin_text)
+    text = output.strip()
+    return json.loads(text) if text else {}
+
+
+def resolve_repo_root(repo_root: str) -> Path:
+    requested = Path(repo_root).resolve()
+    if not requested.exists():
+        raise SystemExit(f"[ERROR] Missing repo root: {requested}")
+    try:
+        actual = run_git(requested, ["rev-parse", "--show-toplevel"]).strip()
+    except RuntimeError as exc:
+        raise SystemExit(f"[ERROR] {requested} is not inside a git repository: {exc}") from exc
+    return Path(actual).resolve()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def file_exists(repo_root: Path, relpath: str) -> bool:
+    return (repo_root / Path(relpath)).exists()
+
+
+def read_text_file(repo_root: Path, relpath: str) -> str:
+    return (repo_root / Path(relpath)).read_text(encoding="utf-8", errors="replace")
+
+
+def extract_headings(text: str) -> list[str]:
+    return [match.group(2).strip() for match in MARKDOWN_HEADING_RE.finditer(text)]
+
+
+def parse_scalar_text(raw: str) -> str:
+    text = raw.strip().strip("`").strip().rstrip(",")
+    lower = text.lower()
+    if lower in {"true", "false"}:
+        return lower
+    trimmed = re.sub(r"[fFdDmM]$", "", text)
+    try:
+        if "." in trimmed or "e" in trimmed.lower():
+            value = float(trimmed)
+            if value.is_integer():
+                return str(int(value))
+            return format(value, ".12g")
+        return str(int(trimmed))
+    except ValueError:
+        return text
+
+
+def parse_csharp_string(raw: str) -> str:
+    text = raw.encode("utf-8").decode("unicode_escape")
+    return text.strip()
+
+
+def parse_setting_defaults(setting_text: str) -> dict[str, dict[str, Any]]:
+    defaults_from_properties: dict[str, dict[str, Any]] = {}
+    for match in SETTING_PROPERTY_RE.finditer(setting_text):
+        name = match.group("name")
+        defaults_from_properties[name] = {
+            "type": match.group("type"),
+            "default": parse_scalar_text(match.group("value")) if match.group("value") else None,
+        }
+
+    defaults_from_method: dict[str, str] = {}
+    body_match = SET_DEFAULTS_BODY_RE.search(setting_text)
+    if body_match:
+        for match in SET_DEFAULTS_ASSIGN_RE.finditer(body_match.group("body")):
+            defaults_from_method[match.group("name")] = parse_scalar_text(match.group("value"))
+
+    labels: dict[str, str] = {}
+    descriptions: dict[str, str] = {}
+    for match in LOCALE_TEXT_RE.finditer(setting_text):
+        bucket = labels if match.group("kind") == "Label" else descriptions
+        bucket[match.group("name")] = parse_csharp_string(match.group("text"))
+
+    merged: dict[str, dict[str, Any]] = {}
+    for name, info in defaults_from_properties.items():
+        merged[name] = {
+            "type": info["type"],
+            "default": defaults_from_method.get(name, info["default"]),
+            "label": labels.get(name),
+            "description": descriptions.get(name),
+        }
+    return merged
+
+
+def parse_readme_settings_table(readme_text: str) -> dict[str, dict[str, str]]:
+    rows: dict[str, dict[str, str]] = {}
+    in_table = False
+    for line in readme_text.splitlines():
+        if line.strip() == "| Setting | Default | Purpose |":
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if line.strip().startswith("| ---"):
+            continue
+        if not line.strip().startswith("|"):
+            break
+        match = README_TABLE_ROW_RE.match(line)
+        if not match:
+            continue
+        rows[match.group("name")] = {
+            "default": parse_scalar_text(match.group("default")),
+            "raw_default": match.group("default").strip(),
+            "purpose": match.group("purpose").strip(),
+        }
+    return rows
+
+
+def parse_publish_configuration(publish_text: str) -> dict[str, Any]:
+    root = ET.fromstring(publish_text)
+
+    def read_attr(tag_name: str, attr_name: str = "Value") -> str | None:
+        element = root.find(tag_name)
+        return element.attrib.get(attr_name) if element is not None else None
+
+    def read_block_lines(tag_name: str) -> list[str]:
+        element = root.find(tag_name)
+        if element is None:
+            return []
+        text = "".join(element.itertext())
+        return [line.strip() for line in text.splitlines() if line.strip()]
+
+    return {
+        "display_name": read_attr("DisplayName"),
+        "short_description": read_attr("ShortDescription"),
+        "mod_version": read_attr("ModVersion"),
+        "game_version": read_attr("GameVersion"),
+        "long_description_lines": read_block_lines("LongDescription"),
+        "change_log_lines": read_block_lines("ChangeLog"),
+    }
+
+
+def parse_issue_form_metadata(text: str) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key in ("name", "description", "title", "labels"):
+        match = re.search(rf"^{key}:\s*(.+)$", text, re.MULTILINE)
+        if not match:
+            continue
+        value = match.group(1).strip()
+        if key == "labels" and value.startswith("[") and value.endswith("]"):
+            labels = [
+                part.strip().strip('"').strip("'")
+                for part in value[1:-1].split(",")
+                if part.strip()
+            ]
+            metadata[key] = labels
+        else:
+            metadata[key] = value.strip('"').strip("'")
+    return metadata
+
+
+def classify_text_kind(relpath: str) -> str:
+    lower = relpath.lower()
+    if lower.endswith(".md"):
+        return "markdown"
+    if lower.endswith((".yml", ".yaml")):
+        return "yaml"
+    if lower.endswith(".xml"):
+        return "xml"
+    if lower.endswith(".cs"):
+        return "code"
+    return "text"
+
+
+def scan_relative_links(repo_root: Path, relpath: str, text: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    links: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    parent = (repo_root / Path(relpath)).parent
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        target = match.group(1).strip()
+        if not target or target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        if target.startswith(("app://", "plugin://")):
+            continue
+        base_target = target.split("#", 1)[0]
+        candidate = (parent / Path(base_target)).resolve()
+        try:
+            normalized_target = normalize_path(candidate.relative_to(repo_root))
+            within_repo = True
+        except ValueError:
+            normalized_target = normalize_path(candidate)
+            within_repo = False
+        entry = {
+            "source_path": relpath,
+            "target": target,
+            "resolved_path": normalized_target,
+            "within_repo": within_repo,
+            "exists": within_repo and candidate.exists(),
+        }
+        links.append(entry)
+        if not entry["exists"]:
+            missing.append(entry)
+    return links, missing
+
+
+def summarize_file(repo_root: Path, relpath: str, *, publish_config_path: str | None = None) -> dict[str, Any]:
+    path = repo_root / Path(relpath)
+    summary: dict[str, Any] = {
+        "path": relpath,
+        "exists": path.exists(),
+        "kind": classify_text_kind(relpath),
+    }
+    if not path.exists():
+        return summary
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    summary.update(
+        {
+            "sha256": "sha256:" + sha256_text(text),
+            "line_count": len(text.splitlines()),
+            "preview_lines": text.splitlines()[:12],
+        }
+    )
+    links, missing_links = scan_relative_links(repo_root, relpath, text)
+    summary["relative_links"] = links
+    summary["missing_links"] = missing_links
+
+    if summary["kind"] == "markdown":
+        summary["headings"] = extract_headings(text)
+        if relpath == "README.md":
+            summary["settings_table"] = parse_readme_settings_table(text)
+    elif relpath.endswith(".yml") or relpath.endswith(".yaml"):
+        summary["issue_form"] = parse_issue_form_metadata(text)
+    elif publish_config_path and relpath == normalize_path(publish_config_path):
+        summary["publish_configuration"] = parse_publish_configuration(text)
+
+    return summary
+
+
+def discover_issue_template_paths(repo_root: Path) -> list[str]:
+    issue_dir = repo_root / ".github" / "ISSUE_TEMPLATE"
+    if not issue_dir.is_dir():
+        return []
+    paths = [
+        normalize_path(path.relative_to(repo_root))
+        for path in issue_dir.glob("*.yml")
+        if path.is_file()
+    ]
+    return sorted(dict.fromkeys(paths))
+
+
+def collect_public_doc_paths(repo_root: Path, repo_profile: dict[str, Any]) -> list[str]:
+    discovered = configured_public_doc_inventory(repo_profile) + discover_issue_template_paths(repo_root)
+    return sorted(dict.fromkeys(discovered))
+
+
+def infer_repo_slug(remote_url: str) -> str | None:
+    match = REPO_SLUG_RE.search(remote_url.strip())
+    return match.group("slug") if match else None
+
+
+def repo_identity(repo_root: Path) -> dict[str, str]:
+    remote = run_git(repo_root, ["config", "--get", "remote.origin.url"], check=False).strip()
+    repo_id = remote or normalize_path(repo_root)
+    repo_hash = sha256_text(repo_id)[:16]
+    repo_slug = infer_repo_slug(remote)
+    return {
+        "repo_id": repo_id,
+        "repo_hash": repo_hash,
+        "remote_url": remote or "",
+        "repo_slug": repo_slug or "",
+        "repo_name": repo_root.name,
+    }
+
+
+def default_state_file(repo_hash: str, repo_profile: dict[str, Any] | None = None) -> Path:
+    active_profile = repo_profile or load_repo_profile(default_repo_profile_path())
+    namespace = configured_state_namespace(active_profile)
+    return Path.home() / ".codex" / "state" / namespace / f"{repo_hash}.json"
+
+
+def git_head_commit(repo_root: Path) -> str:
+    return run_git(repo_root, ["rev-parse", "HEAD"]).strip()
+
+
+def git_branch(repo_root: Path) -> str | None:
+    branch = run_git(repo_root, ["branch", "--show-current"], check=False).strip()
+    return branch or None
+
+
+def git_ref_exists(repo_root: Path, ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def git_ref_to_commit(repo_root: Path, ref: str) -> str:
+    try:
+        return run_git(repo_root, ["rev-parse", f"{ref}^{{commit}}"]).strip()
+    except RuntimeError as exc:
+        raise SystemExit(f"[ERROR] Invalid --since-ref `{ref}`: {exc}") from exc
+
+
+def commit_exists(repo_root: Path, commit: str) -> bool:
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def commit_is_ancestor(repo_root: Path, older: str, newer: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", older, newer],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def git_merge_base(repo_root: Path, left: str, right: str) -> str | None:
+    try:
+        return run_git(repo_root, ["merge-base", left, right]).strip() or None
+    except RuntimeError:
+        return None
+
+
+def git_commit_subject(repo_root: Path, commit: str = "HEAD") -> str:
+    return run_git(repo_root, ["show", "-s", "--format=%s", commit], check=False).strip()
+
+
+def git_commit_parents(repo_root: Path, commit: str) -> list[str]:
+    output = run_git(repo_root, ["rev-list", "--parents", "-n", "1", commit], check=False).strip()
+    if not output:
+        return []
+    parts = output.split()
+    return parts[1:]
+
+
+def git_tracking_branch(repo_root: Path, branch: str | None) -> str | None:
+    if not branch:
+        return None
+    output = run_git(repo_root, ["rev-parse", "--abbrev-ref", f"{branch}@{{upstream}}"], check=False).strip()
+    return output or None
+
+
+def git_default_remote_branch(repo_root: Path) -> str | None:
+    output = run_git(repo_root, ["symbolic-ref", "refs/remotes/origin/HEAD"], check=False).strip()
+    return output.replace("refs/remotes/", "", 1) if output else None
+
+
+def collect_status_paths(repo_root: Path) -> list[str]:
+    output = run_git(repo_root, ["status", "--porcelain=v1", "--untracked-files=all"], check=False)
+    paths: list[str] = []
+    for line in output.splitlines():
+        if not line or line.startswith("## "):
+            continue
+        raw_path = line[3:].strip()
+        if " -> " in raw_path:
+            left, right = raw_path.split(" -> ", 1)
+            paths.extend([normalize_path(left), normalize_path(right)])
+        else:
+            paths.append(normalize_path(raw_path))
+    return sorted(dict.fromkeys(paths))
+
+
+def collect_diff_paths(repo_root: Path, base_commit: str) -> list[str]:
+    output = run_git(repo_root, ["diff", "--name-only", f"{base_commit}..HEAD"], check=False)
+    paths = [normalize_path(line.strip()) for line in output.splitlines() if line.strip()]
+    return sorted(dict.fromkeys(paths))
+
+
+def forms_doc_paths(public_doc_paths: list[str]) -> list[str]:
+    return [path for path in public_doc_paths if path.startswith(".github/ISSUE_TEMPLATE/")]
+
+
+def is_generated_path(relpath: str) -> bool:
+    return bool(GENERATED_PATH_RE.search(relpath))
+
+
+def path_matches_any_glob(relpath: str, patterns: list[str]) -> bool:
+    normalized = normalize_path(relpath)
+    return any(fnmatch(normalized, normalize_path(pattern)) for pattern in patterns)
+
+
+def packet_for_path(relpath: str, public_doc_paths: list[str], repo_profile: dict[str, Any]) -> set[str]:
+    packets: set[str] = set()
+    form_paths = set(forms_doc_paths(public_doc_paths))
+    groups = issue_template_groups(repo_profile)
+    review_doc_map = packet_review_doc_config(repo_profile)
+    source_glob_map = packet_source_globs(repo_profile)
+    reporting_forms = {path for path in form_paths if Path(path).name in groups["reporting"]}
+    workflow_forms = {path for path in form_paths if Path(path).name in groups["workflow"]}
+
+    if relpath in form_paths:
+        packets.add("forms_batch_packet")
+        if relpath in reporting_forms:
+            packets.add("reporting_packet")
+        if relpath in workflow_forms:
+            packets.add("workflow_packet")
+
+    for packet_name, review_docs in review_doc_map.items():
+        if relpath in review_docs:
+            packets.add(packet_name)
+    for packet_name, patterns in source_glob_map.items():
+        if path_matches_any_glob(relpath, patterns):
+            packets.add(packet_name)
+
+    return packets
+
+
+def packet_review_docs(public_doc_paths: list[str], repo_profile: dict[str, Any]) -> dict[str, list[str]]:
+    configured = packet_review_doc_config(repo_profile)
+    form_paths = forms_doc_paths(public_doc_paths)
+    result = {
+        "claims_packet": [path for path in configured.get("claims_packet", []) if path in public_doc_paths],
+        "reporting_packet": [path for path in configured.get("reporting_packet", []) if path in public_doc_paths],
+        "workflow_packet": [path for path in configured.get("workflow_packet", []) if path in public_doc_paths],
+        "forms_batch_packet": form_paths,
+    }
+    if configured.get("forms_batch_packet"):
+        result["forms_batch_packet"] = [
+            path for path in configured["forms_batch_packet"] if path in public_doc_paths
+        ] or form_paths
+    return result
+
+
+def connection_nodes(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        nodes = value.get("nodes")
+        if isinstance(nodes, list):
+            return nodes
+    return []
+
+
+def clip_text(value: Any, limit: int = 180) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def stable_dedupe(items: list[Any]) -> list[Any]:
+    seen: set[str] = set()
+    result: list[Any] = []
+    for item in items:
+        key = json.dumps(item, sort_keys=True, ensure_ascii=True) if not isinstance(item, str) else item
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(item)
+    return result
+
+
+def normalize_comment(raw: dict[str, Any], artifact_type: str, artifact_id: str) -> dict[str, Any]:
+    author = raw.get("author") or {}
+    return {
+        "artifact_type": artifact_type,
+        "artifact_id": artifact_id,
+        "author": str(author.get("login") or author.get("name") or raw.get("authorLogin") or "").strip() or None,
+        "created_at": raw.get("createdAt") or raw.get("created_at"),
+        "updated_at": raw.get("updatedAt") or raw.get("updated_at"),
+        "url": raw.get("url"),
+        "body": str(raw.get("body") or raw.get("bodyText") or "").strip(),
+    }
+
+
+def normalize_file_entries(raw: Any) -> list[dict[str, Any]]:
+    items = connection_nodes(raw)
+    results: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, str):
+            results.append({"path": normalize_path(item), "additions": None, "deletions": None})
+            continue
+        if not isinstance(item, dict):
+            continue
+        path = str(item.get("path") or item.get("name") or "").strip()
+        if not path:
+            continue
+        results.append(
+            {
+                "path": normalize_path(path),
+                "additions": item.get("additions"),
+                "deletions": item.get("deletions"),
+            }
+        )
+    return stable_dedupe(results)
+
+
+def normalize_review_summary(raw_reviews: Any, review_decision: Any) -> dict[str, Any]:
+    reviews = connection_nodes(raw_reviews)
+    states: dict[str, int] = {}
+    normalized_reviews: list[dict[str, Any]] = []
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        state = str(review.get("state") or "").strip() or "UNKNOWN"
+        states[state] = states.get(state, 0) + 1
+        author = review.get("author") or {}
+        normalized_reviews.append(
+            {
+                "state": state,
+                "author": author.get("login") or author.get("name"),
+                "submitted_at": review.get("submittedAt"),
+                "url": review.get("url"),
+                "body_excerpt": clip_text(review.get("body")),
+            }
+        )
+    return {
+        "review_decision": review_decision,
+        "state_counts": states,
+        "latest_reviews": normalized_reviews[-5:],
+    }
+
+
+def digest_comments(comments: list[dict[str, Any]], limit: int = 3) -> list[dict[str, Any]]:
+    ordered = sorted(
+        comments,
+        key=lambda item: (
+            str(item.get("updated_at") or ""),
+            str(item.get("created_at") or ""),
+            str(item.get("url") or ""),
+        ),
+    )
+    digests: list[dict[str, Any]] = []
+    for item in ordered[-limit:]:
+        digests.append(
+            {
+                "artifact_type": item.get("artifact_type"),
+                "artifact_id": item.get("artifact_id"),
+                "author": item.get("author"),
+                "updated_at": item.get("updated_at") or item.get("created_at"),
+                "url": item.get("url"),
+                "body_excerpt": clip_text(item.get("body")),
+            }
+        )
+    return digests
+
+
+def ensure_gh_auth(repo_root: Path) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            cwd=repo_root,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "stdout": "",
+            "stderr": "gh not found",
+        }
+    return {
+        "ok": result.returncode == 0,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def require_gh_auth(repo_root: Path) -> dict[str, Any]:
+    status = ensure_gh_auth(repo_root)
+    if status["ok"]:
+        return status
+    detail = status["stderr"] or status["stdout"] or "gh auth status failed"
+    raise SystemExit(
+        "[ERROR] GitHub evidence is required for this run but gh auth is invalid. "
+        f"Run `gh auth login` first. Detail: {detail}"
+    )
+
+
+def parse_owner_repo(repo_slug: str) -> tuple[str, str]:
+    owner, name = repo_slug.split("/", 1)
+    return owner, name
+
+
+def build_candidate(
+    *,
+    kind: str,
+    label: str,
+    source: str,
+    base_commit: str | None,
+    head_commit: str | None,
+    selection_reason: str,
+    primary_pr_number: int | None = None,
+    primary_pr_url: str | None = None,
+    base_ref: str | None = None,
+    head_ref: str | None = None,
+    requires_github_evidence: bool = False,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "label": label,
+        "source": source,
+        "base_commit": base_commit,
+        "head_commit": head_commit,
+        "selection_reason": selection_reason,
+        "primary_pr_number": primary_pr_number,
+        "primary_pr_url": primary_pr_url,
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "requires_github_evidence": requires_github_evidence,
+        "metadata": metadata or {},
+    }
+
+
+def annotate_candidate(candidate: dict[str, Any], *, selected: bool, rejected_reason: str | None = None) -> dict[str, Any]:
+    payload = dict(candidate)
+    payload["selected"] = selected
+    payload["usable"] = selected or rejected_reason is None
+    payload["rejected_reason"] = rejected_reason
+    return payload
+
+
+def build_baseline(
+    repo_root: Path,
+    args: argparse.Namespace,
+    state_file: Path,
+    identity: dict[str, str],
+    head_commit: str,
+    branch: str | None,
+) -> dict[str, Any]:
+    if args.full:
+        return {
+            "mode": "full",
+            "status": "full_requested",
+            "base_commit": None,
+            "requested_ref": None,
+            "state_file": normalize_path(state_file),
+            "saved_marker": None,
+            "fallback_reason": None,
+        }
+
+    if args.since_ref:
+        base_commit = git_ref_to_commit(repo_root, args.since_ref)
+        return {
+            "mode": "since-ref",
+            "status": "explicit_ref",
+            "base_commit": base_commit,
+            "requested_ref": args.since_ref,
+            "state_file": normalize_path(state_file),
+            "saved_marker": None,
+            "fallback_reason": None,
+        }
+
+    if not state_file.exists():
+        return {
+            "mode": "saved-marker-unavailable",
+            "status": "missing_saved_marker",
+            "base_commit": None,
+            "requested_ref": None,
+            "state_file": normalize_path(state_file),
+            "saved_marker": None,
+            "fallback_reason": "missing_saved_marker",
+        }
+
+    marker = load_json(state_file)
+    marker_commit = str(marker.get("head_commit", "")).strip()
+    marker_repo_id = str(marker.get("repo_id", "")).strip()
+    marker_repo_slug = str(marker.get("repo_slug", "")).strip()
+    marker_branch = str(marker.get("branch", "")).strip() or None
+    marker_relevant_ref = marker.get("relevant_ref") or {}
+    relevant_base = str(marker_relevant_ref.get("base_commit") or "").strip()
+    relevant_head = str(marker_relevant_ref.get("head_commit") or "").strip()
+    stale_reason = None
+
+    if marker_repo_id and marker_repo_id != identity["repo_id"]:
+        stale_reason = "repo_identity_mismatch"
+    elif marker_repo_slug and identity["repo_slug"] and marker_repo_slug != identity["repo_slug"]:
+        stale_reason = "repo_slug_mismatch"
+    elif not marker_commit:
+        stale_reason = "missing_marker_commit"
+    elif not commit_exists(repo_root, marker_commit):
+        stale_reason = "unreachable_saved_baseline"
+    elif not commit_is_ancestor(repo_root, marker_commit, head_commit):
+        stale_reason = "non_ancestor_saved_baseline"
+    elif marker_branch and branch and marker_branch != branch:
+        stale_reason = "branch_changed_since_last_success"
+    elif relevant_base and not commit_exists(repo_root, relevant_base):
+        stale_reason = "relevant_ref_base_unreachable"
+    elif relevant_head and not commit_exists(repo_root, relevant_head):
+        stale_reason = "relevant_ref_head_unreachable"
+    elif relevant_head and not commit_is_ancestor(repo_root, relevant_head, head_commit):
+        stale_reason = "relevant_ref_head_not_ancestor"
+
+    if stale_reason:
+        return {
+            "mode": "saved-marker-unavailable",
+            "status": "saved_marker_stale",
+            "base_commit": None,
+            "requested_ref": None,
+            "state_file": normalize_path(state_file),
+            "saved_marker": marker,
+            "fallback_reason": stale_reason,
+        }
+
+    return {
+        "mode": "saved-marker",
+        "status": "saved_marker_usable",
+        "base_commit": marker_commit,
+        "requested_ref": None,
+        "state_file": normalize_path(state_file),
+        "saved_marker": marker,
+        "fallback_reason": None,
+    }
+
+
+def head_merge_pr_candidate(repo_root: Path, head_commit: str) -> dict[str, Any] | None:
+    subject = git_commit_subject(repo_root, head_commit)
+    match = MERGE_PR_SUBJECT_RE.match(subject)
+    if not match:
+        return None
+    parents = git_commit_parents(repo_root, head_commit)
+    if len(parents) < 2:
+        return None
+    pr_number = int(match.group("number"))
+    return build_candidate(
+        kind="merged-pr",
+        label=f"PR #{pr_number}",
+        source="head-merge-commit",
+        base_commit=parents[0],
+        head_commit=head_commit,
+        selection_reason="HEAD is a merge commit for a pull request; use its first-parent range as the relevant unit.",
+        primary_pr_number=pr_number,
+        head_ref=match.group("head"),
+        requires_github_evidence=True,
+        metadata={"merge_commit": head_commit},
+    )
+
+
+def latest_merged_pr_candidate_in_range(repo_root: Path, base_commit: str, head_commit: str) -> dict[str, Any] | None:
+    if base_commit == head_commit:
+        return None
+    output = run_git(
+        repo_root,
+        ["log", "--first-parent", "--merges", "--format=%H%x09%s", f"{base_commit}..{head_commit}"],
+        check=False,
+    )
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        commit, _, subject = line.partition("\t")
+        match = MERGE_PR_SUBJECT_RE.match(subject.strip())
+        if not match:
+            continue
+        parents = git_commit_parents(repo_root, commit)
+        if len(parents) < 2:
+            continue
+        pr_number = int(match.group("number"))
+        return build_candidate(
+            kind="merged-pr",
+            label=f"PR #{pr_number}",
+            source="saved-marker-range",
+            base_commit=parents[0],
+            head_commit=commit,
+            selection_reason="The saved-marker range contains a merged pull request; use the latest merged PR as the primary evidence unit.",
+            primary_pr_number=pr_number,
+            head_ref=match.group("head"),
+            requires_github_evidence=True,
+            metadata={"merge_commit": commit, "range_base": base_commit},
+        )
+    return None
+
+
+def load_current_branch_pr_candidate(
+    repo_root: Path,
+    repo_slug: str,
+    branch: str | None,
+    head_commit: str,
+) -> dict[str, Any] | None:
+    if not branch:
+        return None
+    require_gh_auth(repo_root)
+    try:
+        payload = run_gh_json(
+            repo_root,
+            [
+                "pr",
+                "view",
+                branch,
+                "--repo",
+                repo_slug,
+                "--json",
+                "number,title,url,baseRefName,baseRefOid,headRefName,headRefOid,state",
+            ],
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+        if "no pull requests found" in message.lower():
+            return None
+        raise
+
+    base_ref = str(payload.get("baseRefName") or "").strip() or None
+    head_ref = str(payload.get("headRefName") or "").strip() or branch
+    merge_base = None
+    for candidate_ref in [
+        str(payload.get("baseRefOid") or "").strip(),
+        base_ref or "",
+        f"origin/{base_ref}" if base_ref else "",
+    ]:
+        if not candidate_ref:
+            continue
+        merge_base = git_merge_base(repo_root, candidate_ref, head_commit)
+        if merge_base:
+            break
+    if not merge_base:
+        merge_base = git_head_commit(repo_root)
+
+    return build_candidate(
+        kind="current-branch-pr",
+        label=f"PR #{payload.get('number')}",
+        source="current-branch-open-pr",
+        base_commit=merge_base,
+        head_commit=str(payload.get("headRefOid") or head_commit),
+        selection_reason="The current branch has an open pull request; use the PR base/head range as the relevant unit.",
+        primary_pr_number=int(payload.get("number")),
+        primary_pr_url=str(payload.get("url") or "") or None,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        requires_github_evidence=True,
+    )
+
+
+def merge_base_candidate(
+    repo_root: Path,
+    branch: str | None,
+    head_commit: str,
+) -> dict[str, Any] | None:
+    tracking = git_tracking_branch(repo_root, branch)
+    default_remote = git_default_remote_branch(repo_root)
+    candidate_refs = [tracking, default_remote]
+    for extra in ("origin/master", "origin/main", "origin/develop", "master", "main", "develop"):
+        candidate_refs.append(extra)
+    seen: set[str] = set()
+    for ref in candidate_refs:
+        if not ref or ref in seen:
+            continue
+        seen.add(ref)
+        if not git_ref_exists(repo_root, ref):
+            continue
+        merge_base = git_merge_base(repo_root, ref, head_commit)
+        if not merge_base:
+            continue
+        return build_candidate(
+            kind="git-merge-base",
+            label=f"{ref}...HEAD",
+            source="git-merge-base",
+            base_commit=merge_base,
+            head_commit=head_commit,
+            selection_reason="No merged PR or open PR was selected; use the current branch versus its upstream/default merge-base range.",
+            base_ref=ref,
+            requires_github_evidence=False,
+        )
+    return None
+
+
+def select_relevant_ref(
+    repo_root: Path,
+    identity: dict[str, str],
+    args: argparse.Namespace,
+    baseline: dict[str, Any],
+    head_commit: str,
+    branch: str | None,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    candidates: list[dict[str, Any]] = []
+
+    if args.full:
+        selected = build_candidate(
+            kind="full-audit",
+            label="full public-doc audit",
+            source="explicit-full",
+            base_commit=None,
+            head_commit=head_commit,
+            selection_reason="The caller requested a full audit.",
+            requires_github_evidence=False,
+        )
+        return selected, [annotate_candidate(selected, selected=True)]
+
+    if args.since_ref and baseline.get("base_commit"):
+        selected = build_candidate(
+            kind="explicit-ref",
+            label=args.since_ref,
+            source="explicit-since-ref",
+            base_commit=baseline["base_commit"],
+            head_commit=head_commit,
+            selection_reason="The caller supplied --since-ref, which overrides saved state for this run.",
+            requires_github_evidence=False,
+        )
+        return selected, [annotate_candidate(selected, selected=True)]
+
+    if baseline.get("mode") == "saved-marker" and baseline.get("base_commit"):
+        merged_candidate = latest_merged_pr_candidate_in_range(repo_root, baseline["base_commit"], head_commit)
+        saved_range_candidate = build_candidate(
+            kind="saved-marker-range",
+            label=f"{baseline['base_commit'][:12]}..{head_commit[:12]}",
+            source="saved-marker",
+            base_commit=baseline["base_commit"],
+            head_commit=head_commit,
+            selection_reason="A reusable saved marker exists; use its range unless a newer merged PR or open PR provides a tighter evidence unit.",
+            requires_github_evidence=False,
+        )
+        if merged_candidate:
+            candidates.append(annotate_candidate(merged_candidate, selected=True))
+            candidates.append(annotate_candidate(saved_range_candidate, selected=False, rejected_reason="superseded_by_latest_merged_pr"))
+            return merged_candidate, candidates
+
+        current_pr_candidate = None
+        if identity["repo_slug"]:
+            current_pr_candidate = load_current_branch_pr_candidate(repo_root, identity["repo_slug"], branch, head_commit)
+        if current_pr_candidate:
+            candidates.append(annotate_candidate(current_pr_candidate, selected=True))
+            candidates.append(annotate_candidate(saved_range_candidate, selected=False, rejected_reason="superseded_by_current_branch_pr"))
+            return current_pr_candidate, candidates
+
+        candidates.append(annotate_candidate(saved_range_candidate, selected=True))
+        return saved_range_candidate, candidates
+
+    merged_head_candidate = head_merge_pr_candidate(repo_root, head_commit)
+    if merged_head_candidate:
+        candidates.append(annotate_candidate(merged_head_candidate, selected=True))
+        return merged_head_candidate, candidates
+
+    if identity["repo_slug"]:
+        current_pr_candidate = load_current_branch_pr_candidate(repo_root, identity["repo_slug"], branch, head_commit)
+        if current_pr_candidate:
+            candidates.append(annotate_candidate(current_pr_candidate, selected=True))
+            return current_pr_candidate, candidates
+
+    merge_base_fallback = merge_base_candidate(repo_root, branch, head_commit)
+    if merge_base_fallback:
+        candidates.append(annotate_candidate(merge_base_fallback, selected=True))
+        return merge_base_fallback, candidates
+
+    full_fallback = build_candidate(
+        kind="full-audit",
+        label="full public-doc audit",
+        source="auto-fallback-full",
+        base_commit=None,
+        head_commit=head_commit,
+        selection_reason="No saved marker, PR-backed unit, or merge-base range was usable; fall back to a full audit.",
+        requires_github_evidence=False,
+    )
+    candidates.append(annotate_candidate(full_fallback, selected=True))
+    return full_fallback, candidates
+
+
+def collect_discussion_refs(text: str, repo_slug: str) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for match in DISCUSSION_URL_RE.finditer(text or ""):
+        if match.group("slug").lower() != repo_slug.lower():
+            continue
+        refs.append(
+            {
+                "repo_slug": repo_slug,
+                "number": int(match.group("number")),
+                "url": f"https://github.com/{repo_slug}/discussions/{match.group('number')}",
+            }
+        )
+    return stable_dedupe(refs)
+
+
+def packet_hints_from_text(text: str) -> set[str]:
+    lower = text.lower()
+    packets: set[str] = set()
+    for packet_name, keywords in PACKET_KEYWORDS.items():
+        if any(keyword in lower for keyword in keywords):
+            packets.add(packet_name)
+    return packets
+
+
+def packet_hints_from_paths(
+    paths: list[str],
+    public_doc_paths: list[str],
+    repo_profile: dict[str, Any],
+) -> set[str]:
+    packets: set[str] = set()
+    for path in paths:
+        packets.update(packet_for_path(path, public_doc_paths, repo_profile))
+    return packets
+
+
+def build_artifact_summary(title: str | None, body: str | None, comment_digests: list[dict[str, Any]]) -> str:
+    pieces: list[str] = []
+    if title:
+        pieces.append(clip_text(title, 100))
+    if body:
+        pieces.append(clip_text(body, 120))
+    if comment_digests:
+        pieces.append("latest comment: " + clip_text(comment_digests[-1].get("body_excerpt"), 120))
+    return " | ".join(piece for piece in pieces if piece)
+
+
+def gather_pr_evidence(repo_root: Path, repo_slug: str, pr_number: int) -> dict[str, Any]:
+    payload = run_gh_json(
+        repo_root,
+        [
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo_slug,
+            "--json",
+            ",".join(
+                [
+                    "number",
+                    "title",
+                    "body",
+                    "url",
+                    "baseRefName",
+                    "baseRefOid",
+                    "headRefName",
+                    "headRefOid",
+                    "changedFiles",
+                    "files",
+                    "closingIssuesReferences",
+                    "comments",
+                    "latestReviews",
+                    "reviewDecision",
+                    "mergedAt",
+                    "updatedAt",
+                    "mergeCommit",
+                ]
+            ),
+        ],
+    )
+    comments = [
+        normalize_comment(item, "pull_request", f"PR #{pr_number}")
+        for item in connection_nodes(payload.get("comments"))
+        if isinstance(item, dict)
+    ]
+    comment_digests = digest_comments(comments)
+    files = normalize_file_entries(payload.get("files"))
+    review_summary = normalize_review_summary(payload.get("latestReviews"), payload.get("reviewDecision"))
+    linked_issues = connection_nodes(payload.get("closingIssuesReferences"))
+    return {
+        "number": payload.get("number"),
+        "title": payload.get("title"),
+        "body": payload.get("body"),
+        "url": payload.get("url"),
+        "base_ref": payload.get("baseRefName"),
+        "base_oid": payload.get("baseRefOid"),
+        "head_ref": payload.get("headRefName"),
+        "head_oid": payload.get("headRefOid"),
+        "changed_files_count": payload.get("changedFiles"),
+        "files": files,
+        "linked_issues": linked_issues,
+        "comments": comment_digests,
+        "review_summary": review_summary,
+        "merged_at": payload.get("mergedAt"),
+        "updated_at": payload.get("updatedAt"),
+    }
+
+
+def gather_issue_evidence(repo_root: Path, repo_slug: str, issue_number: int) -> dict[str, Any]:
+    payload = run_gh_json(
+        repo_root,
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo_slug,
+            "--json",
+            "number,title,body,url,state,labels,comments,updatedAt",
+        ],
+    )
+    comments = [
+        normalize_comment(item, "issue", f"Issue #{issue_number}")
+        for item in connection_nodes(payload.get("comments"))
+        if isinstance(item, dict)
+    ]
+    labels = []
+    for label in connection_nodes(payload.get("labels")):
+        if isinstance(label, dict):
+            name = str(label.get("name") or "").strip()
+            if name:
+                labels.append(name)
+        elif isinstance(label, str) and label.strip():
+            labels.append(label.strip())
+    return {
+        "number": payload.get("number"),
+        "title": payload.get("title"),
+        "body": payload.get("body"),
+        "url": payload.get("url"),
+        "state": payload.get("state"),
+        "labels": labels,
+        "updated_at": payload.get("updatedAt"),
+        "comments": digest_comments(comments),
+    }
+
+
+def gather_discussion_evidence(repo_root: Path, repo_slug: str, discussion_number: int) -> dict[str, Any]:
+    owner, name = parse_owner_repo(repo_slug)
+    query = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    discussion(number: $number) {
+      number
+      title
+      body
+      url
+      updatedAt
+      category {
+        name
+      }
+      comments(last: 10) {
+        nodes {
+          author {
+            login
+          }
+          body
+          url
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+}
+"""
+    payload = run_gh_json(
+        repo_root,
+        [
+            "api",
+            "graphql",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={discussion_number}",
+            "-f",
+            f"query={query}",
+        ],
+    )
+    discussion = (((payload.get("data") or {}).get("repository") or {}).get("discussion") or {})
+    comments = [
+        normalize_comment(item, "discussion", f"Discussion #{discussion_number}")
+        for item in connection_nodes(discussion.get("comments"))
+        if isinstance(item, dict)
+    ]
+    return {
+        "number": discussion.get("number"),
+        "title": discussion.get("title"),
+        "body": discussion.get("body"),
+        "url": discussion.get("url"),
+        "updated_at": discussion.get("updatedAt"),
+        "category": (discussion.get("category") or {}).get("name"),
+        "comments": digest_comments(comments),
+    }
+
+
+def build_artifact_entry(
+    *,
+    artifact_type: str,
+    identifier: str,
+    title: str | None,
+    body: str | None,
+    url: str | None,
+    comment_digests: list[dict[str, Any]],
+    changed_paths: list[str],
+    public_doc_paths: list[str],
+    repo_profile: dict[str, Any],
+) -> dict[str, Any]:
+    comment_text = " ".join(str(item.get("body_excerpt") or "") for item in comment_digests)
+    packet_hints = packet_hints_from_paths(changed_paths, public_doc_paths, repo_profile)
+    packet_hints.update(packet_hints_from_text(" ".join([title or "", body or "", comment_text])))
+    return {
+        "artifact_type": artifact_type,
+        "identifier": identifier,
+        "url": url,
+        "title": title,
+        "changed_paths": changed_paths,
+        "packet_hints": sorted(packet_hints),
+        "summary": build_artifact_summary(title, body, comment_digests),
+        "comment_digests": comment_digests,
+    }
+
+
+def collect_github_evidence(
+    repo_root: Path,
+    identity: dict[str, str],
+    relevant_ref: dict[str, Any],
+    public_doc_paths: list[str],
+    repo_profile: dict[str, Any],
+) -> dict[str, Any]:
+    required = bool(relevant_ref.get("requires_github_evidence"))
+    evidence = {
+        "enabled": False,
+        "auth_policy": GITHUB_AUTH_POLICY,
+        "required": required,
+        "auth_status": None,
+        "repo_slug": identity["repo_slug"] or None,
+        "primary_pr": None,
+        "related_issues": [],
+        "related_discussions": [],
+        "artifacts": [],
+        "comment_digests": [],
+        "evidence_urls": [],
+        "fetch_errors": [],
+        "digest": None,
+    }
+    if not identity["repo_slug"]:
+        if required:
+            raise SystemExit(
+                "[ERROR] The selected relevant ref requires GitHub evidence, but the repository slug could not be inferred."
+            )
+        return evidence
+
+    if not evidence["required"]:
+        return evidence
+
+    evidence["auth_status"] = require_gh_auth(repo_root)
+    pr_number = relevant_ref.get("primary_pr_number")
+    if not pr_number:
+        raise SystemExit("[ERROR] The selected relevant ref requires GitHub evidence, but no primary PR number was available.")
+
+    pr = gather_pr_evidence(repo_root, identity["repo_slug"], int(pr_number))
+    evidence["enabled"] = True
+    evidence["primary_pr"] = pr
+    if pr.get("url"):
+        evidence["evidence_urls"].append(pr.get("url"))
+
+    pr_files = [entry.get("path") for entry in pr.get("files", []) if entry.get("path")]
+    pr_artifact = build_artifact_entry(
+        artifact_type="pull_request",
+        identifier=f"PR #{pr.get('number')}",
+        title=pr.get("title"),
+        body=pr.get("body"),
+        url=pr.get("url"),
+        comment_digests=pr.get("comments", []),
+        changed_paths=pr_files,
+        public_doc_paths=public_doc_paths,
+        repo_profile=repo_profile,
+    )
+    evidence["artifacts"].append(pr_artifact)
+    evidence["comment_digests"].extend(pr_artifact["comment_digests"])
+
+    discussion_refs = collect_discussion_refs(
+        " ".join(
+            filter(
+                None,
+                [str(pr.get("body") or "")] + [str(item.get("body_excerpt") or "") for item in pr.get("comments", [])],
+            )
+        ),
+        identity["repo_slug"],
+    )
+    for linked_issue in connection_nodes(pr.get("linked_issues")):
+        if not isinstance(linked_issue, dict):
+            continue
+        issue_number = linked_issue.get("number")
+        if issue_number is None:
+            continue
+        issue = gather_issue_evidence(repo_root, identity["repo_slug"], int(issue_number))
+        evidence["related_issues"].append(issue)
+        if issue.get("url"):
+            evidence["evidence_urls"].append(issue.get("url"))
+        issue_artifact = build_artifact_entry(
+            artifact_type="issue",
+            identifier=f"Issue #{issue.get('number')}",
+            title=issue.get("title"),
+            body=issue.get("body"),
+            url=issue.get("url"),
+            comment_digests=issue.get("comments", []),
+            changed_paths=[],
+            public_doc_paths=public_doc_paths,
+            repo_profile=repo_profile,
+        )
+        evidence["artifacts"].append(issue_artifact)
+        evidence["comment_digests"].extend(issue_artifact["comment_digests"])
+        discussion_refs.extend(
+            collect_discussion_refs(
+                " ".join(
+                    filter(
+                        None,
+                        [str(issue.get("body") or "")] + [str(item.get("body_excerpt") or "") for item in issue.get("comments", [])],
+                    )
+                ),
+                identity["repo_slug"],
+            )
+        )
+
+    for ref in stable_dedupe(discussion_refs):
+        try:
+            discussion = gather_discussion_evidence(repo_root, identity["repo_slug"], int(ref["number"]))
+        except RuntimeError as exc:
+            evidence["fetch_errors"].append(
+                {
+                    "artifact_type": "discussion",
+                    "number": ref["number"],
+                    "url": ref["url"],
+                    "message": str(exc),
+                }
+            )
+            continue
+        evidence["related_discussions"].append(discussion)
+        if discussion.get("url"):
+            evidence["evidence_urls"].append(discussion.get("url"))
+        discussion_artifact = build_artifact_entry(
+            artifact_type="discussion",
+            identifier=f"Discussion #{discussion.get('number')}",
+            title=discussion.get("title"),
+            body=discussion.get("body"),
+            url=discussion.get("url"),
+            comment_digests=discussion.get("comments", []),
+            changed_paths=[],
+            public_doc_paths=public_doc_paths,
+            repo_profile=repo_profile,
+        )
+        evidence["artifacts"].append(discussion_artifact)
+        evidence["comment_digests"].extend(discussion_artifact["comment_digests"])
+
+    evidence["comment_digests"] = stable_dedupe(evidence["comment_digests"])
+    evidence["evidence_urls"] = [url for url in stable_dedupe([url for url in evidence["evidence_urls"] if url])]
+    evidence["digest"] = "sha256:" + sha256_text(
+        json.dumps(
+            {
+                "primary_pr": evidence["primary_pr"],
+                "related_issues": evidence["related_issues"],
+                "related_discussions": evidence["related_discussions"],
+                "artifacts": evidence["artifacts"],
+            },
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+    )
+    return evidence
+
+
+def build_evidence_summary(github_evidence: dict[str, Any]) -> dict[str, Any]:
+    packet_signals: dict[str, list[str]] = {
+        "claims_packet": [],
+        "reporting_packet": [],
+        "workflow_packet": [],
+        "forms_batch_packet": [],
+    }
+    for artifact in github_evidence.get("artifacts", []):
+        message = f"{artifact.get('identifier')}: {artifact.get('summary')}".strip()
+        for packet_name in artifact.get("packet_hints", []):
+            if packet_name in packet_signals and message not in packet_signals[packet_name]:
+                packet_signals[packet_name].append(message)
+    return {
+        "packet_signals": packet_signals,
+        "artifact_count": len(github_evidence.get("artifacts", [])),
+        "comment_count": len(github_evidence.get("comment_digests", [])),
+        "urls": github_evidence.get("evidence_urls", []),
+    }
+
+
+def build_packet_candidates(
+    audit_target_paths: list[str],
+    public_doc_paths: list[str],
+    audit_mode: str,
+    github_summary: dict[str, Any],
+    repo_profile: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    review_docs = packet_review_docs(public_doc_paths, repo_profile)
+    packets: dict[str, dict[str, Any]] = {
+        "claims_packet": {
+            "packet_id": "claims_packet",
+            "packet_kind": "focused",
+            "review_docs": review_docs["claims_packet"],
+            "changed_paths": [],
+            "direct_doc_changes": [],
+            "direct_source_changes": [],
+            "activation_reasons": [],
+            "active": False,
+        },
+        "reporting_packet": {
+            "packet_id": "reporting_packet",
+            "packet_kind": "focused",
+            "review_docs": review_docs["reporting_packet"],
+            "changed_paths": [],
+            "direct_doc_changes": [],
+            "direct_source_changes": [],
+            "activation_reasons": [],
+            "active": False,
+        },
+        "workflow_packet": {
+            "packet_id": "workflow_packet",
+            "packet_kind": "focused",
+            "review_docs": review_docs["workflow_packet"],
+            "changed_paths": [],
+            "direct_doc_changes": [],
+            "direct_source_changes": [],
+            "activation_reasons": [],
+            "active": False,
+        },
+        "forms_batch_packet": {
+            "packet_id": "forms_batch_packet",
+            "packet_kind": "batch",
+            "review_docs": review_docs["forms_batch_packet"],
+            "changed_paths": [],
+            "direct_doc_changes": [],
+            "direct_source_changes": [],
+            "activation_reasons": [],
+            "active": False,
+        },
+    }
+
+    for relpath in audit_target_paths:
+        packet_names = packet_for_path(relpath, public_doc_paths, repo_profile)
+        for packet_name in packet_names:
+            packet = packets[packet_name]
+            packet["active"] = True
+            packet["changed_paths"].append(relpath)
+            bucket = "direct_doc_changes" if relpath in public_doc_paths else "direct_source_changes"
+            packet[bucket].append(relpath)
+
+    if packets["reporting_packet"]["active"] and packets["forms_batch_packet"]["review_docs"]:
+        packets["forms_batch_packet"]["active"] = True
+        packets["forms_batch_packet"]["activation_reasons"].append(
+            "reporting surfaces changed; related public issue forms should be reviewed."
+        )
+
+    for packet_name, packet in packets.items():
+        remote_signals = github_summary.get("packet_signals", {}).get(packet_name, [])
+        if remote_signals:
+            packet["active"] = True
+            packet["activation_reasons"].append(
+                "GitHub evidence references this docs surface: " + "; ".join(remote_signals[:2])
+            )
+        if packet["active"] and audit_mode == "full":
+            packet["activation_reasons"].append("full audit requested or auto-fallback required.")
+        if packet["direct_doc_changes"]:
+            packet["activation_reasons"].append(
+                "changed public docs: " + ", ".join(packet["direct_doc_changes"][:4])
+            )
+        if packet["direct_source_changes"]:
+            packet["activation_reasons"].append(
+                "changed runtime or workflow surfaces: " + ", ".join(packet["direct_source_changes"][:4])
+            )
+        if not packet["activation_reasons"] and packet["active"]:
+            packet["activation_reasons"].append("packet activated by public-doc ownership rules.")
+        packet["changed_paths"] = sorted(dict.fromkeys(packet["changed_paths"]))
+        packet["direct_doc_changes"] = sorted(dict.fromkeys(packet["direct_doc_changes"]))
+        packet["direct_source_changes"] = sorted(dict.fromkeys(packet["direct_source_changes"]))
+        packet["review_docs"] = sorted(dict.fromkeys(packet["review_docs"]))
+
+    return packets
+
+
+def build_context_fingerprint(
+    head_commit: str,
+    baseline: dict[str, Any],
+    relevant_ref: dict[str, Any],
+    audit_target_paths: list[str],
+    public_doc_inventory: dict[str, dict[str, Any]],
+    github_evidence_digest: str | None,
+) -> str:
+    parts = [
+        head_commit,
+        baseline.get("mode", ""),
+        baseline.get("base_commit") or "",
+        relevant_ref.get("kind", ""),
+        relevant_ref.get("base_commit") or "",
+        relevant_ref.get("head_commit") or "",
+        str(relevant_ref.get("primary_pr_number") or ""),
+        github_evidence_digest or "",
+    ]
+    for relpath in sorted(audit_target_paths):
+        parts.append(relpath)
+    for relpath in sorted(public_doc_inventory):
+        entry = public_doc_inventory[relpath]
+        parts.append(relpath)
+        parts.append(str(entry.get("sha256", "")))
+    return "sha256:" + sha256_text("\n".join(parts))
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = resolve_repo_root(args.repo_root)
+    profile_path = resolve_profile_path(args.profile, repo_root)
+    repo_profile = load_repo_profile(profile_path)
+    bindings = repo_profile_bindings(repo_profile)
+    publish_path = normalize_path(bindings.get("publish_config_path") or "")
+    identity = repo_identity(repo_root)
+    state_file = (
+        Path(args.state_file).resolve()
+        if args.state_file
+        else default_state_file(identity["repo_hash"], repo_profile)
+    )
+    head_commit = git_head_commit(repo_root)
+    branch = git_branch(repo_root)
+    public_doc_paths = collect_public_doc_paths(repo_root, repo_profile)
+    public_doc_inventory = {
+        relpath: summarize_file(repo_root, relpath, publish_config_path=publish_path)
+        for relpath in public_doc_paths
+    }
+
+    baseline = build_baseline(repo_root, args, state_file, identity, head_commit, branch)
+    relevant_ref, ref_candidates = select_relevant_ref(repo_root, identity, args, baseline, head_commit, branch)
+    effective_base_commit = baseline.get("base_commit") or relevant_ref.get("base_commit")
+    audit_mode = "full" if args.full or not effective_base_commit else "ref-range"
+
+    status_paths = collect_status_paths(repo_root)
+    diff_paths = collect_diff_paths(repo_root, effective_base_commit) if effective_base_commit else []
+    raw_changed_paths = sorted(dict.fromkeys(diff_paths + status_paths))
+
+    github_evidence = collect_github_evidence(repo_root, identity, relevant_ref, public_doc_paths, repo_profile)
+    evidence_summary = build_evidence_summary(github_evidence)
+
+    if audit_mode == "full":
+        audit_target_paths = sorted(dict.fromkeys(public_doc_paths + raw_changed_paths))
+        if not audit_target_paths:
+            audit_target_paths = public_doc_paths[:]
+    else:
+        audit_target_paths = [
+            path for path in raw_changed_paths if packet_for_path(path, public_doc_paths, repo_profile)
+        ]
+
+    unmapped_changed_paths = [
+        path for path in raw_changed_paths if path not in audit_target_paths
+    ]
+    changed_path_summaries = {
+        relpath: summarize_file(repo_root, relpath)
+        for relpath in audit_target_paths
+        if file_exists(repo_root, relpath)
+    }
+
+    setting_path = normalize_path(bindings.get("settings_source_path") or "")
+    readme_path = normalize_path(bindings.get("primary_readme_path") or "README.md")
+    settings = (
+        parse_setting_defaults(read_text_file(repo_root, setting_path))
+        if setting_path and file_exists(repo_root, setting_path)
+        else {}
+    )
+    readme_settings = public_doc_inventory.get(readme_path, {}).get("settings_table", {})
+    publish_info = public_doc_inventory.get(publish_path, {}).get("publish_configuration", {})
+
+    packet_candidates = build_packet_candidates(
+        audit_target_paths,
+        public_doc_paths,
+        audit_mode,
+        evidence_summary,
+        repo_profile,
+    )
+    active_packet_count = sum(1 for packet in packet_candidates.values() if packet["active"])
+    doc_changes = sum(1 for path in audit_target_paths if path in public_doc_paths)
+    code_changes = max(len(audit_target_paths) - doc_changes, 0)
+    generated_count = sum(1 for path in audit_target_paths if is_generated_path(path))
+    context_fingerprint = build_context_fingerprint(
+        head_commit,
+        baseline,
+        relevant_ref,
+        audit_target_paths,
+        public_doc_inventory,
+        github_evidence.get("digest"),
+    )
+
+    context = {
+        "skill_name": SKILL_NAME,
+        "skill_version": SKILL_VERSION,
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "context_id": f"{SKILL_NAME}:{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "repo_root": normalize_path(repo_root),
+        "repo_name": identity["repo_name"],
+        "repo_id": identity["repo_id"],
+        "repo_hash": identity["repo_hash"],
+        "remote_url": identity["remote_url"] or None,
+        "repo_slug": identity["repo_slug"] or None,
+        "branch": branch,
+        "head_commit": head_commit,
+        "repo_profile_name": repo_profile.get("name"),
+        "repo_profile_path": profile_path.as_posix(),
+        "repo_profile_summary": repo_profile.get("summary"),
+        "repo_profile": repo_profile,
+        "builder_compatibility": build_builder_compatibility(repo_profile),
+        "state_file": normalize_path(state_file),
+        "context_fingerprint": context_fingerprint,
+        "authority_order": DEFAULT_AUTHORITY_ORDER,
+        "stop_conditions": DEFAULT_STOP_CONDITIONS,
+        "baseline": baseline,
+        "relevant_ref": relevant_ref,
+        "ref_candidates": ref_candidates,
+        "effective_base_commit": effective_base_commit,
+        "audit_mode": audit_mode,
+        "git_changes": {
+            "status_paths": status_paths,
+            "diff_paths_since_base": diff_paths,
+            "raw_changed_paths": raw_changed_paths,
+        },
+        "audit_target_paths": audit_target_paths,
+        "unmapped_changed_paths": unmapped_changed_paths,
+        "public_doc_paths": public_doc_paths,
+        "public_doc_inventory": public_doc_inventory,
+        "changed_path_summaries": changed_path_summaries,
+        "settings": {
+            "source_path": setting_path,
+            "defaults": settings,
+        },
+        "readme": {
+            "path": readme_path,
+            "settings_table": readme_settings,
+            "headings": public_doc_inventory.get(readme_path, {}).get("headings", []),
+        },
+        "publish_configuration": {
+            "path": publish_path,
+            "fields": publish_info,
+        },
+        "github_evidence_required": bool(github_evidence.get("required")),
+        "github_evidence": github_evidence,
+        "github_evidence_digest": github_evidence.get("digest"),
+        "evidence_summary": evidence_summary,
+        "packet_candidates": packet_candidates,
+        "counts": {
+            "changed_files": len(audit_target_paths),
+            "task_packet_count": active_packet_count,
+            "batch_count": 1 if packet_candidates["forms_batch_packet"]["active"] else 0,
+            "active_packet_count": active_packet_count,
+            "public_doc_count": len(public_doc_paths),
+            "doc_changes": doc_changes,
+            "code_changes": code_changes,
+            "generated_changes": generated_count,
+            "github_artifact_count": evidence_summary.get("artifact_count", 0),
+            "github_comment_count": evidence_summary.get("comment_count", 0),
+        },
+        "override_signals": {
+            "high_churn": len(audit_target_paths) > 20,
+            "multi_group_core_files": sum(
+                1 for name, packet in packet_candidates.items()
+                if name != "forms_batch_packet" and packet["direct_source_changes"]
+            ) >= 2,
+            "generated_not_majority": generated_count > 0 and generated_count < len(audit_target_paths),
+            "github_evidence_scattered": evidence_summary.get("artifact_count", 0) >= 3,
+        },
+        "deterministic_apply_boundaries": {
+            "allowed": [
+                "settings table default sync",
+                "relative link fix",
+                "simple public doc list or reference sync",
+                "issue-template metadata sync",
+            ],
+            "blocked": [
+                "release status claim rewrite",
+                "investigation conclusion rewrite",
+                "evidence-strength or experiment-status prose rewrite",
+            ],
+        },
+        "notes": [
+            "Collector separates saved-marker reuse from relevant-ref selection so markerless runs can still narrow to a defensible change unit.",
+            f"GitHub evidence policy is {GITHUB_AUTH_POLICY}.",
+        ],
+    }
+
+    if baseline.get("fallback_reason"):
+        context["notes"].append(f"Saved baseline was unavailable: {baseline['fallback_reason']}.")
+    if relevant_ref.get("selection_reason"):
+        context["notes"].append("Selected relevant ref: " + relevant_ref["selection_reason"])
+    if github_evidence.get("enabled"):
+        context["notes"].append(
+            f"Collected GitHub evidence from {evidence_summary.get('artifact_count', 0)} artifact(s) tied to the selected change unit."
+        )
+    if unmapped_changed_paths:
+        context["notes"].append(
+            "Some changed paths were outside current public-doc ownership rules: "
+            + ", ".join(unmapped_changed_paths[:6])
+        )
+
+    if context["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(context["builder_compatibility"]), file=sys.stderr)
+    write_json(Path(args.output).resolve(), context)
+    print(json.dumps(context, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/lint_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/lint_public_docs_sync.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Run deterministic lint checks for public-docs-sync."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from public_docs_sync_contract import DETERMINISTIC_ACTION_ALIASES, PACKET_NAMES
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--output", required=True, help="Output lint JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def ensure_packet_basis(findings: dict[str, Any], packet: str | None) -> dict[str, Any] | None:
+    if not packet:
+        return None
+    packet_basis = findings.setdefault("packet_basis", {})
+    return packet_basis.setdefault(
+        packet,
+        {
+            "deterministic_action_candidates": [],
+            "manual_review_residuals": [],
+            "marker_gate_signals": {
+                "marker_blocked_by_packet": False,
+                "blocking_reasons": [],
+                "manual_review_residual_count": 0,
+                "deterministic_candidate_count": 0,
+            },
+        },
+    )
+
+
+def push_issue(
+    findings: dict[str, Any],
+    *,
+    classification: str,
+    packet: str | None,
+    path: str | None,
+    message: str,
+    severity: str,
+    related_paths: list[str] | None = None,
+    resolution_mode: str = "manual-only-review",
+    blocking_scope: str = "marker-update",
+    evidence_anchor: str | None = None,
+) -> None:
+    issue = {
+        "classification": classification,
+        "packet": packet,
+        "path": path,
+        "message": message,
+        "severity": severity,
+        "related_paths": related_paths or [],
+        "resolution_mode": resolution_mode,
+        "blocking_scope": blocking_scope,
+        "evidence_anchor": evidence_anchor,
+    }
+    findings["issues"].append(issue)
+    findings["classifications"][classification].append(issue)
+    bucket = {"error": "errors", "warning": "warnings", "info": "infos"}[severity]
+    findings[bucket].append(message)
+
+
+def packet_for_path(context: dict[str, Any], relpath: str) -> str | None:
+    packets = context.get("packet_candidates", {})
+    for packet_name, packet in packets.items():
+        if relpath in packet.get("review_docs", []) or relpath in packet.get("changed_paths", []):
+            return packet_name
+    if relpath.startswith(".github/ISSUE_TEMPLATE/"):
+        return "forms_batch_packet"
+    return None
+
+
+def add_auto_apply_candidate(
+    findings: dict[str, Any],
+    *,
+    packet: str | None,
+    kind: str,
+    path: str,
+    message: str,
+    details: dict[str, Any] | None = None,
+    evidence_anchor: str | None = None,
+    expected_edit_scope: str | None = None,
+) -> None:
+    candidate = {
+        "packet": packet,
+        "kind": kind,
+        "canonical_type": DETERMINISTIC_ACTION_ALIASES.get(kind, kind),
+        "path": path,
+        "message": message,
+        "details": details or {},
+        "evidence_anchor": evidence_anchor,
+        "expected_edit_scope": expected_edit_scope,
+    }
+    findings["auto_apply_candidates"].append(candidate)
+    basis = ensure_packet_basis(findings, packet)
+    if basis is not None:
+        basis["deterministic_action_candidates"].append(candidate)
+
+
+def finalize_packet_basis(context: dict[str, Any], findings: dict[str, Any]) -> None:
+    for packet_name in PACKET_NAMES:
+        basis = ensure_packet_basis(findings, packet_name)
+        packet_issues = [
+            issue
+            for issue in findings["issues"]
+            if issue.get("packet") == packet_name and issue.get("resolution_mode") != "deterministic-edit"
+        ]
+        manual_review_residuals = [
+            {
+                "classification": issue.get("classification"),
+                "path": issue.get("path"),
+                "message": issue.get("message"),
+                "severity": issue.get("severity"),
+                "blocking_scope": issue.get("blocking_scope"),
+                "related_paths": issue.get("related_paths", []),
+                "evidence_anchor": issue.get("evidence_anchor"),
+            }
+            for issue in packet_issues
+        ]
+        basis["manual_review_residuals"] = manual_review_residuals
+        basis["marker_gate_signals"] = {
+            "marker_blocked_by_packet": bool(manual_review_residuals),
+            "blocking_reasons": [item["message"] for item in manual_review_residuals],
+            "manual_review_residual_count": len(manual_review_residuals),
+            "deterministic_candidate_count": len(basis["deterministic_action_candidates"]),
+            "requires_github_evidence": bool(context.get("github_evidence_required")),
+        }
+
+
+def lint_readme_settings(context: dict[str, Any], findings: dict[str, Any]) -> None:
+    settings = context.get("settings", {}).get("defaults", {})
+    readme_settings = context.get("readme", {}).get("settings_table", {})
+    readme_path = context.get("readme", {}).get("path", "README.md")
+    packet = "claims_packet"
+
+    for name, info in settings.items():
+        expected = str(info.get("default"))
+        documented = readme_settings.get(name)
+        if documented is None:
+            push_issue(
+                findings,
+                classification="hard_drift",
+                packet=packet,
+                path=readme_path,
+                message=f"README settings table is missing `{name}`.",
+                severity="error",
+                related_paths=[context.get("settings", {}).get("source_path", "")],
+                resolution_mode="deterministic-edit",
+                blocking_scope="apply",
+                evidence_anchor=f"runtime default for {name}",
+            )
+            add_auto_apply_candidate(
+                findings,
+                packet=packet,
+                kind="settings_table_row",
+                path=readme_path,
+                message=f"Add `{name}` to the README settings table.",
+                details={"setting": name, "expected_default": expected},
+                evidence_anchor=f"runtime default for {name}",
+                expected_edit_scope="single README settings-table row insert",
+            )
+            continue
+        actual = str(documented.get("default"))
+        if actual != expected:
+            push_issue(
+                findings,
+                classification="hard_drift",
+                packet=packet,
+                path=readme_path,
+                message=f"README default for `{name}` is `{actual}` but code default is `{expected}`.",
+                severity="error",
+                related_paths=[context.get("settings", {}).get("source_path", "")],
+                resolution_mode="deterministic-edit",
+                blocking_scope="apply",
+                evidence_anchor=f"runtime default for {name}",
+            )
+            add_auto_apply_candidate(
+                findings,
+                packet=packet,
+                kind="settings_default_sync",
+                path=readme_path,
+                message=f"Sync README default for `{name}` to `{expected}`.",
+                details={"setting": name, "expected_default": expected, "documented_default": actual},
+                evidence_anchor=f"runtime default for {name}",
+                expected_edit_scope="single README settings-table cell update",
+            )
+
+    for name in sorted(readme_settings):
+        if name not in settings:
+            push_issue(
+                findings,
+                classification="hard_drift",
+                packet=packet,
+                path=readme_path,
+                message=f"README settings table contains `{name}` but it is not present in `Setting.cs`.",
+                severity="error",
+                related_paths=[context.get("settings", {}).get("source_path", "")],
+                resolution_mode="manual-only-review",
+                blocking_scope="marker-update",
+                evidence_anchor=f"README settings row {name}",
+            )
+
+
+def lint_missing_links(context: dict[str, Any], findings: dict[str, Any]) -> None:
+    inventory = context.get("public_doc_inventory", {})
+    for relpath, summary in inventory.items():
+        packet = packet_for_path(context, relpath)
+        for missing in summary.get("missing_links", []):
+            target = str(missing.get("target") or "").strip()
+            push_issue(
+                findings,
+                classification="link_error",
+                packet=packet,
+                path=relpath,
+                message=f"Broken relative link `{target}` in `{relpath}`.",
+                severity="error",
+                related_paths=[missing.get("resolved_path", "")],
+                resolution_mode="deterministic-edit",
+                blocking_scope="apply",
+                evidence_anchor=target,
+            )
+            replacement_target = str(missing.get("resolved_path") or "").strip()
+            if replacement_target:
+                if not replacement_target.startswith((".", "/")):
+                    replacement_target = "./" + replacement_target
+                add_auto_apply_candidate(
+                    findings,
+                    packet=packet,
+                    kind="relative_link_fix",
+                    path=relpath,
+                    message=f"Fix broken link `{target}` in `{relpath}`.",
+                    details={
+                        "target": target,
+                        "replacement_target": replacement_target,
+                        "resolved_path": missing.get("resolved_path"),
+                    },
+                    evidence_anchor=target,
+                    expected_edit_scope="single markdown link target replacement",
+                )
+
+
+def lint_packet_reviews(context: dict[str, Any], findings: dict[str, Any]) -> None:
+    if context.get("audit_mode") == "full":
+        findings["infos"].append(
+            "Full audit requested; review-required drift is reported through packet activation instead of missing-doc warnings."
+        )
+        return
+
+    packets = context.get("packet_candidates", {})
+    packet_signals = context.get("evidence_summary", {}).get("packet_signals", {})
+    for packet_name, packet in packets.items():
+        direct_sources = packet.get("direct_source_changes", [])
+        direct_docs = packet.get("direct_doc_changes", [])
+        remote_signals = packet_signals.get(packet_name, [])
+        if direct_docs or (not direct_sources and not remote_signals):
+            continue
+        review_docs = packet.get("review_docs", [])
+        if not review_docs:
+            continue
+        message = (
+            f"{packet_name} has runtime, workflow, or selected GitHub evidence changes without matching "
+            "public-doc changes since the baseline."
+        )
+        if remote_signals:
+            message += " Evidence: " + remote_signals[0]
+        push_issue(
+            findings,
+            classification="review_required",
+            packet=packet_name,
+            path=review_docs[0],
+            message=message,
+            severity="warning",
+            related_paths=direct_sources[:6] + review_docs[:6],
+            resolution_mode="manual-only-review",
+            blocking_scope="marker-update",
+            evidence_anchor=remote_signals[0] if remote_signals else None,
+        )
+
+
+def lint_baseline(context: dict[str, Any], findings: dict[str, Any]) -> None:
+    baseline = context.get("baseline", {})
+    fallback_reason = baseline.get("fallback_reason")
+    if not fallback_reason:
+        return
+    audit_mode = context.get("audit_mode")
+    if audit_mode == "full":
+        message = f"Saved baseline was not reusable and the run fell back to a full audit: {fallback_reason}."
+    else:
+        message = f"Saved baseline was not reusable; the run used an auto-discovered relevant ref instead: {fallback_reason}."
+    push_issue(
+        findings,
+        classification="stale_baseline",
+        packet=None,
+        path=None,
+        message=message,
+        severity="warning",
+        related_paths=[],
+        resolution_mode="manual-only-review",
+        blocking_scope="marker-update",
+        evidence_anchor="baseline reuse failed",
+    )
+
+
+def lint_missing_review_docs(context: dict[str, Any], findings: dict[str, Any]) -> None:
+    inventory = context.get("public_doc_inventory", {})
+    for packet_name, packet in context.get("packet_candidates", {}).items():
+        for relpath in packet.get("review_docs", []):
+            if inventory.get(relpath, {}).get("exists"):
+                continue
+            push_issue(
+                findings,
+                classification="hard_drift",
+                packet=packet_name,
+                path=relpath,
+                message=f"Expected review doc `{relpath}` is missing from the repository.",
+                severity="error",
+                related_paths=[],
+                resolution_mode="manual-only-review",
+                blocking_scope="marker-update",
+                evidence_anchor=relpath,
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    findings: dict[str, Any] = {
+        "errors": [],
+        "warnings": [],
+        "infos": [],
+        "issues": [],
+        "classifications": {
+            "hard_drift": [],
+            "review_required": [],
+            "link_error": [],
+            "stale_baseline": [],
+        },
+        "auto_apply_candidates": [],
+        "packet_basis": {},
+        "override_signals": dict(context.get("override_signals", {})),
+        "can_proceed": True,
+    }
+
+    lint_baseline(context, findings)
+    lint_readme_settings(context, findings)
+    lint_missing_links(context, findings)
+    lint_missing_review_docs(context, findings)
+    lint_packet_reviews(context, findings)
+    finalize_packet_basis(context, findings)
+
+    if not findings["issues"]:
+        findings["infos"].append("No deterministic public-doc drift was detected.")
+    findings["can_proceed"] = True
+
+    write_json(Path(args.output).resolve(), findings)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/public_docs_sync_contract.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/public_docs_sync_contract.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Shared contracts and helpers for public-docs-sync."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+PACKET_NAMES = [
+    "claims_packet",
+    "reporting_packet",
+    "workflow_packet",
+    "forms_batch_packet",
+]
+
+WORKFLOW_FAMILY = "repo-audit"
+ARCHETYPE = "audit-and-apply"
+ORCHESTRATOR_PROFILE = "standard"
+DECISION_READY_PACKETS = False
+WORKER_RETURN_CONTRACT = "generic"
+WORKER_OUTPUT_SHAPE = "flat"
+
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["repo_mapper", "docs_verifier"],
+    "candidate_producers": ["evidence_summarizer", "large_diff_auditor", "log_triager"],
+    "verifiers": ["docs_verifier"],
+}
+
+PACKET_WORKER_MAP = {
+    "claims_packet": ["large_diff_auditor", "repo_mapper"],
+    "reporting_packet": ["evidence_summarizer"],
+    "workflow_packet": ["docs_verifier"],
+    "forms_batch_packet": ["docs_verifier"],
+    "batch-packet-01": ["docs_verifier"],
+}
+
+WORKER_SELECTION_GUIDANCE = {
+    "routing_authority": "packet_worker_map",
+    "notes": "worker_selection_guidance is explanatory only; packet_worker_map is the concrete routing source.",
+    "agent_type_guidance": {
+        "repo_mapper": "Use for baseline reuse questions, packet ownership, and relevant-ref mapping when the selected ref is ambiguous.",
+        "docs_verifier": "Use for public docs wording, workflow docs, and issue-template or policy verification.",
+        "evidence_summarizer": "Use for GitHub evidence and narrative change digests that need narrow compression.",
+        "large_diff_auditor": "Use for claims drift, runtime-default drift, and broad doc/code diffs.",
+        "log_triager": "Use for workflow-run failures, issue-form anomalies, or blocker triage.",
+    },
+}
+
+REVIEW_MODE_OVERRIDES = [
+    "diff churn exceeds the public-docs threshold",
+    "runtime defaults and public workflow files span multiple packet groups",
+    "generated files are present but are not the majority of the change",
+]
+
+RAW_REREAD_ALLOWED_REASONS = [
+    "explicit_stop",
+    "evidence_dispute",
+    "edge_case_layout",
+    "validator_blocker",
+]
+
+XHIGH_REREAD_POLICY = (
+    "Focused packets should support common-path local review; raw reread is allowed only for explicit edge cases."
+)
+
+VALIDATION_ERROR_CODES = {
+    "missing_field": "E_PLAN_MISSING_FIELD",
+    "context_id_mismatch": "E_PLAN_CONTEXT_ID_MISMATCH",
+    "context_fingerprint_mismatch": "E_PLAN_CONTEXT_FINGERPRINT_MISMATCH",
+    "head_changed": "E_PLAN_HEAD_CHANGED",
+    "ambiguous_selected_packet": "E_PLAN_AMBIGUOUS_SELECTED_PACKET",
+    "missing_required_evidence": "E_PLAN_MISSING_REQUIRED_EVIDENCE",
+    "deterministic_scope_exceeded": "E_PLAN_DETERMINISTIC_SCOPE_EXCEEDED",
+    "stale_marker_context": "E_PLAN_STALE_MARKER_CONTEXT",
+}
+
+VALIDATION_WARNING_CODES = {
+    "unknown_top_level_field": "W_PLAN_UNKNOWN_TOP_LEVEL_FIELD",
+    "unknown_action_field": "W_PLAN_UNKNOWN_ACTION_FIELD",
+    "action_string_normalized": "W_PLAN_ACTION_STRING_NORMALIZED",
+}
+
+DETERMINISTIC_ACTION_ALIASES = {
+    "settings_default_sync": "settings_table_default_sync",
+    "settings_table_row": "settings_table_default_sync",
+    "settings_table_default_sync": "settings_table_default_sync",
+    "relative_link_fix": "relative_link_fix",
+    "public_doc_reference_sync": "public_doc_reference_sync",
+    "doc_reference_sync": "public_doc_reference_sync",
+    "public_doc_list_sync": "public_doc_reference_sync",
+    "issue_template_metadata_sync": "issue_template_metadata_sync",
+}
+
+MANUAL_ONLY_ACTION_TYPES = {
+    "manual_review",
+    "narrative_review",
+    "release_status_review",
+    "investigation_review",
+    "evidence_review",
+    "note",
+}
+
+MANUAL_ONLY_ACTION_PREFIXES = (
+    "manual_",
+    "narrative_",
+)
+
+STOP_CATEGORY_SCOPES = {
+    "narrative_drift_remaining": "marker-update",
+    "deterministic_scope_exceeded": "apply-and-marker",
+    "marker_update_without_doc_completion": "marker-update",
+    "stale_marker_context": "apply-and-marker",
+    "missing_required_evidence": "apply-and-marker",
+}
+
+PLAN_PHASE_FIELD_TABLES = {
+    "draft_plan": {
+        "top_level": {
+            "required": [
+                "context_id",
+                "context_fingerprint",
+                "overall_confidence",
+                "doc_update_status",
+                "allow_marker_update",
+                "actions",
+                "stop_reasons",
+            ],
+            "allowed": [
+                "marker_reason",
+                "selected_packets",
+                "remaining_manual_reviews",
+            ],
+            "ignored": [],
+        },
+        "action": {
+            "required": [
+                "type",
+                "summary",
+            ],
+            "allowed": [
+                "path",
+                "details",
+            ],
+            "ignored": [],
+        },
+    }
+}
+
+APPLY_CONTEXT_SNAPSHOT_FIELDS = [
+    "repo_root",
+    "state_file",
+    "context_id",
+    "context_fingerprint",
+    "head_commit",
+    "repo_hash",
+    "repo_slug",
+    "branch",
+    "baseline_commit",
+    "relevant_ref",
+    "primary_pr_number",
+    "primary_pr_url",
+    "github_evidence_digest",
+    "ref_selection_source",
+    "audited_doc_paths",
+]
+
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+
+
+def dedupe_preserve(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def json_bytes(payload: Any) -> int:
+    return len(json.dumps(payload, ensure_ascii=True, sort_keys=True).encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return max(1, int(round(byte_count / 4.0)))
+
+
+def compute_packet_metrics(
+    packet_payloads: dict[str, Any],
+    *,
+    local_only_sources: dict[str, Any],
+) -> dict[str, int]:
+    packet_sizes = {
+        name: json_bytes(payload)
+        for name, payload in packet_payloads.items()
+    }
+    total_packet_bytes = sum(packet_sizes.values())
+    largest_sizes = sorted(packet_sizes.values(), reverse=True)
+    local_only_bytes = sum(json_bytes(payload) for payload in local_only_sources.values())
+    estimated_local_only_tokens = estimate_tokens_from_bytes(local_only_bytes)
+    estimated_packet_tokens = estimate_tokens_from_bytes(largest_sizes[0] if largest_sizes else 0)
+    return {
+        "packet_count": len(packet_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "largest_packet_bytes": largest_sizes[0] if largest_sizes else 0,
+        "largest_two_packets_bytes": sum(largest_sizes[:2]),
+        "estimated_local_only_tokens": estimated_local_only_tokens,
+        "estimated_packet_tokens": estimated_packet_tokens,
+        "estimated_delegation_savings": max(0, estimated_local_only_tokens - estimated_packet_tokens),
+    }

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/smoke_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/smoke_public_docs_sync.py
@@ -1,0 +1,381 @@
+﻿#!/usr/bin/env python3
+"""Smoke-test the public-docs-sync workflow on a temp repository."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def run_python(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, *args],
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"python {' '.join(args)} failed")
+    return result
+
+
+def run_git(repo_root: Path, args: list[str]) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def create_repo(repo_root: Path) -> None:
+    (repo_root / "ExampleProduct").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".codex" / "project" / "profiles" / "public-docs-sync").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".github" / "ISSUE_TEMPLATE").mkdir(parents=True, exist_ok=True)
+    (repo_root / "docs").mkdir(parents=True, exist_ok=True)
+
+    (repo_root / "README.md").write_text(
+        "\n".join(
+            [
+                "# Project",
+                "",
+                "| Setting | Default | Purpose |",
+                "| --- | --- | --- |",
+                "| `EnableThing` | `false` | Turn the feature on. |",
+                "",
+                "See the [Guide](./missing.md).",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (repo_root / "CONTRIBUTING.md").write_text("Public docs live in README.old.md\n", encoding="utf-8")
+    (repo_root / "LOG_REPORTING.md").write_text("# Log Reporting\n", encoding="utf-8")
+    (repo_root / "PERF_REPORTING.md").write_text("# Perf Reporting\n", encoding="utf-8")
+    (repo_root / "MAINTAINING.md").write_text("# Maintaining\n", encoding="utf-8")
+    (repo_root / ".github" / "pull_request_template.md").write_text("## Summary\n", encoding="utf-8")
+    (repo_root / ".github" / "software-evidence-schema.md").write_text("# Schema\n", encoding="utf-8")
+    (repo_root / ".github" / "software-investigation-workflow.md").write_text("# Workflow\n", encoding="utf-8")
+    (repo_root / ".github" / "workflows").mkdir(exist_ok=True)
+    (repo_root / ".github" / "workflows" / "release.yml").write_text("name: release\n", encoding="utf-8")
+    write_json(
+        repo_root / ".codex" / "project" / "profiles" / "public-docs-sync" / "profile.json",
+        {
+            "name": "public-docs-sync",
+            "summary": "smoke profile",
+            "bindings": {
+                "primary_readme_path": "README.md",
+                "publish_config_path": "ExampleProduct/Properties/PublishConfiguration.xml",
+                "settings_source_path": "ExampleProduct/Setting.cs",
+            },
+            "packet_defaults": {
+                "review_docs": {
+                    "claims_packet": [
+                        "README.md",
+                        "ExampleProduct/Properties/PublishConfiguration.xml",
+                    ]
+                },
+                "source_path_globs": {}
+            },
+            "extra": {
+                "public_docs_sync": {
+                    "audited_public_doc_inventory": [
+                        "README.md",
+                        "LOG_REPORTING.md",
+                        "PERF_REPORTING.md",
+                        "CONTRIBUTING.md",
+                        "MAINTAINING.md",
+                        ".github/pull_request_template.md",
+                        ".github/software-evidence-schema.md",
+                        ".github/software-investigation-workflow.md",
+                        ".github/workflows/release.yml",
+                        "ExampleProduct/Properties/PublishConfiguration.xml",
+                    ]
+                }
+            },
+        },
+    )
+    (repo_root / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml").write_text(
+        "\n".join(
+            [
+                'name: "Bug Report"',
+                'description: "Tell us what broke."',
+                'title: "Bug: "',
+                'labels: ["bug"]',
+                "body:",
+                "  - type: textarea",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "docs" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (repo_root / "ExampleProduct" / "Setting.cs").write_text(
+        "\n".join(
+            [
+                "public class Setting {",
+                "    public bool EnableThing { get; set; } = true;",
+                '    public override void SetDefaults() {',
+                "        EnableThing = true;",
+                "    }",
+                '    GetOptionLabelLocaleID(nameof(Setting.EnableThing)), "Enable Thing"',
+                '    GetOptionDescLocaleID(nameof(Setting.EnableThing)), "Turn the feature on."',
+                "}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "ExampleProduct" / "Properties").mkdir(exist_ok=True)
+    (repo_root / "ExampleProduct" / "Properties" / "PublishConfiguration.xml").write_text(
+        "<Configuration><DisplayName Value=\"ExampleProduct\" /></Configuration>\n",
+        encoding="utf-8",
+    )
+
+    run_git(repo_root, ["init"])
+    run_git(repo_root, ["config", "user.email", "smoke@example.test"])
+    run_git(repo_root, ["config", "user.name", "Smoke Test"])
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "-m", "Initial smoke fixture"])
+
+
+def build_plan(context: dict, lint: dict) -> dict:
+    actions = [
+        {
+            "type": "relative_link_fix",
+            "summary": "Fix the README guide link.",
+            "path": "README.md",
+            "details": {
+                "target": "./missing.md",
+                "replacement_target": "./docs/guide.md",
+            },
+        },
+        {
+            "type": "public_doc_reference_sync",
+            "summary": "Update CONTRIBUTING to point at the current README.",
+            "path": "CONTRIBUTING.md",
+            "details": {
+                "match_text": "README.old.md",
+                "replacement_text": "README.md",
+            },
+        },
+        {
+            "type": "issue_template_metadata_sync",
+            "summary": "Sync bug-report labels.",
+            "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+            "details": {
+                "field": "labels",
+                "value": ["bug", "player-report"],
+            },
+        },
+    ]
+    active_packets = [
+        name
+        for name, packet in (context.get("packet_candidates") or {}).items()
+        if isinstance(packet, dict) and packet.get("active")
+    ]
+    return {
+        "context_id": context["context_id"],
+        "context_fingerprint": context["context_fingerprint"],
+        "overall_confidence": "high",
+        "doc_update_status": "completed",
+        "allow_marker_update": True,
+        "actions": actions,
+        "stop_reasons": [],
+        "selected_packets": active_packets,
+        "remaining_manual_reviews": [],
+    }
+
+
+def main() -> int:
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "public-docs-sync"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-") as tmp_dir:
+        root = Path(tmp_dir)
+        repo_root = root / "repo"
+        repo_root.mkdir()
+        create_repo(repo_root)
+
+        context_path = root / "context.json"
+        lint_path = root / "lint.json"
+        plan_path = root / "plan.json"
+        validation_path = root / "validation.json"
+        apply_result_path = root / "apply-result.json"
+        build_result_path = root / "build-result.json"
+        eval_log_path = root / "eval-log.json"
+        packet_dir = root / "packets"
+        state_file = root / "state.json"
+
+        run_python(
+            [
+                str(SCRIPT_DIR / "collect_public_docs_sync_context.py"),
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(context_path),
+                "--full",
+                "--state-file",
+                str(state_file),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "lint_public_docs_sync.py"),
+                "--context",
+                str(context_path),
+                "--output",
+                str(lint_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "build_public_docs_sync_packets.py"),
+                "--context",
+                str(context_path),
+                "--lint",
+                str(lint_path),
+                "--output-dir",
+                str(packet_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+        )
+
+        context = load_json(context_path)
+        lint = load_json(lint_path)
+        plan = build_plan(context, lint)
+        write_json(plan_path, plan)
+
+        run_python(
+            [
+                str(SCRIPT_DIR / "validate_public_docs_sync.py"),
+                "--context",
+                str(context_path),
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(validation_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "apply_public_docs_sync.py"),
+                "--validation",
+                str(validation_path),
+                "--dry-run",
+                "--state-file",
+                str(state_file),
+                "--result-output",
+                str(apply_result_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "init",
+                "--context",
+                str(context_path),
+                "--orchestrator",
+                str(packet_dir / "orchestrator.json"),
+                "--lint",
+                str(lint_path),
+                "--output",
+                str(eval_log_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "build",
+                "--result",
+                str(build_result_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "validate",
+                "--result",
+                str(validation_path),
+            ]
+        )
+        run_python(
+            [
+                str(SCRIPT_DIR / "write_evaluation_log.py"),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "apply",
+                "--result",
+                str(apply_result_path),
+            ]
+        )
+
+        orchestrator = load_json(packet_dir / "orchestrator.json")
+        packet_metrics = load_json(packet_dir / "packet_metrics.json")
+        apply_result = load_json(apply_result_path)
+        eval_log = load_json(eval_log_path)
+
+        assert orchestrator["orchestrator_profile"] == "standard"
+        assert "packet_size_bytes" not in orchestrator
+        assert packet_metrics["estimated_packet_tokens"] < packet_metrics["estimated_local_only_tokens"]
+        assert packet_metrics["estimated_delegation_savings"] > 0
+        assert apply_result["dry_run"] is True
+        assert apply_result["marker_written"] is False
+        assert eval_log["skill_specific"]["data"]["packet_count"] == packet_metrics["packet_count"]
+        assert not state_file.exists()
+
+        print(
+            json.dumps(
+                {
+                    "smoke": "passed",
+                    "packet_count": packet_metrics["packet_count"],
+                    "estimated_local_only_tokens": packet_metrics["estimated_local_only_tokens"],
+                    "estimated_packet_tokens": packet_metrics["estimated_packet_tokens"],
+                    "estimated_delegation_savings": packet_metrics["estimated_delegation_savings"],
+                    "raw_reread_count": 0,
+                    "common_path_sufficient": True,
+                },
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/validate_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/validate_public_docs_sync.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Validate and normalize a public-docs-sync plan before marker apply."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from public_docs_sync_contract import (
+    APPLY_CONTEXT_SNAPSHOT_FIELDS,
+    DETERMINISTIC_ACTION_ALIASES,
+    MANUAL_ONLY_ACTION_PREFIXES,
+    MANUAL_ONLY_ACTION_TYPES,
+    PLAN_PHASE_FIELD_TABLES,
+    STOP_CATEGORY_SCOPES,
+    VALIDATION_ERROR_CODES,
+    VALIDATION_WARNING_CODES,
+    dedupe_preserve,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--plan", required=True, help="Planned action JSON.")
+    parser.add_argument("--output", help="Optional path to write the validation JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def json_fingerprint(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def run_git(repo_root: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
+def push_issue(
+    messages: list[str],
+    details: list[dict[str, Any]],
+    *,
+    code: str,
+    message: str,
+    field: str | None = None,
+    action_index: int | None = None,
+) -> None:
+    messages.append(message)
+    detail = {"code": code, "message": message}
+    if field is not None:
+        detail["field"] = field
+    if action_index is not None:
+        detail["action_index"] = action_index
+    details.append(detail)
+
+
+def push_stop(stop_messages: dict[str, list[str]], category: str, message: str) -> None:
+    stop_messages.setdefault(category, [])
+    if message not in stop_messages[category]:
+        stop_messages[category].append(message)
+
+
+def required_keys(
+    payload: dict[str, Any],
+    keys: list[str],
+    errors: list[str],
+    error_details: list[dict[str, Any]],
+    prefix: str,
+    *,
+    action_index: int | None = None,
+) -> None:
+    for key in keys:
+        if key not in payload:
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_field"],
+                message=f"{prefix} missing required field `{key}`.",
+                field=key,
+                action_index=action_index,
+            )
+
+
+def unknown_fields(
+    payload: dict[str, Any],
+    *,
+    scope: str,
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+    action_index: int | None = None,
+) -> None:
+    rules = PLAN_PHASE_FIELD_TABLES["draft_plan"][scope]
+    allowed = set(rules["required"]) | set(rules["allowed"]) | set(rules["ignored"])
+    code = (
+        VALIDATION_WARNING_CODES["unknown_top_level_field"]
+        if scope == "top_level"
+        else VALIDATION_WARNING_CODES["unknown_action_field"]
+    )
+    for field in sorted(set(payload) - allowed):
+        push_issue(
+            warnings,
+            warning_details,
+            code=code,
+            message=f"Removed unknown {scope.replace('_', ' ')} field `{field}` during normalization.",
+            field=field,
+            action_index=action_index,
+        )
+
+
+def normalize_details(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def is_manual_only_action_type(raw_type: str) -> bool:
+    lowered = raw_type.strip().lower()
+    return lowered in MANUAL_ONLY_ACTION_TYPES or lowered.startswith(MANUAL_ONLY_ACTION_PREFIXES)
+
+
+def classify_action_type(raw_type: str) -> tuple[str, str | None, bool]:
+    lowered = raw_type.strip().lower()
+    canonical_type = DETERMINISTIC_ACTION_ALIASES.get(lowered)
+    if canonical_type:
+        return "deterministic-edit", canonical_type, False
+    if is_manual_only_action_type(lowered):
+        return "manual-only-review", None, False
+    return "manual-only-review", None, True
+
+
+def normalize_action(
+    action: Any,
+    index: int,
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if isinstance(action, str):
+        push_issue(
+            warnings,
+            warning_details,
+            code=VALIDATION_WARNING_CODES["action_string_normalized"],
+            message=f"Normalized string action at index {index} into a manual review action.",
+            field="actions",
+            action_index=index,
+        )
+        action = {"type": "manual_review", "summary": action.strip()}
+    if not isinstance(action, dict):
+        action = {"type": "manual_review", "summary": str(action)}
+    unknown_fields(
+        action,
+        scope="action",
+        warnings=warnings,
+        warning_details=warning_details,
+        action_index=index,
+    )
+    raw_type = str(action.get("type", "")).strip()
+    action_mode, canonical_type, scope_exceeded = classify_action_type(raw_type)
+    return {
+        "index": index,
+        "type": raw_type,
+        "canonical_type": canonical_type,
+        "summary": str(action.get("summary", "")).strip(),
+        "path": str(action.get("path", "")).strip() or None,
+        "details": normalize_details(action.get("details")),
+        "action_mode": action_mode,
+        "scope_exceeded": scope_exceeded,
+    }
+
+
+def normalize_plan(
+    plan: dict[str, Any],
+    warnings: list[str],
+    warning_details: list[dict[str, Any]],
+) -> dict[str, Any]:
+    unknown_fields(plan, scope="top_level", warnings=warnings, warning_details=warning_details)
+    raw_actions = plan.get("actions")
+    normalized_actions = []
+    if isinstance(raw_actions, list):
+        for index, action in enumerate(raw_actions, start=1):
+            normalized_actions.append(normalize_action(action, index, warnings, warning_details))
+    return {
+        "context_id": str(plan.get("context_id", "")).strip(),
+        "context_fingerprint": str(plan.get("context_fingerprint", "")).strip(),
+        "overall_confidence": str(plan.get("overall_confidence", "")).strip().lower(),
+        "doc_update_status": str(plan.get("doc_update_status", "")).strip(),
+        "allow_marker_update": bool(plan.get("allow_marker_update")),
+        "actions": normalized_actions,
+        "stop_reasons": string_list(plan.get("stop_reasons")),
+        "marker_reason": str(plan.get("marker_reason", "")).strip() or None,
+        "selected_packets": string_list(plan.get("selected_packets")),
+        "remaining_manual_reviews": string_list(plan.get("remaining_manual_reviews")),
+    }
+
+
+def public_doc_paths(context: dict[str, Any]) -> set[str]:
+    return {
+        str(path)
+        for path in context.get("public_doc_paths", [])
+        if str(path).strip()
+    }
+
+
+def validate_settings_table_action(context: dict[str, Any], action: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    readme_path = str(context.get("readme", {}).get("path") or "README.md")
+    action["path"] = action.get("path") or readme_path
+    if action["path"] != readme_path:
+        issues.append("settings-table default sync is only supported for the collected README settings table.")
+    setting = str(action["details"].get("setting") or "").strip()
+    if not setting:
+        issues.append("settings-table default sync requires `details.setting`.")
+        return issues
+
+    defaults = (context.get("settings") or {}).get("defaults") or {}
+    setting_info = defaults.get(setting)
+    if not isinstance(setting_info, dict):
+        issues.append(f"settings-table default sync cannot find runtime metadata for `{setting}`.")
+        return issues
+
+    action["details"]["setting"] = setting
+    action["details"]["expected_default"] = str(setting_info.get("default"))
+    action["details"]["setting_label"] = setting_info.get("label")
+    action["details"]["setting_description"] = setting_info.get("description")
+    documented = ((context.get("readme") or {}).get("settings_table") or {}).get(setting)
+    if isinstance(documented, dict):
+        action["details"]["documented_default"] = str(documented.get("default"))
+        action["details"]["documented_purpose"] = str(documented.get("purpose") or "").strip() or None
+    return issues
+
+
+def validate_relative_link_action(context: dict[str, Any], action: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    path = str(action.get("path") or "").strip()
+    if not path:
+        issues.append("relative-link fix requires `path`.")
+        return issues
+    inventory = (context.get("public_doc_inventory") or {}).get(path) or {}
+    target = str(action["details"].get("target") or "").strip()
+    replacement = str(action["details"].get("replacement_target") or "").strip()
+    if not target or not replacement:
+        issues.append("relative-link fix requires `details.target` and `details.replacement_target`.")
+    elif replacement == target:
+        issues.append("relative-link fix replacement must differ from the current target.")
+    if "\n" in target or "\n" in replacement:
+        issues.append("relative-link fix targets must stay single-line.")
+    missing_targets = {
+        str(item.get("target") or "").strip()
+        for item in inventory.get("missing_links", [])
+        if str(item.get("target") or "").strip()
+    }
+    if target and missing_targets and target not in missing_targets:
+        issues.append("relative-link fix target is not one of the collected broken links for this file.")
+    action["details"]["target"] = target
+    action["details"]["replacement_target"] = replacement
+    action["details"]["expected_count"] = int(action["details"].get("expected_count") or 1)
+    return issues
+
+
+def validate_public_doc_reference_action(context: dict[str, Any], action: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    path = str(action.get("path") or "").strip()
+    if not path:
+        issues.append("public doc reference sync requires `path`.")
+        return issues
+    if path not in public_doc_paths(context):
+        issues.append("public doc reference sync must target a collected public doc path.")
+    match_text = str(action["details"].get("match_text") or "").strip()
+    replacement = str(action["details"].get("replacement_text") or "").strip()
+    if not match_text or not replacement:
+        issues.append("public doc reference sync requires `details.match_text` and `details.replacement_text`.")
+    elif replacement == match_text:
+        issues.append("public doc reference sync replacement must differ from the current text.")
+    if "\n" in match_text or "\n" in replacement:
+        issues.append("public doc reference sync is limited to single-line replacements.")
+    action["details"]["match_text"] = match_text
+    action["details"]["replacement_text"] = replacement
+    action["details"]["expected_count"] = int(action["details"].get("expected_count") or 1)
+    return issues
+
+
+def validate_issue_template_metadata_action(context: dict[str, Any], action: dict[str, Any]) -> list[str]:
+    issues: list[str] = []
+    path = str(action.get("path") or "").strip()
+    if not path:
+        issues.append("issue-template metadata sync requires `path`.")
+        return issues
+    if not path.startswith(".github/ISSUE_TEMPLATE/"):
+        issues.append("issue-template metadata sync must target a public issue-template YAML file.")
+    inventory = (context.get("public_doc_inventory") or {}).get(path) or {}
+    if inventory.get("kind") not in {"yaml", "text"}:
+        issues.append("issue-template metadata sync requires a YAML issue template target.")
+    field = str(action["details"].get("field") or "").strip()
+    if field not in {"name", "description", "title", "labels"}:
+        issues.append("issue-template metadata sync supports only `name`, `description`, `title`, or `labels`.")
+    value = action["details"].get("value")
+    if field == "labels":
+        labels = string_list(value)
+        if not labels:
+            issues.append("issue-template metadata sync requires a non-empty `details.value` label list.")
+        action["details"]["value"] = labels
+    else:
+        text = str(value or "").strip()
+        if not text:
+            issues.append("issue-template metadata sync requires a non-empty string `details.value`.")
+        elif "\n" in text:
+            issues.append("issue-template metadata sync is limited to single-line metadata values.")
+        action["details"]["value"] = text
+    action["details"]["field"] = field
+    return issues
+
+
+def validate_deterministic_action(context: dict[str, Any], action: dict[str, Any]) -> list[str]:
+    canonical_type = action.get("canonical_type")
+    if canonical_type == "settings_table_default_sync":
+        return validate_settings_table_action(context, action)
+    if canonical_type == "relative_link_fix":
+        return validate_relative_link_action(context, action)
+    if canonical_type == "public_doc_reference_sync":
+        return validate_public_doc_reference_action(context, action)
+    if canonical_type == "issue_template_metadata_sync":
+        return validate_issue_template_metadata_action(context, action)
+    return ["action type is outside the deterministic apply contract."]
+
+
+def build_stop_status(stop_messages: dict[str, list[str]], *, marker_requested: bool) -> dict[str, Any]:
+    applicable = sorted(STOP_CATEGORY_SCOPES)
+    not_applicable: list[str] = []
+    if not marker_requested:
+        not_applicable.append("marker_update_without_doc_completion")
+    statuses: dict[str, dict[str, Any]] = {}
+    triggered: list[str] = []
+    for category in applicable:
+        triggered_here = bool(stop_messages.get(category))
+        if triggered_here:
+            triggered.append(category)
+        statuses[category] = {
+            "scope": STOP_CATEGORY_SCOPES[category],
+            "triggered": triggered_here,
+            "messages": stop_messages.get(category, []),
+        }
+    covered = [category for category in applicable if category not in not_applicable]
+    return {
+        "applicable_stop_categories": applicable,
+        "covered_stop_categories": covered,
+        "uncovered_stop_categories": [],
+        "not_applicable_stop_categories": not_applicable,
+        "triggered_stop_categories": triggered,
+        "stop_category_statuses": statuses,
+    }
+
+
+def build_apply_context_snapshot(context: dict[str, Any], normalized_plan: dict[str, Any]) -> dict[str, Any]:
+    relevant_ref = context.get("relevant_ref")
+    if isinstance(relevant_ref, dict):
+        relevant_ref_value: Any = relevant_ref.get("name") or relevant_ref.get("base_commit") or relevant_ref.get("kind")
+        ref_selection_source = relevant_ref.get("source")
+        primary_pr_number = relevant_ref.get("primary_pr_number")
+        primary_pr_url = relevant_ref.get("primary_pr_url")
+    else:
+        relevant_ref_value = relevant_ref
+        ref_selection_source = None
+        primary_pr_number = None
+        primary_pr_url = None
+
+    primary_pr = (context.get("github_evidence") or {}).get("primary_pr") or {}
+    snapshot = {
+        "repo_root": str(context.get("repo_root", "")).strip(),
+        "state_file": str(context.get("state_file", "")).strip(),
+        "context_id": str(context.get("context_id", "")).strip(),
+        "context_fingerprint": str(context.get("context_fingerprint", "")).strip(),
+        "head_commit": str(context.get("head_commit", "")).strip(),
+        "repo_hash": str(context.get("repo_hash", "")).strip() or None,
+        "repo_slug": str(context.get("repo_slug", "")).strip() or None,
+        "branch": str(context.get("branch", "")).strip() or None,
+        "baseline_commit": (
+            str(context.get("effective_base_commit", "")).strip()
+            or str((context.get("baseline") or {}).get("base_commit") or "").strip()
+            or None
+        ),
+        "relevant_ref": relevant_ref_value,
+        "primary_pr_number": primary_pr.get("number") or primary_pr_number,
+        "primary_pr_url": primary_pr.get("url") or primary_pr_url,
+        "github_evidence_digest": str(context.get("github_evidence_digest", "")).strip() or None,
+        "ref_selection_source": ref_selection_source,
+        "audited_doc_paths": list(context.get("public_doc_paths", [])),
+    }
+    if normalized_plan.get("selected_packets"):
+        snapshot["selected_packets"] = list(normalized_plan["selected_packets"])
+    return {key: snapshot.get(key) for key in APPLY_CONTEXT_SNAPSHOT_FIELDS if key in snapshot}
+
+
+def validate_public_docs_sync_plan(context: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    error_details: list[dict[str, Any]] = []
+    warning_details: list[dict[str, Any]] = []
+    stop_messages: dict[str, list[str]] = {name: [] for name in STOP_CATEGORY_SCOPES}
+    required_keys(
+        plan,
+        PLAN_PHASE_FIELD_TABLES["draft_plan"]["top_level"]["required"],
+        errors,
+        error_details,
+        "plan",
+    )
+    raw_actions = plan.get("actions", [])
+    if isinstance(raw_actions, list):
+        for index, action in enumerate(raw_actions, start=1):
+            if isinstance(action, dict):
+                required_keys(
+                    action,
+                    PLAN_PHASE_FIELD_TABLES["draft_plan"]["action"]["required"],
+                    errors,
+                    error_details,
+                    f"action {index}",
+                    action_index=index,
+                )
+
+    normalized_plan = normalize_plan(plan, warnings, warning_details)
+    if normalized_plan["context_id"] != str(context.get("context_id", "")):
+        message = "plan `context_id` does not match the collected context."
+        push_issue(errors, error_details, code=VALIDATION_ERROR_CODES["context_id_mismatch"], message=message, field="context_id")
+        push_stop(stop_messages, "stale_marker_context", message)
+    if normalized_plan["context_fingerprint"] != str(context.get("context_fingerprint", "")):
+        message = "plan `context_fingerprint` does not match the collected context fingerprint."
+        push_issue(
+            errors,
+            error_details,
+            code=VALIDATION_ERROR_CODES["context_fingerprint_mismatch"],
+            message=message,
+            field="context_fingerprint",
+        )
+        push_stop(stop_messages, "stale_marker_context", message)
+
+    repo_root = Path(str(context.get("repo_root", ""))).resolve()
+    expected_head = str(context.get("head_commit", "")).strip()
+    if repo_root.exists() and expected_head:
+        current_head = run_git(repo_root, ["rev-parse", "HEAD"])
+        if current_head != expected_head:
+            message = "Repository HEAD changed since context collection."
+            push_issue(errors, error_details, code=VALIDATION_ERROR_CODES["head_changed"], message=message, field="head_commit")
+            push_stop(stop_messages, "stale_marker_context", message)
+
+    selected_packets = normalized_plan.get("selected_packets", [])
+    active_packets = [
+        name
+        for name, packet in (context.get("packet_candidates", {}) or {}).items()
+        if isinstance(packet, dict) and packet.get("active")
+    ]
+    if len(selected_packets) != len(set(selected_packets)):
+        message = "plan `selected_packets` contains duplicates."
+        push_issue(errors, error_details, code=VALIDATION_ERROR_CODES["ambiguous_selected_packet"], message=message, field="selected_packets")
+        push_stop(stop_messages, "deterministic_scope_exceeded", message)
+    for packet_name in selected_packets:
+        if packet_name.endswith(".json"):
+            packet_name = packet_name[:-5]
+        if packet_name not in active_packets:
+            message = f"plan selects inactive or unknown packet `{packet_name}`."
+            push_issue(errors, error_details, code=VALIDATION_ERROR_CODES["ambiguous_selected_packet"], message=message, field="selected_packets")
+            push_stop(stop_messages, "deterministic_scope_exceeded", message)
+    if bool(context.get("github_evidence_required")):
+        evidence_urls = string_list((context.get("evidence_summary") or {}).get("urls"))
+        evidence_digest = str(context.get("github_evidence_digest", "")).strip()
+        if not evidence_urls and not evidence_digest:
+            message = "GitHub evidence is required for this run but no evidence digest or evidence URLs were collected."
+            push_issue(
+                errors,
+                error_details,
+                code=VALIDATION_ERROR_CODES["missing_required_evidence"],
+                message=message,
+                field="github_evidence_required",
+            )
+            push_stop(stop_messages, "missing_required_evidence", message)
+
+    deterministic_actions: list[dict[str, Any]] = []
+    manual_review_actions: list[dict[str, Any]] = []
+    for action in normalized_plan["actions"]:
+        if action["action_mode"] == "deterministic-edit":
+            issues = validate_deterministic_action(context, action)
+            if issues:
+                for message in issues:
+                    push_issue(
+                        errors,
+                        error_details,
+                        code=VALIDATION_ERROR_CODES["deterministic_scope_exceeded"],
+                        message=f"action {action['index']}: {message}",
+                        field="actions",
+                        action_index=action["index"],
+                    )
+                    push_stop(stop_messages, "deterministic_scope_exceeded", f"action {action['index']}: {message}")
+            else:
+                deterministic_actions.append(action)
+        else:
+            manual_review_actions.append(action)
+            if action.get("scope_exceeded"):
+                message = f"action {action['index']}: `{action.get('type')}` is outside the deterministic apply contract."
+                push_issue(
+                    errors,
+                    error_details,
+                    code=VALIDATION_ERROR_CODES["deterministic_scope_exceeded"],
+                    message=message,
+                    field="actions",
+                    action_index=action["index"],
+                )
+                push_stop(stop_messages, "deterministic_scope_exceeded", message)
+
+    if normalized_plan["remaining_manual_reviews"]:
+        push_stop(
+            stop_messages,
+            "narrative_drift_remaining",
+            "remaining_manual_reviews is non-empty; marker update must wait for manual doc review to finish.",
+        )
+    if normalized_plan["stop_reasons"]:
+        push_stop(
+            stop_messages,
+            "narrative_drift_remaining",
+            "plan `stop_reasons` is non-empty; marker update must wait for the remaining review blockers.",
+        )
+    if manual_review_actions:
+        push_stop(
+            stop_messages,
+            "narrative_drift_remaining",
+            "manual-only-review actions remain in the plan; marker update must wait for local narrative review to finish.",
+        )
+    marker_requested = bool(normalized_plan["allow_marker_update"])
+    doc_update_complete = normalized_plan["doc_update_status"] in {"completed", "noop"}
+    if marker_requested and not doc_update_complete:
+        push_stop(
+            stop_messages,
+            "marker_update_without_doc_completion",
+            "plan requested a marker update before `doc_update_status` reached `completed` or `noop`.",
+        )
+    if marker_requested and normalized_plan["overall_confidence"] == "low":
+        push_stop(
+            stop_messages,
+            "marker_update_without_doc_completion",
+            "low-confidence plans cannot persist a success marker.",
+        )
+
+    stop_status = build_stop_status(stop_messages, marker_requested=marker_requested)
+    apply_blocking_categories = {
+        "stale_marker_context",
+        "deterministic_scope_exceeded",
+        "missing_required_evidence",
+    }
+    marker_blocking_categories = {
+        "narrative_drift_remaining",
+        "marker_update_without_doc_completion",
+    }
+    triggered = set(stop_status["triggered_stop_categories"])
+    can_apply = not errors and not (triggered & apply_blocking_categories)
+    can_update_marker = can_apply and marker_requested and not (triggered & marker_blocking_categories)
+    stop_reasons = dedupe_preserve(
+        [
+            *errors,
+            *[message for category in stop_status["triggered_stop_categories"] for message in stop_messages.get(category, [])],
+        ]
+    )
+    apply_context_snapshot = build_apply_context_snapshot(context, normalized_plan)
+    return {
+        "valid": not errors,
+        "can_apply": can_apply,
+        "can_update_marker": can_update_marker,
+        "errors": errors,
+        "warnings": warnings,
+        "error_details": error_details,
+        "warning_details": warning_details,
+        "stop_reasons": stop_reasons,
+        "normalized_plan": normalized_plan,
+        "normalized_plan_fingerprint": json_fingerprint(normalized_plan),
+        "context_file_fingerprint": json_fingerprint(context),
+        "apply_context_snapshot": apply_context_snapshot,
+        "apply_context_snapshot_fingerprint": json_fingerprint(apply_context_snapshot),
+        "deterministic_actions": deterministic_actions,
+        "manual_review_actions": manual_review_actions,
+        "action_summary": {
+            "deterministic_edit_count": len(deterministic_actions),
+            "manual_only_review_count": len(manual_review_actions),
+        },
+        "apply_gate_status": {
+            "status": "pass" if can_apply else "fail",
+            "apply_edits_status": "pass" if can_apply else "fail",
+            "marker_update_status": (
+                "pass"
+                if can_update_marker
+                else "not-requested"
+                if not marker_requested
+                else "blocked"
+            ),
+            **stop_status,
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        context = load_json(Path(args.context).resolve())
+        plan = load_json(Path(args.plan).resolve())
+        payload = validate_public_docs_sync_plan(context, plan)
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(f"validate_public_docs_sync_plan.py: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        write_json(Path(args.output).resolve(), payload)
+    else:
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if payload.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/write_evaluation_log.py
@@ -1,0 +1,1099 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    raw = orchestrator.get("packet_files")
+    if not isinstance(raw, list):
+        raw = orchestrator.get("packet_order")
+    return [str(item) for item in raw or [] if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    for key in ("active_packet_count", "active_areas"):
+        detected = safe_int(counts.get(key))
+        if detected is not None:
+            return detected
+    detected = safe_int(orchestrator.get("active_packet_count"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = list_of_strings(orchestrator.get("applied_override_signals"))
+    if signals:
+        return signals
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def lint_findings_payload(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    report = lint_report or {}
+    nested = report.get("findings")
+    if isinstance(nested, dict):
+        return nested
+    return {
+        "errors": report.get("errors", []),
+        "warnings": report.get("warnings", []),
+        "info": report.get("info", report.get("infos", [])),
+        "hard_drift": (report.get("classifications") or {}).get("hard_drift", []),
+        "review_required": (report.get("classifications") or {}).get("review_required", []),
+        "link_error": (report.get("classifications") or {}).get("link_error", []),
+        "stale_baseline": (report.get("classifications") or {}).get("stale_baseline", []),
+    }
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = lint_findings_payload(lint_report)
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = lint_findings_payload(lint_report)
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "public-docs-sync":
+        packet_candidates = context.get("packet_candidates", {})
+        baseline = context.get("baseline", {})
+        active_packets = [name for name, packet in packet_candidates.items() if packet.get("active")]
+        selected_packets = list(orchestrator.get("selected_packets") or [f"{name}.json" for name in active_packets])
+        auto_apply_candidate_count = 0
+        if isinstance(lint_report, dict):
+            auto_apply = lint_report.get("auto_apply_candidates")
+            if isinstance(auto_apply, list):
+                auto_apply_candidate_count = len(auto_apply)
+        return {
+            "baseline_mode": baseline.get("mode"),
+            "baseline_fallback_reason": baseline.get("fallback_reason"),
+            "review_mode": orchestrator.get("review_mode"),
+            "selected_packets": selected_packets,
+            "active_packets": active_packets,
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_mix": worker_roles(orchestrator),
+            "hard_drift_count": len(findings.get("hard_drift", [])) if isinstance(findings.get("hard_drift"), list) else 0,
+            "review_required_count": len(findings.get("review_required", [])) if isinstance(findings.get("review_required"), list) else 0,
+            "link_error_count": len(findings.get("link_error", [])) if isinstance(findings.get("link_error"), list) else 0,
+            "stale_baseline_count": len(findings.get("stale_baseline", [])) if isinstance(findings.get("stale_baseline"), list) else 0,
+            "auto_apply_candidate_count": auto_apply_candidate_count,
+            "deterministic_edit_count": safe_int(context.get("deterministic_edit_count")),
+            "manual_review_count": safe_int(context.get("manual_review_count")),
+            "plan_overall_confidence": context.get("plan_overall_confidence"),
+            "allow_marker_update": context.get("allow_marker_update"),
+            "marker_update_attempted": context.get("marker_update_attempted"),
+            "marker_update_written": context.get("marker_update_written"),
+            "marker_written": context.get("marker_written"),
+            "stop_reasons": list_of_strings(context.get("stop_reasons")),
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        baseline = log.setdefault("baseline", {})
+        measurement = log.setdefault("measurement", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        worker_mix = worker_roles(result)
+        if worker_mix:
+            orchestration["worker_roles"] = worker_mix
+            skill_data["worker_mix"] = worker_mix
+        selected_packets = list_of_strings(result.get("selected_packets"))
+        if selected_packets:
+            skill_data["selected_packets"] = selected_packets
+            orchestration["item_packets_used"] = len(
+                [
+                    packet
+                    for packet in selected_packets
+                    if "batch-packet" not in packet.lower()
+                ]
+            )
+            orchestration["batch_packets_used"] = len(
+                [
+                    packet
+                    for packet in selected_packets
+                    if "batch-packet" in packet.lower()
+                ]
+            )
+        active_packets = list_of_strings(result.get("active_packets"))
+        if active_packets:
+            skill_data["active_packets"] = active_packets
+        override_signals = list_of_strings(result.get("applied_override_signals"))
+        if override_signals:
+            orchestration["override_signals"] = override_signals
+        active_packet_count = safe_int(result.get("active_packet_count"))
+        if active_packet_count is not None:
+            log.setdefault("input_size", {})["active_areas"] = active_packet_count
+        auto_apply_candidate_count = safe_int(result.get("auto_apply_candidate_count"))
+        if auto_apply_candidate_count is not None:
+            skill_data["auto_apply_candidate_count"] = auto_apply_candidate_count
+        packet_metrics = result.get("packet_metrics")
+        if isinstance(packet_metrics, dict):
+            baseline["estimated_local_only_tokens"] = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+            baseline["estimated_token_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            baseline["estimated_delegation_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            skill_data["packet_count"] = safe_int(packet_metrics.get("packet_count"))
+            skill_data["packet_size_bytes"] = safe_int(packet_metrics.get("packet_size_bytes"))
+            skill_data["largest_packet_bytes"] = safe_int(packet_metrics.get("largest_packet_bytes"))
+            skill_data["largest_two_packets_bytes"] = safe_int(packet_metrics.get("largest_two_packets_bytes"))
+            skill_data["estimated_local_only_tokens"] = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+            skill_data["estimated_packet_tokens"] = safe_int(packet_metrics.get("estimated_packet_tokens"))
+            skill_data["estimated_delegation_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            measurement["efficiency_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+            skill_data["stop_reasons"] = existing
+        action_summary = result.get("action_summary")
+        if isinstance(action_summary, dict):
+            skill_data["deterministic_edit_count"] = safe_int(action_summary.get("deterministic_edit_count"))
+            skill_data["manual_review_count"] = safe_int(action_summary.get("manual_only_review_count"))
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_data = log.setdefault("skill_specific", {}).setdefault("data", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        for key in ("marker_update_attempted", "marker_update_written", "marker_written", "can_update_marker"):
+            if key in result:
+                skill_data[key] = result.get(key)
+        for key in ("deterministic_edit_count", "manual_review_count"):
+            if key in result:
+                skill_data[key] = safe_int(result.get(key))
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_apply_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_apply_public_docs_sync.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import apply_public_docs_sync as apply_sync  # noqa: E402
+import validate_public_docs_sync as validator  # noqa: E402
+
+
+def write_repo_files(repo_root: Path) -> None:
+    (repo_root / "docs").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".github" / "ISSUE_TEMPLATE").mkdir(parents=True, exist_ok=True)
+    (repo_root / "README.md").write_text(
+        "\n".join(
+            [
+                "# Project",
+                "",
+                "| Setting | Default | Purpose |",
+                "| --- | --- | --- |",
+                "| `EnableThing` | `false` | Turn the feature on. |",
+                "",
+                "See the [Guide](./missing.md).",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / "CONTRIBUTING.md").write_text(
+        "Public docs live in README.old.md\n",
+        encoding="utf-8",
+    )
+    (repo_root / "docs" / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (repo_root / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml").write_text(
+        "\n".join(
+            [
+                'name: "Bug Report"',
+                'description: "Tell us what broke."',
+                'title: "Bug: "',
+                'labels: ["bug"]',
+                "body:",
+                "  - type: textarea",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def sample_context(repo_root: Path, state_file: Path) -> dict[str, object]:
+    return {
+        "skill_name": "public-docs-sync",
+        "context_id": "ctx-1",
+        "context_fingerprint": "fp-1",
+        "repo_root": str(repo_root),
+        "repo_hash": "hash-1",
+        "repo_slug": "owner/repo",
+        "branch": "main",
+        "head_commit": "abc123",
+        "effective_base_commit": "base123",
+        "public_doc_paths": [
+            "README.md",
+            "CONTRIBUTING.md",
+            ".github/ISSUE_TEMPLATE/bug_report.yml",
+        ],
+        "public_doc_inventory": {
+            "README.md": {
+                "kind": "markdown",
+                "exists": True,
+                "missing_links": [{"target": "./missing.md"}],
+            },
+            "CONTRIBUTING.md": {
+                "kind": "markdown",
+                "exists": True,
+                "missing_links": [],
+            },
+            ".github/ISSUE_TEMPLATE/bug_report.yml": {
+                "kind": "yaml",
+                "exists": True,
+                "missing_links": [],
+            },
+        },
+        "settings": {
+            "source_path": "ExampleProduct/Setting.cs",
+            "defaults": {
+                "EnableThing": {
+                    "default": "true",
+                    "label": "Enable Thing",
+                    "description": "Turn the feature on.",
+                }
+            },
+        },
+        "readme": {
+            "path": "README.md",
+            "settings_table": {
+                "EnableThing": {
+                    "default": "false",
+                    "purpose": "Turn the feature on.",
+                }
+            },
+        },
+        "packet_candidates": {
+            "claims_packet": {"active": True},
+            "workflow_packet": {"active": True},
+            "forms_batch_packet": {"active": True},
+        },
+        "relevant_ref": {"source": "merge-base", "base_commit": "base123"},
+        "github_evidence_digest": "digest-1",
+        "state_file": str(state_file),
+        "evidence_summary": {"urls": ["https://example.test/pr/1"]},
+        "baseline": {"base_commit": "base123"},
+    }
+
+
+def build_validation(context: dict[str, object], plan: dict[str, object]) -> dict[str, object]:
+    with patch.object(validator, "run_git", return_value="abc123"):
+        return validator.validate_public_docs_sync_plan(context, plan)
+
+
+def sample_plan(allow_marker_update: bool = True) -> dict[str, object]:
+    return {
+        "context_id": "ctx-1",
+        "context_fingerprint": "fp-1",
+        "overall_confidence": "high",
+        "doc_update_status": "completed",
+        "allow_marker_update": allow_marker_update,
+        "actions": [
+            {
+                "type": "settings_default_sync",
+                "summary": "Sync the README settings defaults.",
+                "path": "README.md",
+                "details": {"setting": "EnableThing"},
+            },
+            {
+                "type": "relative_link_fix",
+                "summary": "Fix the README guide link.",
+                "path": "README.md",
+                "details": {
+                    "target": "./missing.md",
+                    "replacement_target": "./docs/guide.md",
+                },
+            },
+            {
+                "type": "public_doc_reference_sync",
+                "summary": "Update the README reference in CONTRIBUTING.",
+                "path": "CONTRIBUTING.md",
+                "details": {
+                    "match_text": "README.old.md",
+                    "replacement_text": "README.md",
+                },
+            },
+            {
+                "type": "issue_template_metadata_sync",
+                "summary": "Sync bug-report labels.",
+                "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+                "details": {
+                    "field": "labels",
+                    "value": ["bug", "player-report"],
+                },
+            },
+        ],
+        "stop_reasons": [],
+        "selected_packets": ["claims_packet", "workflow_packet", "forms_batch_packet"],
+        "remaining_manual_reviews": [],
+    }
+
+
+class ApplyPublicDocsSyncTests(unittest.TestCase):
+    def test_dry_run_consumes_validator_output_without_mutating_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir) / "repo"
+            repo_root.mkdir()
+            state_file = Path(tmp_dir) / "state.json"
+            write_repo_files(repo_root)
+            context = sample_context(repo_root, state_file)
+            validation = build_validation(context, sample_plan())
+            readme_before = (repo_root / "README.md").read_text(encoding="utf-8")
+
+            with patch.object(apply_sync, "run_git", return_value="abc123"):
+                payload = apply_sync.apply_validated_plan(validation, dry_run=True, state_file=state_file)
+
+            self.assertTrue(payload["dry_run"])
+            self.assertEqual(payload["validation_source"], "validator_normalized_plan")
+            self.assertEqual(payload["deterministic_edit_count"], 4)
+            self.assertFalse(payload["marker_written"])
+            self.assertEqual((repo_root / "README.md").read_text(encoding="utf-8"), readme_before)
+            self.assertFalse(state_file.exists())
+
+    def test_apply_executes_all_supported_deterministic_edit_categories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir) / "repo"
+            repo_root.mkdir()
+            state_file = Path(tmp_dir) / "state.json"
+            write_repo_files(repo_root)
+            context = sample_context(repo_root, state_file)
+            validation = build_validation(context, sample_plan())
+
+            with patch.object(apply_sync, "run_git", return_value="abc123"):
+                payload = apply_sync.apply_validated_plan(validation, dry_run=False, state_file=state_file)
+
+            readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
+            contributing_text = (repo_root / "CONTRIBUTING.md").read_text(encoding="utf-8")
+            issue_template_text = (repo_root / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml").read_text(encoding="utf-8")
+
+            self.assertTrue(payload["apply_succeeded"])
+            self.assertTrue(payload["marker_written"])
+            self.assertEqual(payload["doc_edit_count"], 3)
+            self.assertIn("| `EnableThing` | `true` | Turn the feature on. |", readme_text)
+            self.assertIn("[Guide](./docs/guide.md)", readme_text)
+            self.assertIn("README.md", contributing_text)
+            self.assertIn('labels: ["bug", "player-report"]', issue_template_text)
+            self.assertTrue(state_file.exists())
+
+    def test_apply_skips_marker_write_when_manual_reviews_remain(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir) / "repo"
+            repo_root.mkdir()
+            state_file = Path(tmp_dir) / "state.json"
+            write_repo_files(repo_root)
+            context = sample_context(repo_root, state_file)
+            plan = sample_plan()
+            plan["actions"].append("Finish the release-status wording.")
+            plan["remaining_manual_reviews"] = ["Finalize the public narrative."]
+            validation = build_validation(context, plan)
+
+            with patch.object(apply_sync, "run_git", return_value="abc123"):
+                payload = apply_sync.apply_validated_plan(validation, dry_run=False, state_file=state_file)
+
+            self.assertTrue(payload["apply_succeeded"])
+            self.assertFalse(payload["can_update_marker"])
+            self.assertFalse(payload["marker_written"])
+            self.assertFalse(state_file.exists())
+            self.assertIn("| `EnableThing` | `true` | Turn the feature on. |", (repo_root / "README.md").read_text(encoding="utf-8"))
+
+    def test_apply_rejects_stale_head_before_file_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir) / "repo"
+            repo_root.mkdir()
+            state_file = Path(tmp_dir) / "state.json"
+            write_repo_files(repo_root)
+            context = sample_context(repo_root, state_file)
+            validation = build_validation(context, sample_plan())
+
+            with (
+                patch.object(apply_sync, "run_git", return_value="different-head"),
+                self.assertRaisesRegex(RuntimeError, "stale context"),
+            ):
+                apply_sync.apply_validated_plan(validation, dry_run=False, state_file=state_file)
+
+    def test_apply_uses_embedded_validation_snapshot_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir) / "repo"
+            repo_root.mkdir()
+            state_file = Path(tmp_dir) / "state.json"
+            write_repo_files(repo_root)
+            context = sample_context(repo_root, state_file)
+            validation = build_validation(context, sample_plan())
+
+            self.assertIn("apply_context_snapshot", validation)
+            self.assertNotIn("context", validation)
+            with patch.object(apply_sync, "run_git", return_value="abc123"):
+                payload = apply_sync.apply_validated_plan(validation, dry_run=True, state_file=state_file)
+
+            self.assertEqual(payload["apply_context_snapshot"]["repo_root"], str(repo_root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_build_public_docs_sync_packets_contract.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_build_public_docs_sync_packets_contract.py
@@ -1,0 +1,422 @@
+import json
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import build_public_docs_sync_packets as packets
+import public_docs_sync_contract as contract
+
+
+class BuildPublicDocsSyncPacketsContractTests(unittest.TestCase):
+    def write_json(self, path: Path, payload: dict) -> None:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def read_json(self, path: Path) -> dict:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_routing_metadata_and_review_mode_helpers(self) -> None:
+        self.assertEqual(packets.PACKET_WORKER_MAP["claims_packet"], ["large_diff_auditor", "repo_mapper"])
+        self.assertEqual(packets.PACKET_WORKER_MAP["batch-packet-01"], ["docs_verifier"])
+        self.assertEqual(
+            packets.compute_review_mode(
+                {"counts": {"active_packet_count": 1, "changed_files": 3, "doc_changes": 1, "code_changes": 0}},
+                {"override_signals": {}},
+            ),
+            ("local-only", False, []),
+        )
+        self.assertEqual(
+            packets.compute_review_mode(
+                {"counts": {"active_packet_count": 2, "changed_files": 3, "doc_changes": 1, "code_changes": 0}},
+                {"override_signals": {}},
+            ),
+            ("targeted-delegation", False, []),
+        )
+        self.assertEqual(
+            packets.compute_review_mode(
+                {"counts": {"active_packet_count": 4, "changed_files": 3, "doc_changes": 1, "code_changes": 0}},
+                {"override_signals": {}},
+            ),
+            ("broad-delegation", False, []),
+        )
+        self.assertEqual(
+            packets.compute_review_mode(
+                {
+                    "counts": {"active_packet_count": 1, "changed_files": 3, "doc_changes": 1, "code_changes": 0},
+                    "override_signals": {"high_churn": True},
+                },
+                {"override_signals": {}},
+            ),
+            ("targeted-delegation", True, ["high_churn"]),
+        )
+        recommended = packets.recommended_workers(
+            ["claims_packet", "reporting_packet", "workflow_packet"],
+            "targeted-delegation",
+        )
+        self.assertEqual(recommended[0]["agent_type"], "large_diff_auditor")
+        self.assertEqual(recommended[1]["agent_type"], "evidence_summarizer")
+        optional = packets.optional_workers(
+            "broad-delegation",
+            packets.recommended_workers(
+                ["claims_packet", "reporting_packet", "workflow_packet", "batch-packet-01"],
+                "broad-delegation",
+            ),
+        )
+        self.assertEqual([item["agent_type"] for item in optional], ["repo_mapper", "log_triager"])
+
+    def test_packet_emission_result_output_and_metrics_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context_path = tmp / "context.json"
+            lint_path = tmp / "lint.json"
+            output_dir = tmp / "packets"
+            result_path = tmp / "build-result.json"
+
+            context = {
+                "skill_name": "public-docs-sync",
+                "context_id": "ctx-1",
+                "context_fingerprint": "fp-1",
+                "repo_root": str(tmp / "repo"),
+                "relevant_ref": {"kind": "merge-base", "base_commit": "abc123"},
+                "authority_order": ["runtime", "docs", "workflow"],
+                "stop_conditions": ["stale"],
+                "github_evidence_required": True,
+                "evidence_summary": {
+                    "urls": ["https://example.test/pr/1"],
+                    "packet_signals": {"claims_packet": ["comment"]},
+                },
+                "github_evidence": {
+                    "auth_policy": "fail-closed",
+                    "artifacts": [
+                        {
+                            "packet_hints": ["claims_packet", "forms_batch_packet"],
+                            "url": "https://example.test/artifact",
+                        }
+                    ],
+                },
+                "counts": {"active_packet_count": 4, "changed_files": 7, "doc_changes": 2, "code_changes": 1},
+                "override_signals": {},
+                "deterministic_apply_boundaries": {"mode": "narrow"},
+                "notes": ["note"],
+                "public_doc_inventory": {
+                    "README.md": {
+                        "exists": True,
+                        "kind": "markdown",
+                        "sha256": "aaa",
+                        "headings": ["One"],
+                        "preview_lines": ["# One"],
+                        "issue_form": None,
+                        "publish_configuration": None,
+                        "settings_table": None,
+                    },
+                    "docs/issue-form.md": {
+                        "exists": True,
+                        "kind": "markdown",
+                        "sha256": "bbb",
+                        "headings": ["Issue"],
+                        "preview_lines": ["# Issue"],
+                        "issue_form": None,
+                        "publish_configuration": None,
+                        "settings_table": None,
+                    },
+                },
+                "changed_path_summaries": {
+                    "README.md": {
+                        "kind": "markdown",
+                        "exists": True,
+                        "preview_lines": ["# One"],
+                        "headings": ["One"],
+                    }
+                },
+                "packet_candidates": {
+                    "claims_packet": {
+                        "active": True,
+                        "packet_kind": "focused",
+                        "review_docs": ["README.md"],
+                        "changed_paths": ["README.md"],
+                        "direct_doc_changes": ["README.md"],
+                        "direct_source_changes": [],
+                        "activation_reasons": ["claims drift"],
+                    },
+                    "reporting_packet": {
+                        "active": True,
+                        "packet_kind": "focused",
+                        "review_docs": ["README.md"],
+                        "changed_paths": [],
+                        "direct_doc_changes": [],
+                        "direct_source_changes": [],
+                        "activation_reasons": ["evidence"],
+                    },
+                    "workflow_packet": {
+                        "active": True,
+                        "packet_kind": "focused",
+                        "review_docs": ["README.md"],
+                        "changed_paths": [],
+                        "direct_doc_changes": [],
+                        "direct_source_changes": [],
+                        "activation_reasons": ["workflow"],
+                    },
+                    "forms_batch_packet": {
+                        "active": True,
+                        "packet_kind": "batch",
+                        "review_docs": ["README.md", "docs/issue-form.md"],
+                        "changed_paths": ["README.md"],
+                        "direct_doc_changes": ["README.md"],
+                        "direct_source_changes": [],
+                        "activation_reasons": ["forms"],
+                    },
+                },
+            }
+            lint = {
+                "issues": [
+                    {"packet": "claims_packet", "message": "claims drift"},
+                    {"packet": "forms_batch_packet", "message": "forms drift"},
+                ],
+                "packet_basis": {
+                    "claims_packet": {
+                        "deterministic_action_candidates": [
+                            {
+                                "packet": "claims_packet",
+                                "kind": "settings_default_sync",
+                                "canonical_type": "settings_table_default_sync",
+                                "path": "README.md",
+                                "message": "Sync a README setting row.",
+                                "details": {"setting": "EnableThing"},
+                                "evidence_anchor": "runtime default",
+                                "expected_edit_scope": "single README settings-table cell update",
+                            }
+                        ],
+                        "manual_review_residuals": [],
+                        "marker_gate_signals": {
+                            "marker_blocked_by_packet": False,
+                            "blocking_reasons": [],
+                            "manual_review_residual_count": 0,
+                            "deterministic_candidate_count": 1,
+                        },
+                    },
+                    "forms_batch_packet": {
+                        "deterministic_action_candidates": [
+                            {
+                                "packet": "forms_batch_packet",
+                                "kind": "issue_template_metadata_sync",
+                                "canonical_type": "issue_template_metadata_sync",
+                                "path": "docs/issue-form.md",
+                                "message": "Sync issue-form metadata.",
+                                "details": {"field": "labels"},
+                                "evidence_anchor": "form metadata",
+                                "expected_edit_scope": "single issue-template metadata update",
+                            }
+                        ],
+                        "manual_review_residuals": [
+                            {
+                                "classification": "review_required",
+                                "path": "README.md",
+                                "message": "Narrative review still needed.",
+                                "severity": "warning",
+                                "blocking_scope": "marker-update",
+                                "related_paths": ["README.md"],
+                                "evidence_anchor": "review signal",
+                            }
+                        ],
+                        "marker_gate_signals": {
+                            "marker_blocked_by_packet": True,
+                            "blocking_reasons": ["Narrative review still needed."],
+                            "manual_review_residual_count": 1,
+                            "deterministic_candidate_count": 1,
+                        },
+                    },
+                },
+                "auto_apply_candidates": [
+                    {"packet": "claims_packet", "path": "README.md", "kind": "settings_default_sync"},
+                    {"packet": "forms_batch_packet", "path": "docs/issue-form.md", "kind": "issue_template_metadata_sync"},
+                ],
+                "override_signals": {"lint": True},
+            }
+
+            self.write_json(context_path, context)
+            self.write_json(lint_path, lint)
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "build_public_docs_sync_packets.py",
+                    "--context",
+                    str(context_path),
+                    "--lint",
+                    str(lint_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--result-output",
+                    str(result_path),
+                ],
+            ):
+                exit_code = packets.main()
+
+            self.assertEqual(exit_code, 0)
+
+            orchestrator = self.read_json(output_dir / "orchestrator.json")
+            global_packet = self.read_json(output_dir / "global_packet.json")
+            claims_packet = self.read_json(output_dir / "claims_packet.json")
+            forms_packet = self.read_json(output_dir / "forms_batch_packet.json")
+            batch_packet = self.read_json(output_dir / "batch-packet-01.json")
+            packet_metrics = self.read_json(output_dir / "packet_metrics.json")
+            build_result = self.read_json(result_path)
+
+            self.assertEqual(orchestrator["orchestrator_profile"], "standard")
+            self.assertEqual(orchestrator["review_mode"], "broad-delegation")
+            self.assertFalse(orchestrator["decision_ready_packets"])
+            self.assertEqual(orchestrator["worker_return_contract"], contract.WORKER_RETURN_CONTRACT)
+            self.assertEqual(orchestrator["worker_output_shape"], contract.WORKER_OUTPUT_SHAPE)
+            self.assertEqual(orchestrator["applied_override_signals"], ["lint"])
+            self.assertEqual(orchestrator["packet_worker_map"], contract.PACKET_WORKER_MAP)
+            self.assertEqual(orchestrator["raw_reread_allowed_reasons"], contract.RAW_REREAD_ALLOWED_REASONS)
+            self.assertNotIn("packet_size_bytes", orchestrator)
+            self.assertEqual(
+                [worker["agent_type"] for worker in orchestrator["recommended_workers"]],
+                ["large_diff_auditor", "evidence_summarizer", "docs_verifier", "docs_verifier"],
+            )
+            self.assertEqual(orchestrator["recommended_workers"][-1]["packet"], "batch-packet-01.json")
+            self.assertEqual([worker["agent_type"] for worker in orchestrator["optional_workers"]], ["repo_mapper", "log_triager"])
+            self.assertEqual(global_packet["orchestrator_profile"], "standard")
+            self.assertEqual(global_packet["review_mode_overrides"], contract.REVIEW_MODE_OVERRIDES)
+            self.assertEqual(global_packet["packet_worker_map"]["batch-packet-01"], ["docs_verifier"])
+            self.assertEqual(global_packet["raw_reread_allowed_reasons"], contract.RAW_REREAD_ALLOWED_REASONS)
+            self.assertEqual(global_packet["github_evidence_urls"], ["https://example.test/pr/1"])
+            self.assertEqual(claims_packet["ownership_summary"]["packet"], "claims_packet")
+            self.assertEqual(claims_packet["deterministic_action_candidates"][0]["canonical_type"], "settings_table_default_sync")
+            self.assertEqual(claims_packet["manual_review_residuals"], [])
+            self.assertFalse(claims_packet["marker_gate_signals"]["marker_blocked_by_packet"])
+            self.assertEqual(forms_packet["marker_gate_signals"]["manual_review_residual_count"], 1)
+            self.assertEqual(batch_packet["deterministic_action_candidates"][0]["canonical_type"], "issue_template_metadata_sync")
+            self.assertEqual(
+                packet_metrics,
+                contract.compute_packet_metrics(
+                    {
+                        "orchestrator.json": orchestrator,
+                        "global_packet.json": global_packet,
+                        "claims_packet.json": claims_packet,
+                        "reporting_packet.json": self.read_json(output_dir / "reporting_packet.json"),
+                        "workflow_packet.json": self.read_json(output_dir / "workflow_packet.json"),
+                        "forms_batch_packet.json": forms_packet,
+                        "batch-packet-01.json": batch_packet,
+                    },
+                    local_only_sources={
+                        "context.json": context,
+                        "lint.json": lint,
+                    },
+                ),
+            )
+            self.assertEqual(packet_metrics["packet_count"], 7)
+            self.assertEqual(build_result["auto_apply_candidate_count"], 2)
+            self.assertEqual(build_result["packet_metrics"]["largest_packet_bytes"], packet_metrics["largest_packet_bytes"])
+
+    def test_common_path_focused_packets_are_decision_ready(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            context_path = tmp / "context.json"
+            lint_path = tmp / "lint.json"
+            output_dir = tmp / "packets"
+
+            context = {
+                "skill_name": "public-docs-sync",
+                "context_id": "ctx-1",
+                "context_fingerprint": "fp-1",
+                "repo_root": str(tmp / "repo"),
+                "relevant_ref": {"kind": "merge-base", "base_commit": "abc123"},
+                "authority_order": ["runtime", "docs"],
+                "stop_conditions": ["stale"],
+                "github_evidence_required": False,
+                "evidence_summary": {"urls": [], "packet_signals": {}},
+                "github_evidence": {"auth_policy": "fail-closed", "artifacts": []},
+                "counts": {"active_packet_count": 1, "changed_files": 1, "doc_changes": 1, "code_changes": 0},
+                "override_signals": {},
+                "deterministic_apply_boundaries": {"mode": "narrow"},
+                "notes": [],
+                "public_doc_inventory": {
+                    "README.md": {"exists": True, "kind": "markdown", "sha256": "aaa", "headings": ["One"], "preview_lines": ["# One"]},
+                },
+                "changed_path_summaries": {
+                    "README.md": {"kind": "markdown", "exists": True, "preview_lines": ["# One"], "headings": ["One"]},
+                },
+                "packet_candidates": {
+                    "claims_packet": {
+                        "active": True,
+                        "packet_kind": "focused",
+                        "review_docs": ["README.md"],
+                        "changed_paths": ["README.md"],
+                        "direct_doc_changes": ["README.md"],
+                        "direct_source_changes": [],
+                        "activation_reasons": ["claims drift"],
+                    },
+                    "reporting_packet": {"active": False, "packet_kind": "focused", "review_docs": [], "changed_paths": [], "direct_doc_changes": [], "direct_source_changes": [], "activation_reasons": []},
+                    "workflow_packet": {"active": False, "packet_kind": "focused", "review_docs": [], "changed_paths": [], "direct_doc_changes": [], "direct_source_changes": [], "activation_reasons": []},
+                    "forms_batch_packet": {"active": False, "packet_kind": "batch", "review_docs": [], "changed_paths": [], "direct_doc_changes": [], "direct_source_changes": [], "activation_reasons": []},
+                },
+            }
+            lint = {
+                "issues": [],
+                "packet_basis": {
+                    "claims_packet": {
+                        "deterministic_action_candidates": [
+                            {
+                                "packet": "claims_packet",
+                                "kind": "public_doc_reference_sync",
+                                "canonical_type": "public_doc_reference_sync",
+                                "path": "README.md",
+                                "message": "Sync a single line.",
+                                "details": {"match_text": "old", "replacement_text": "new"},
+                                "evidence_anchor": "changed source summary",
+                                "expected_edit_scope": "single-line replacement",
+                            }
+                        ],
+                        "manual_review_residuals": [],
+                        "marker_gate_signals": {
+                            "marker_blocked_by_packet": False,
+                            "blocking_reasons": [],
+                            "manual_review_residual_count": 0,
+                            "deterministic_candidate_count": 1,
+                        },
+                    }
+                },
+                "auto_apply_candidates": [{"packet": "claims_packet", "path": "README.md", "kind": "public_doc_reference_sync"}],
+                "override_signals": {},
+            }
+
+            self.write_json(context_path, context)
+            self.write_json(lint_path, lint)
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "build_public_docs_sync_packets.py",
+                    "--context",
+                    str(context_path),
+                    "--lint",
+                    str(lint_path),
+                    "--output-dir",
+                    str(output_dir),
+                ],
+            ):
+                exit_code = packets.main()
+
+            self.assertEqual(exit_code, 0)
+            global_packet = self.read_json(output_dir / "global_packet.json")
+            claims_packet = self.read_json(output_dir / "claims_packet.json")
+            self.assertEqual(global_packet["selected_packets"], ["claims_packet.json"])
+            self.assertIn("xhigh_reread_policy", global_packet)
+            self.assertEqual(claims_packet["ownership_summary"]["review_docs"], ["README.md"])
+            self.assertEqual(claims_packet["deterministic_action_candidates"][0]["expected_edit_scope"], "single-line replacement")
+            self.assertEqual(claims_packet["manual_review_residuals"], [])
+            self.assertFalse(claims_packet["marker_gate_signals"]["marker_blocked_by_packet"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_collect_public_docs_sync_context_helpers.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_collect_public_docs_sync_context_helpers.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import collect_public_docs_sync_context as collector  # noqa: E402
+
+
+class CollectPublicDocsSyncContextHelperTests(unittest.TestCase):
+    def test_default_state_file_uses_skill_state_path(self) -> None:
+        path = collector.default_state_file("abc123")
+        self.assertTrue(str(path).endswith(str(Path(".codex/state/public-docs-sync/abc123.json"))))
+
+    def test_builder_compatibility_reports_current(self) -> None:
+        profile = collector.load_repo_profile(collector.default_repo_profile_path())
+        compatibility = collector.build_builder_compatibility(profile)
+        self.assertEqual(compatibility["status"], "current")
+
+    def test_build_context_fingerprint_changes_when_inventory_changes(self) -> None:
+        left = collector.build_context_fingerprint(
+            "head",
+            {"mode": "saved", "base_commit": "base"},
+            {"kind": "merge-base", "base_commit": "base", "head_commit": "head", "primary_pr_number": None},
+            ["README.md"],
+            {"README.md": {"sha256": "aaa"}},
+            "digest-1",
+        )
+        right = collector.build_context_fingerprint(
+            "head",
+            {"mode": "saved", "base_commit": "base"},
+            {"kind": "merge-base", "base_commit": "base", "head_commit": "head", "primary_pr_number": None},
+            ["README.md"],
+            {"README.md": {"sha256": "bbb"}},
+            "digest-1",
+        )
+        self.assertNotEqual(left, right)
+
+    def test_require_gh_auth_stops_cleanly_when_gh_is_missing(self) -> None:
+        with mock.patch.object(collector.subprocess, "run", side_effect=FileNotFoundError("gh")):
+            with self.assertRaises(SystemExit) as exc_info:
+                collector.require_gh_auth(Path("C:/repo"))
+        self.assertIn("gh auth is invalid", str(exc_info.exception))
+
+    def test_build_artifact_entry_uses_repo_profile_for_path_packet_hints(self) -> None:
+        profile = collector.load_repo_profile(collector.default_repo_profile_path())
+        artifact = collector.build_artifact_entry(
+            artifact_type="pull_request",
+            identifier="PR #1",
+            title="docs: update workflow docs",
+            body=None,
+            url="https://example.invalid/pr/1",
+            comment_digests=[],
+            changed_paths=["CONTRIBUTING.md"],
+            public_doc_paths=["CONTRIBUTING.md"],
+            repo_profile=profile,
+        )
+        self.assertIn("workflow_packet", artifact["packet_hints"])
+
+    def test_infer_repo_slug_accepts_dotted_repo_names(self) -> None:
+        self.assertEqual(
+            collector.infer_repo_slug("git@github.com:owner/my.repo.git"),
+            "owner/my.repo",
+        )
+
+    def test_main_passes_repo_profile_into_github_evidence_collection(self) -> None:
+        profile = {
+            "name": "default",
+            "summary": "test profile",
+            "bindings": {
+                "primary_readme_path": "README.md",
+                "publish_config_path": None,
+                "settings_source_path": None,
+            },
+        }
+        identity = {
+            "repo_name": "packetflow_foundry",
+            "repo_id": "repo-id",
+            "repo_hash": "repo-hash",
+            "remote_url": "https://github.com/FennexFox/packetflow_foundry",
+            "repo_slug": "FennexFox/packetflow_foundry",
+        }
+        relevant_ref = {
+            "kind": "current-branch-pr",
+            "base_commit": None,
+            "head_commit": "head-sha",
+            "primary_pr_number": 1,
+        }
+        observed: dict[str, object] = {}
+
+        def fake_collect_github_evidence(
+            repo_root: Path,
+            actual_identity: dict[str, str],
+            actual_relevant_ref: dict[str, object],
+            public_doc_paths: list[str],
+            actual_repo_profile: dict[str, object],
+        ) -> dict[str, object]:
+            observed["repo_root"] = repo_root
+            observed["identity"] = actual_identity
+            observed["relevant_ref"] = actual_relevant_ref
+            observed["public_doc_paths"] = public_doc_paths
+            observed["repo_profile"] = actual_repo_profile
+            return {"required": False, "enabled": False, "digest": None}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "context.json"
+            state_path = Path(temp_dir) / "state.json"
+            args = mock.Mock(
+                repo_root="C:/repo",
+                output=str(output_path),
+                profile="profile.json",
+                full=True,
+                since_ref=None,
+                state_file=None,
+            )
+            with (
+                mock.patch.object(collector, "parse_args", return_value=args),
+                mock.patch.object(collector, "resolve_repo_root", return_value=Path("C:/repo")),
+                mock.patch.object(collector, "resolve_profile_path", return_value=Path("C:/repo/profile.json")),
+                mock.patch.object(collector, "load_repo_profile", return_value=profile),
+                mock.patch.object(collector, "repo_identity", return_value=identity),
+                mock.patch.object(collector, "default_state_file", return_value=state_path),
+                mock.patch.object(collector, "git_head_commit", return_value="head-sha"),
+                mock.patch.object(collector, "git_branch", return_value="develop"),
+                mock.patch.object(collector, "collect_public_doc_paths", return_value=[]),
+                mock.patch.object(collector, "build_baseline", return_value={"mode": "saved", "base_commit": None}),
+                mock.patch.object(collector, "select_relevant_ref", return_value=(relevant_ref, [])),
+                mock.patch.object(collector, "collect_status_paths", return_value=[]),
+                mock.patch.object(collector, "collect_github_evidence", side_effect=fake_collect_github_evidence),
+                mock.patch.object(collector, "build_evidence_summary", return_value={"artifact_count": 0, "comment_count": 0}),
+                mock.patch.object(
+                    collector,
+                    "build_packet_candidates",
+                    return_value={"forms_batch_packet": {"active": False, "direct_source_changes": []}},
+                ),
+                mock.patch.object(collector, "build_builder_compatibility", return_value={"status": "current"}),
+                mock.patch.object(collector, "write_json"),
+            ):
+                self.assertEqual(collector.main(), 0)
+
+        self.assertEqual(observed["repo_root"], Path("C:/repo"))
+        self.assertIs(observed["identity"], identity)
+        self.assertIs(observed["relevant_ref"], relevant_ref)
+        self.assertEqual(observed["public_doc_paths"], [])
+        self.assertIs(observed["repo_profile"], profile)
+
+    def test_collect_github_evidence_fails_closed_when_required_slug_is_missing(self) -> None:
+        with self.assertRaises(SystemExit) as exc_info:
+            collector.collect_github_evidence(
+                Path("C:/repo"),
+                {"repo_slug": ""},
+                {"requires_github_evidence": True, "primary_pr_number": 1},
+                [],
+                {},
+            )
+
+        self.assertIn("repository slug could not be inferred", str(exc_info.exception))
+
+    def test_collect_github_evidence_allows_missing_slug_when_not_required(self) -> None:
+        evidence = collector.collect_github_evidence(
+            Path("C:/repo"),
+            {"repo_slug": ""},
+            {"requires_github_evidence": False, "primary_pr_number": None},
+            [],
+            {},
+        )
+
+        self.assertFalse(evidence["required"])
+        self.assertFalse(evidence["enabled"])
+        self.assertIsNone(evidence["repo_slug"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_lint_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_lint_public_docs_sync.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import lint_public_docs_sync as lint_mod  # noqa: E402
+
+
+def empty_findings() -> dict[str, object]:
+    return {
+        "errors": [],
+        "warnings": [],
+        "infos": [],
+        "issues": [],
+        "classifications": {
+            "hard_drift": [],
+            "review_required": [],
+            "link_error": [],
+            "stale_baseline": [],
+        },
+        "auto_apply_candidates": [],
+        "packet_basis": {},
+    }
+
+
+class LintPublicDocsSyncTests(unittest.TestCase):
+    def test_lint_detects_settings_drift_and_broken_links(self) -> None:
+        context = {
+            "settings": {
+                "source_path": "ExampleProduct/Setting.cs",
+                "defaults": {"EnableThing": {"default": "true"}},
+            },
+            "readme": {
+                "path": "README.md",
+                "settings_table": {"EnableThing": {"default": "false"}},
+            },
+            "public_doc_inventory": {
+                "README.md": {
+                    "missing_links": [{"target": "./missing.md", "resolved_path": "missing.md"}],
+                }
+            },
+            "packet_candidates": {
+                "claims_packet": {"review_docs": ["README.md"], "changed_paths": ["README.md"]},
+            },
+        }
+        findings = empty_findings()
+
+        lint_mod.lint_readme_settings(context, findings)
+        lint_mod.lint_missing_links(context, findings)
+        lint_mod.finalize_packet_basis(context, findings)
+
+        self.assertEqual(len(findings["classifications"]["hard_drift"]), 1)
+        self.assertEqual(len(findings["classifications"]["link_error"]), 1)
+        self.assertEqual(findings["auto_apply_candidates"][0]["kind"], "settings_default_sync")
+        self.assertEqual(findings["packet_basis"]["claims_packet"]["deterministic_action_candidates"][0]["canonical_type"], "settings_table_default_sync")
+        self.assertFalse(findings["packet_basis"]["claims_packet"]["marker_gate_signals"]["marker_blocked_by_packet"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_validate_public_docs_sync_plan.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_validate_public_docs_sync_plan.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import validate_public_docs_sync as validator  # noqa: E402
+import public_docs_sync_contract as contract  # noqa: E402
+
+
+def sample_context() -> dict[str, object]:
+    return {
+        "context_id": "ctx-1",
+        "context_fingerprint": "fp-1",
+        "repo_root": "C:/repo",
+        "repo_hash": "hash-1",
+        "repo_slug": "owner/repo",
+        "branch": "main",
+        "head_commit": "abc123",
+        "effective_base_commit": "base123",
+        "state_file": "C:/repo/.codex/state.json",
+        "github_evidence_required": False,
+        "github_evidence_digest": "digest-1",
+        "github_evidence": {
+            "primary_pr": {"number": 42, "url": "https://example.test/pr/42"},
+        },
+        "relevant_ref": {
+            "kind": "merge-base",
+            "base_commit": "base123",
+            "source": "merge-base",
+            "primary_pr_number": 42,
+            "primary_pr_url": "https://example.test/pr/42",
+        },
+        "packet_candidates": {
+            "claims_packet": {"active": True},
+            "workflow_packet": {"active": True},
+            "forms_batch_packet": {"active": True},
+        },
+        "public_doc_paths": [
+            "README.md",
+            "CONTRIBUTING.md",
+            ".github/ISSUE_TEMPLATE/bug_report.yml",
+        ],
+        "public_doc_inventory": {
+            "README.md": {
+                "kind": "markdown",
+                "missing_links": [{"target": "./missing.md"}],
+            },
+            "CONTRIBUTING.md": {"kind": "markdown"},
+            ".github/ISSUE_TEMPLATE/bug_report.yml": {"kind": "yaml"},
+        },
+        "settings": {
+            "source_path": "ExampleProduct/Setting.cs",
+            "defaults": {
+                "EnableThing": {
+                    "default": "true",
+                    "label": "Enable Thing",
+                    "description": "Turn the feature on.",
+                }
+            },
+        },
+        "readme": {
+            "path": "README.md",
+            "settings_table": {
+                "EnableThing": {
+                    "default": "false",
+                    "purpose": "Turn the feature on.",
+                }
+            },
+        },
+        "evidence_summary": {"urls": ["https://example.test/pr/1"]},
+        "baseline": {"base_commit": "base123"},
+    }
+
+
+def sample_plan() -> dict[str, object]:
+    return {
+        "context_id": "ctx-1",
+        "context_fingerprint": "fp-1",
+        "overall_confidence": "high",
+        "doc_update_status": "completed",
+        "allow_marker_update": True,
+        "actions": [
+            {
+                "type": "settings_default_sync",
+                "summary": "Sync the README settings defaults.",
+                "path": "README.md",
+                "details": {"setting": "EnableThing"},
+                "extra": "ignored",
+            }
+        ],
+        "stop_reasons": [],
+        "selected_packets": ["claims_packet"],
+        "remaining_manual_reviews": [],
+        "extra": "ignored",
+    }
+
+
+class ValidatePublicDocsSyncPlanTests(unittest.TestCase):
+    def test_validator_normalizes_actions_and_embeds_minimal_apply_snapshot(self) -> None:
+        with patch.object(validator, "run_git", return_value="abc123"):
+            payload = validator.validate_public_docs_sync_plan(sample_context(), sample_plan())
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["can_apply"])
+        self.assertTrue(payload["can_update_marker"])
+        warning_codes = {item["code"] for item in payload["warning_details"]}
+        self.assertIn(validator.VALIDATION_WARNING_CODES["unknown_top_level_field"], warning_codes)
+        self.assertIn(validator.VALIDATION_WARNING_CODES["unknown_action_field"], warning_codes)
+        normalized_action = payload["normalized_plan"]["actions"][0]
+        self.assertEqual(normalized_action["action_mode"], "deterministic-edit")
+        self.assertEqual(normalized_action["canonical_type"], "settings_table_default_sync")
+        self.assertEqual(payload["action_summary"]["deterministic_edit_count"], 1)
+        self.assertEqual(payload["apply_gate_status"]["apply_edits_status"], "pass")
+        self.assertEqual(payload["apply_gate_status"]["marker_update_status"], "pass")
+        self.assertEqual(payload["apply_gate_status"]["triggered_stop_categories"], [])
+        self.assertNotIn("extra", payload["normalized_plan"])
+        self.assertNotIn("extra", payload["normalized_plan"]["actions"][0])
+        snapshot = payload["apply_context_snapshot"]
+        self.assertEqual(
+            sorted(snapshot),
+            sorted(contract.APPLY_CONTEXT_SNAPSHOT_FIELDS),
+        )
+        self.assertEqual(
+            set(payload["apply_gate_status"]["applicable_stop_categories"]),
+            set(contract.STOP_CATEGORY_SCOPES),
+        )
+        self.assertNotIn("public_doc_inventory", snapshot)
+        self.assertEqual(snapshot["primary_pr_number"], 42)
+        self.assertTrue(payload["apply_context_snapshot_fingerprint"].startswith("sha256:"))
+
+    def test_validator_blocks_marker_update_when_manual_reviews_remain(self) -> None:
+        plan = sample_plan()
+        plan["actions"].append("Finish the release-status prose.")
+        plan["remaining_manual_reviews"] = ["Review the README narrative."]
+        with patch.object(validator, "run_git", return_value="abc123"):
+            payload = validator.validate_public_docs_sync_plan(sample_context(), plan)
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["can_apply"])
+        self.assertFalse(payload["can_update_marker"])
+        self.assertEqual(payload["action_summary"]["manual_only_review_count"], 1)
+        self.assertIn("narrative_drift_remaining", payload["apply_gate_status"]["triggered_stop_categories"])
+        self.assertEqual(payload["apply_gate_status"]["marker_update_status"], "blocked")
+
+    def test_validator_rejects_out_of_scope_deterministic_actions(self) -> None:
+        plan = sample_plan()
+        plan["actions"] = [
+            {
+                "type": "repo_wide_rewrite",
+                "summary": "Rewrite the release narrative everywhere.",
+                "path": "README.md",
+            }
+        ]
+        with patch.object(validator, "run_git", return_value="abc123"):
+            payload = validator.validate_public_docs_sync_plan(sample_context(), plan)
+
+        self.assertFalse(payload["valid"])
+        self.assertFalse(payload["can_apply"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["deterministic_scope_exceeded"], error_codes)
+        self.assertIn("deterministic_scope_exceeded", payload["apply_gate_status"]["triggered_stop_categories"])
+
+    def test_validator_flags_missing_required_evidence_with_fixed_code(self) -> None:
+        context = sample_context()
+        context["github_evidence_required"] = True
+        context["github_evidence_digest"] = ""
+        context["evidence_summary"] = {"urls": []}
+        with patch.object(validator, "run_git", return_value="abc123"):
+            payload = validator.validate_public_docs_sync_plan(context, sample_plan())
+
+        self.assertFalse(payload["valid"])
+        self.assertFalse(payload["can_apply"])
+        error_codes = {item["code"] for item in payload["error_details"]}
+        self.assertIn(validator.VALIDATION_ERROR_CODES["missing_required_evidence"], error_codes)
+        self.assertEqual(
+            validator.VALIDATION_ERROR_CODES["missing_required_evidence"],
+            contract.VALIDATION_ERROR_CODES["missing_required_evidence"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_write_evaluation_log_repo_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/tests/test_write_evaluation_log_repo_public_docs_sync.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # noqa: E402
+
+
+class RepoPublicDocsSyncEvaluationLogTests(unittest.TestCase):
+    def test_skill_specific_data_reads_lint_and_runtime_contract_fields(self) -> None:
+        lint_report = {
+            "errors": ["hard drift"],
+            "warnings": ["review required"],
+            "infos": ["info"],
+            "auto_apply_candidates": [{"kind": "settings_default_sync"}],
+            "classifications": {
+                "hard_drift": [{"message": "hard drift"}],
+                "review_required": [{"message": "review required"}],
+                "link_error": [{"message": "broken link"}],
+                "stale_baseline": [{"message": "stale baseline"}],
+            },
+        }
+        context = {
+            "baseline": {"mode": "saved", "fallback_reason": None},
+            "packet_candidates": {"claims_packet": {"active": True}},
+            "deterministic_edit_count": 2,
+            "manual_review_count": 1,
+        }
+        orchestrator = {
+            "review_mode": "targeted-delegation",
+            "packet_order": ["global_packet.json", "claims_packet.json"],
+            "selected_packets": ["claims_packet.json"],
+            "recommended_worker_count": 1,
+            "recommended_workers": [{"agent_type": "large_diff_auditor"}],
+            "applied_override_signals": ["lint"],
+        }
+
+        payload = eval_log.skill_specific_data("public-docs-sync", context, orchestrator, lint_report)
+
+        self.assertEqual(payload["hard_drift_count"], 1)
+        self.assertEqual(payload["review_required_count"], 1)
+        self.assertEqual(payload["link_error_count"], 1)
+        self.assertEqual(payload["stale_baseline_count"], 1)
+        self.assertEqual(payload["auto_apply_candidate_count"], 1)
+        self.assertEqual(payload["worker_mix"], ["large_diff_auditor"])
+
+    def test_build_phase_merges_packet_metrics_and_active_packet_counts(self) -> None:
+        log = {
+            "measurement": {},
+            "baseline": {},
+            "orchestration": {},
+            "input_size": {},
+            "skill_specific": {"data": {}},
+        }
+        result = {
+            "review_mode": "targeted-delegation",
+            "recommended_worker_count": 2,
+            "recommended_workers": [{"agent_type": "docs_verifier"}, {"agent_type": "repo_mapper"}],
+            "selected_packets": ["claims_packet.json", "workflow_packet.json"],
+            "active_packets": ["claims_packet", "workflow_packet"],
+            "active_packet_count": 2,
+            "applied_override_signals": ["high_churn"],
+            "auto_apply_candidate_count": 3,
+            "packet_metrics": {
+                "packet_count": 4,
+                "packet_size_bytes": 1024,
+                "largest_packet_bytes": 400,
+                "largest_two_packets_bytes": 700,
+                "estimated_local_only_tokens": 500,
+                "estimated_packet_tokens": 250,
+                "estimated_delegation_savings": 250,
+            },
+        }
+
+        eval_log.apply_phase_update(log, "build", result, 1.25)
+
+        self.assertEqual(log["orchestration"]["review_mode"], "targeted-delegation")
+        self.assertEqual(log["orchestration"]["worker_count"], 2)
+        self.assertEqual(log["orchestration"]["override_signals"], ["high_churn"])
+        self.assertEqual(log["input_size"]["active_areas"], 2)
+        self.assertEqual(log["skill_specific"]["data"]["packet_count"], 4)
+        self.assertEqual(log["skill_specific"]["data"]["auto_apply_candidate_count"], 3)
+        self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 500)
+        self.assertEqual(log["baseline"]["estimated_delegation_savings"], 250)
+        self.assertEqual(log["measurement"]["efficiency_source"], "estimated")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-head-commit/SKILL.md
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: reword-head-commit
+description: Rewrite only the current HEAD commit message to the active repository's commit-message rules. Use when Codex needs a fast amend-based path for one clean HEAD commit with explicit repo guidance and no packet or replay audit requirements.
+---
+
+# Reword Head Commit
+
+Use this skill as the narrow express path for rewriting the current `HEAD`
+commit message without packet generation, subagents, or temp-worktree replay.
+
+This workflow is intentionally narrow:
+- reuse the same commit-rule discovery and validation contract as
+  `reword-recent-commits`
+- stop when the repo only has derived or fallback commit guidance
+- validate locally, then amend `HEAD` directly with `git commit --amend`
+- report when a later `git push --force-with-lease` is likely required
+- keep push decisions outside this skill
+
+Boundary:
+- Keep reusable foundry semantics in `references/core-contract.md`.
+- Keep this skill limited to one clean `HEAD` commit with explicit repo rules.
+- Use `reword-recent-commits` for commit ranges, packet/audit needs, or
+  replay-style safety.
+
+## Decision Guide
+
+- Use `reword-head-commit` when the target is exactly `HEAD`, the worktree is
+  clean, repo guidance is explicit, and no packet/audit trail is needed.
+- Use `reword-recent-commits` when `count > 1`, the target is not exactly
+  `HEAD`, the repo rules are only derived or fallback, or replay-style safety
+  is preferred over a direct amend.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any
+  helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python
+  -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } |
+  Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\
+  python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then
+  reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox,
+  reuse that exact path inside the sandbox instead of calling `py` or bare
+  `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter
+  path.
+
+## Workflow
+
+1. Prepare the full replacement commit message.
+- Keep the first line as the final subject.
+- Add a blank line before any body or footer content.
+- You may pass the message directly with `--message`.
+- If you prefer `--message-file`, keep that file outside the tracked worktree
+  or under `<repo-root>/.codex/tmp/packet-workflow/reword-head-commit/` so the
+  repo stays clean.
+- Any repo-local temporary, helper, or ad hoc input file for this workflow
+  belongs under `<repo-root>/.codex/tmp/`.
+
+2. Run the express driver.
+- Run `<python-bin> -B <skill-dir>/scripts/reword_head_commit.py --repo <repo-root> --message <full-message>`.
+- Or run `<python-bin> -B <skill-dir>/scripts/reword_head_commit.py --repo <repo-root> --message-file <repo-root>/.codex/tmp/packet-workflow/reword-head-commit/message.txt`.
+- Add `--apply` only after confirmation. Without `--apply`, the driver stops
+  after validation and writes a dry-run apply summary.
+- Artifacts default to `<repo-root>/.codex/tmp/packet-workflow/reword-head-commit/<run-id>/`.
+
+3. Validate before mutation.
+- The driver reuses the same canonical rule discovery as
+  `reword-recent-commits`.
+- The driver reuses the same subject/type/scope/body validation contract as
+  `reword-recent-commits`.
+- The driver stops if repo rules are not explicit, the worktree is dirty,
+  another git operation is active, `HEAD` is detached, `HEAD` is a merge
+  commit, or `HEAD` is the root commit.
+
+4. Apply only after confirmation.
+- When `--apply` is present, the driver amends `HEAD` directly with
+  `git commit --amend -F <message-file>`.
+- The driver does not push. If the branch has an upstream, it reports that a
+  later `git push --force-with-lease` is likely required.
+- Validate the result with `git log -1 --format=fuller` and
+  `git status --short --branch`.
+
+## Scripts
+
+- `scripts/reword_head_commit.py`
+  - Driver for rule collection, HEAD context collection, validation, dry-run
+    apply summaries, real amend, and evaluation-log writing.
+- `scripts/smoke_reword_head_commit.py`
+  - Run the temp-repo smoke path through the express driver and print a compact
+    JSON summary.
+
+## References
+
+- Read `references/reword-head-commit-contract.md` for the express validation
+  and apply envelope.
+- Read `references/amend-safety.md` before changing the amend preconditions or
+  branch-tip safety checks.
+- Read `references/reword-head-commit-evaluation-contract.md` for the
+  evaluation-log fields.
+
+## Maintenance Notes
+
+- Keep this skill intentionally narrower than `reword-recent-commits`.
+- Reuse the full skill's rule collector and validator instead of forking new
+  rule-discovery semantics here.
+- Prefer `<python-bin> -B ...` so local verification does not leave fresh
+  bytecode artifacts in the distributable skill folder.
+- Keep distributable bundles free of `__pycache__/` directories and `.pyc`
+  files.
+
+## Safety
+
+- Stop if repo commit-message rules are not explicit.
+- Stop if the worktree is dirty.
+- Stop if another git operation is already in progress.
+- Stop if `HEAD` is detached, a merge commit, or the root commit.
+- Do not apply the amend without explicit confirmation.
+- Do not push automatically from this skill.

--- a/builders/packet-workflow/retained-skills/reword-head-commit/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reword Head Commit"
+  short_description: "Rewrite only the current HEAD commit message"
+  default_prompt: "Use $reword-head-commit to rewrite only the current HEAD commit message to the repo rules."

--- a/builders/packet-workflow/retained-skills/reword-head-commit/references/amend-safety.md
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/references/amend-safety.md
@@ -1,0 +1,25 @@
+# Amend Safety
+
+The express path is only for simple `HEAD` message rewrites.
+
+Preconditions:
+- `HEAD` must be the current branch tip
+- the worktree must be clean
+- no rebase, merge, cherry-pick, or bisect operation may be in progress
+- `HEAD` must not be detached
+- `HEAD` must not be a merge commit
+- `HEAD` must not be the root commit
+- commit-message rules must be explicit, not only derived from history
+
+Apply strategy:
+1. collect rules and the current `HEAD` context
+2. validate the replacement message against the shared reword contract
+3. re-check branch-tip safety immediately before mutation
+4. amend `HEAD` directly with `git commit --amend -F <message-file>`
+5. report whether an upstream makes `--force-with-lease` likely
+
+Why this stays narrow:
+- direct amend is faster than replay, but it is intentionally not the generic
+  answer for broader history rewrites
+- use `reword-recent-commits` when replay-style safety or packet evidence is
+  needed

--- a/builders/packet-workflow/retained-skills/reword-head-commit/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/references/core-contract.md
@@ -1,0 +1,25 @@
+# Reword Head Commit Core Contract
+
+`reword-head-commit` is an express retained skill for exactly one `HEAD`
+commit.
+
+Core rules:
+- no packet build
+- no subagents
+- no temp-worktree replay
+- no push side effects
+- direct amend only after local validation succeeds
+- repo-local temporary, helper, scratch, and ad hoc operator-input files stay under `.codex/tmp/`
+
+Shared authority:
+- commit-rule discovery stays aligned with
+  `reword-recent-commits/scripts/collect_commit_rules.py`
+- subject/type/scope/body validation stays aligned with
+  `reword-recent-commits/scripts/reword_plan_contract.py`
+
+Boundary:
+- if the repo rules are only derived or fallback, stop and hand off to
+  `reword-recent-commits`
+- if more than one commit or any non-`HEAD` target is needed, use
+  `reword-recent-commits`
+- this skill is intentionally narrower than the full replay-based workflow

--- a/builders/packet-workflow/retained-skills/reword-head-commit/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/references/evaluation-log-contract.md
@@ -1,0 +1,16 @@
+# Evaluation Log Contract
+
+`eval-log.json` is a compact execution record for `reword-head-commit`.
+
+Shared envelope:
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `quality`
+- `safety`
+- `outputs`
+- `skill_specific`
+
+This skill does not record packet metrics because it has no packet build path.

--- a/builders/packet-workflow/retained-skills/reword-head-commit/references/reword-head-commit-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/references/reword-head-commit-contract.md
@@ -1,0 +1,52 @@
+# Reword Head Commit Contract
+
+The express driver writes repo-local artifacts under:
+
+- `.codex/tmp/packet-workflow/reword-head-commit/<run-id>/`
+
+Artifacts:
+- `rules.json`
+- `context.json`
+- `validation.json`
+- `apply-result.json`
+- `eval-log.json`
+
+Validation contract:
+- reuse the `reword-recent-commits` validator for subject/type/scope/body
+  checks
+- extend it with one express-only hard gate:
+  - `explicit_rules_required`
+- keep the target fixed to exactly one collected `HEAD` commit
+
+`validation.json` includes:
+- `valid`
+- `errors`
+- `warnings`
+- `counters`
+- `context_fingerprint`
+- `message_set_fingerprint`
+- `normalized_rewrite_actions`
+- `rewrite_scope`
+- `rules_reliability`
+- `force_push_likely`
+- `amend_allowed`
+
+`apply-result.json` includes:
+- `status`
+- `dry_run`
+- `amend_succeeded`
+- `validation_boundary_enforced`
+- `branch`
+- `head_commit`
+- `new_head`
+- `force_push_likely`
+- `warnings`
+- `stop_reasons`
+- `context_fingerprint`
+- `message_set_fingerprint`
+
+Status values:
+- `dry-run`
+- `blocked`
+- `ok`
+- `failed`

--- a/builders/packet-workflow/retained-skills/reword-head-commit/references/reword-head-commit-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/references/reword-head-commit-evaluation-contract.md
@@ -1,0 +1,12 @@
+# Reword Head Commit Evaluation Contract
+
+Use this file for `reword-head-commit` evaluation logs.
+
+Record:
+- branch identity and original `head_commit`
+- whether validation passed
+- whether the run stayed dry-run or attempted an amend
+- whether the amend succeeded
+- whether a force push is likely because an upstream exists
+- the resulting `new_head` when the amend succeeds
+- the final stop reasons when validation or preconditions block the run

--- a/builders/packet-workflow/retained-skills/reword-head-commit/scripts/reword_head_commit.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/scripts/reword_head_commit.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Express driver for rewriting the current HEAD commit message."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ARTIFACT_NAMESPACE = Path(".codex") / "tmp" / "packet-workflow" / "reword-head-commit"
+RULES_FILE = "rules.json"
+CONTEXT_FILE = "context.json"
+VALIDATION_FILE = "validation.json"
+APPLY_RESULT_FILE = "apply-result.json"
+EVAL_LOG_FILE = "eval-log.json"
+MESSAGE_COPY_FILE = "message.txt"
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def shared_reword_scripts_dir() -> Path:
+    candidate = skill_root().parent / "reword-recent-commits" / "scripts"
+    if candidate.is_dir():
+        return candidate
+    raise RuntimeError(f"missing sibling reword-recent-commits scripts: {candidate}")
+
+
+SHARED_REWORD_SCRIPTS_DIR = shared_reword_scripts_dir()
+if str(SHARED_REWORD_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_REWORD_SCRIPTS_DIR))
+
+from apply_reword_plan import check_runtime_blockers  # type: ignore  # noqa: E402
+from collect_commit_rules import build_rules  # type: ignore  # noqa: E402
+from collect_recent_commits import build_plan  # type: ignore  # noqa: E402
+from reword_plan_contract import (  # type: ignore  # noqa: E402
+    branch_state,
+    detect_operation,
+    load_normalized_plan_envelope,
+    run_git,
+    validate_reword_plan_payload,
+)
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def load_message(args: argparse.Namespace, repo_root: Path) -> str:
+    if args.message is not None:
+        return str(args.message).strip("\n")
+    if args.message_file is None:
+        raise RuntimeError("either --message or --message-file is required")
+    message_path = args.message_file.expanduser()
+    if not message_path.is_absolute():
+        message_path = repo_root / message_path
+    message_path = message_path.resolve()
+    repo_codex_tmp = (repo_root / ".codex" / "tmp").resolve()
+    if message_path.is_relative_to(repo_root) and not message_path.is_relative_to(repo_codex_tmp):
+        raise RuntimeError("message-file paths inside the repo must live under .codex/tmp/")
+    return message_path.read_text(encoding="utf-8-sig").strip("\n")
+
+
+def runtime_namespace_root(repo_root: Path) -> Path:
+    return repo_root / ARTIFACT_NAMESPACE
+
+
+def create_artifact_root(repo_root: Path) -> Path:
+    root = runtime_namespace_root(repo_root)
+    root.mkdir(parents=True, exist_ok=True)
+    run_id = f"{isoformat_utc().replace(':', '').replace('-', '')}-{uuid.uuid4().hex[:8]}"
+    artifact_root = root / run_id
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    return artifact_root
+
+
+def build_raw_plan(context: dict[str, Any], message: str) -> dict[str, Any]:
+    commits = context.get("commits") or []
+    if not isinstance(commits, list) or len(commits) != 1 or not isinstance(commits[0], dict):
+        raise RuntimeError("expected exactly one collected HEAD commit")
+    commit = commits[0]
+    return {
+        "commits": [
+            {
+                "index": int(commit.get("index") or 1),
+                "hash": str(commit.get("hash") or ""),
+                "new_message": message,
+            }
+        ]
+    }
+
+
+def issue(level: str, code: str, message: str) -> dict[str, Any]:
+    return {"level": level, "code": code, "message": message}
+
+
+def finalize_validation(
+    validation: dict[str, Any],
+    *,
+    repo_root: Path,
+    rules: dict[str, Any],
+    repo_state: dict[str, Any],
+) -> dict[str, Any]:
+    errors = list(validation.get("errors", []))
+    warnings = list(validation.get("warnings", []))
+    stop_reasons = list(validation.get("stop_reasons", []))
+    reliability = str(rules.get("rules_reliability") or validation.get("rules_reliability") or "")
+    if reliability != "explicit":
+        errors.append(
+            issue(
+                "error",
+                "explicit_rules_required",
+                "reword-head-commit requires explicit repo commit-message guidance",
+            )
+        )
+        stop_reasons.append("explicit_rules_required")
+
+    validation["errors"] = errors
+    validation["warnings"] = warnings
+    validation["stop_reasons"] = sorted(dict.fromkeys(stop_reasons))
+    validation["rules_reliability"] = reliability
+    counters = dict(validation.get("counters", {}))
+    counters["error_count"] = len(errors)
+    counters["warning_count"] = len(warnings)
+    counters["force_push_needed"] = bool(repo_state.get("force_push_likely"))
+    validation["counters"] = counters
+    validation["valid"] = not errors
+    validation["amend_allowed"] = not errors
+    validation["force_push_likely"] = bool(repo_state.get("force_push_likely"))
+    validation["repo_root"] = str(repo_root)
+    return validation
+
+
+def validation_result(
+    repo_root: Path,
+    message: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    rules = build_rules(repo_root)
+    context = build_plan(repo_root, 1, rules)
+    repo_state = branch_state(repo_root)
+    raw_plan = build_raw_plan(context, message)
+    validation = validate_reword_plan_payload(
+        context,
+        rules,
+        raw_plan,
+        repo_state=repo_state,
+        active_operation=detect_operation(repo_root),
+    )
+    return rules, context, repo_state, finalize_validation(
+        validation,
+        repo_root=repo_root,
+        rules=rules,
+        repo_state=repo_state,
+    )
+
+
+def dedupe_issues(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str]] = set()
+    result: list[dict[str, Any]] = []
+    for issue_payload in issues:
+        key = (
+            str(issue_payload.get("level") or ""),
+            str(issue_payload.get("code") or ""),
+            str(issue_payload.get("message") or ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(issue_payload)
+    return result
+
+
+def base_apply_result(
+    *,
+    context: dict[str, Any],
+    validation: dict[str, Any],
+    repo_state: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    action = next(iter(validation.get("normalized_rewrite_actions", [])), None)
+    new_message = str(action.get("new_message") or "") if isinstance(action, dict) else ""
+    subject, _sep, body = new_message.partition("\n")
+    return {
+        "status": "dry-run" if dry_run else "pending",
+        "dry_run": dry_run,
+        "apply_requested": not dry_run,
+        "apply_attempted": False,
+        "amend_succeeded": None if dry_run else False,
+        "validation_boundary_enforced": True,
+        "branch": context.get("branch"),
+        "head_commit": context.get("head_commit"),
+        "new_head": None,
+        "force_push_likely": bool(repo_state.get("force_push_likely")),
+        "warnings": dedupe_issues(list(validation.get("warnings", []))),
+        "stop_reasons": [],
+        "context_fingerprint": validation.get("context_fingerprint"),
+        "message_set_fingerprint": validation.get("message_set_fingerprint"),
+        "rules_reliability": validation.get("rules_reliability"),
+        "operation": {
+            "kind": "amend_head_commit",
+            "new_subject": subject or None,
+            "has_body": bool(body.strip()),
+        },
+        "mutation_type": "none",
+        "ref_updated": False,
+        "tree_unchanged": None,
+        "error_message": None,
+    }
+
+
+def dry_run_result(
+    repo_root: Path,
+    context: dict[str, Any],
+    validation: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = load_normalized_plan_envelope(context, validation)
+    stop_reasons, repo_state = check_runtime_blockers(
+        repo_root,
+        context,
+        normalized["normalized_rewrite_actions"],
+    )
+    result = base_apply_result(
+        context=context,
+        validation=validation,
+        repo_state=repo_state,
+        dry_run=True,
+    )
+    if stop_reasons:
+        result["status"] = "blocked"
+        result["amend_succeeded"] = False
+        result["stop_reasons"] = stop_reasons
+    return result
+
+
+def invalid_result(
+    *,
+    context: dict[str, Any],
+    validation: dict[str, Any],
+    repo_state: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    result = base_apply_result(
+        context=context,
+        validation=validation,
+        repo_state=repo_state,
+        dry_run=dry_run,
+    )
+    result["status"] = "blocked"
+    result["amend_succeeded"] = False
+    result["stop_reasons"] = list(validation.get("stop_reasons", []))
+    return result
+
+
+def git_result(
+    repo_root: Path,
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def apply_message(
+    repo_root: Path,
+    artifact_root: Path,
+    context: dict[str, Any],
+    validation: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = load_normalized_plan_envelope(context, validation)
+    stop_reasons, repo_state = check_runtime_blockers(
+        repo_root,
+        context,
+        normalized["normalized_rewrite_actions"],
+    )
+    result = base_apply_result(
+        context=context,
+        validation=validation,
+        repo_state=repo_state,
+        dry_run=False,
+    )
+    if stop_reasons:
+        result["status"] = "blocked"
+        result["stop_reasons"] = stop_reasons
+        return result
+
+    action = normalized["normalized_rewrite_actions"][0]
+    commit = list(context.get("commits", []))[0]
+    old_head = run_git(repo_root, ["rev-parse", "HEAD"]).strip()
+    old_tree = run_git(repo_root, ["show", "-s", "--format=%T", old_head]).strip()
+    committer_name = run_git(repo_root, ["show", "-s", "--format=%cn", old_head]).strip()
+    committer_email = run_git(repo_root, ["show", "-s", "--format=%ce", old_head]).strip()
+    committer_date = run_git(repo_root, ["show", "-s", "--format=%cI", old_head]).strip()
+    message_path = artifact_root / MESSAGE_COPY_FILE
+    message_path.write_text(str(action.get("new_message") or "").strip("\n") + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = str(commit.get("author_name") or "")
+    env["GIT_AUTHOR_EMAIL"] = str(commit.get("author_email") or "")
+    env["GIT_AUTHOR_DATE"] = str(commit.get("author_date") or "")
+    env["GIT_COMMITTER_NAME"] = committer_name
+    env["GIT_COMMITTER_EMAIL"] = committer_email
+    env["GIT_COMMITTER_DATE"] = committer_date
+    result["apply_attempted"] = True
+    result["mutation_type"] = "amend_head_commit"
+    amend = git_result(
+        repo_root,
+        ["commit", "--amend", "--no-gpg-sign", "--allow-empty", "-F", str(message_path)],
+        env=env,
+    )
+    if amend.returncode != 0:
+        result["status"] = "failed"
+        result["error_message"] = amend.stderr.strip() or amend.stdout.strip() or "git commit --amend failed"
+        return result
+
+    new_head = run_git(repo_root, ["rev-parse", "HEAD"]).strip()
+    new_tree = run_git(repo_root, ["show", "-s", "--format=%T", new_head]).strip()
+    result["status"] = "ok"
+    result["amend_succeeded"] = True
+    result["new_head"] = new_head
+    result["ref_updated"] = old_head != new_head
+    result["tree_unchanged"] = old_tree == new_tree
+    return result
+
+
+def evaluation_log(
+    *,
+    run_id: str,
+    context: dict[str, Any],
+    validation: dict[str, Any],
+    apply_result: dict[str, Any],
+    artifact_root: Path,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "run_id": run_id,
+        "timestamp_utc": isoformat_utc(),
+        "skill": {
+            "name": "reword-head-commit",
+            "family": "git-history-express",
+            "archetype": "validate-and-amend",
+            "skill_version": "unversioned",
+        },
+        "repo": {
+            "repo_root": str(context.get("repo_root") or ""),
+            "branch": context.get("branch"),
+            "head_sha": context.get("head_commit"),
+            "base_ref": context.get("base_commit"),
+        },
+        "quality": {
+            "result_status": apply_result.get("status"),
+            "first_pass_usable": bool(validation.get("valid")),
+            "human_post_edit_required": False,
+            "human_post_edit_severity": "none",
+        },
+        "safety": {
+            "validation_run": True,
+            "validation_passed": bool(validation.get("valid")),
+            "apply_attempted": bool(apply_result.get("apply_attempted")),
+            "apply_succeeded": bool(apply_result.get("amend_succeeded")),
+            "mutation_type": str(apply_result.get("mutation_type") or "none"),
+            "fingerprint_match": bool(validation.get("fingerprint_match")),
+            "force_push_likely": bool(apply_result.get("force_push_likely")),
+        },
+        "outputs": {
+            "artifact_root": str(artifact_root),
+            "mutations": (
+                []
+                if not bool(apply_result.get("amend_succeeded"))
+                else [{"kind": "amend_head_commit", "branch": context.get("branch")}]
+            ),
+        },
+        "skill_specific": {
+            "schema_name": "reword-head-commit",
+            "schema_version": "1.0",
+            "data": {
+                "head_commit": context.get("head_commit"),
+                "new_head": apply_result.get("new_head"),
+                "rules_reliability": validation.get("rules_reliability"),
+                "force_push_likely": bool(apply_result.get("force_push_likely")),
+                "stop_reasons": list(apply_result.get("stop_reasons", [])),
+            },
+        },
+    }
+
+
+def summary_payload(
+    *,
+    artifact_root: Path,
+    validation_path: Path,
+    apply_result_path: Path,
+    eval_log_path: Path,
+    validation: dict[str, Any],
+    apply_result: dict[str, Any],
+) -> dict[str, Any]:
+    status = "invalid" if not bool(validation.get("valid")) else str(apply_result.get("status") or "failed")
+    next_action = "fix_message"
+    if status == "dry-run":
+        next_action = "apply"
+    elif status == "ok":
+        next_action = "done"
+    elif status == "blocked":
+        next_action = "inspect_blockers"
+    return {
+        "status": status,
+        "next_action": next_action,
+        "artifact_root": str(artifact_root),
+        "validation_path": str(validation_path),
+        "apply_result_path": str(apply_result_path),
+        "evaluation_log_path": str(eval_log_path),
+        "force_push_likely": bool(apply_result.get("force_push_likely")),
+        "new_head": apply_result.get("new_head"),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Repository path.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--message", help="Full replacement commit message.")
+    group.add_argument(
+        "--message-file",
+        type=Path,
+        help="Path to a UTF-8 text file containing the full replacement commit message. Repo-local temp inputs must live under .codex/tmp/.",
+    )
+    apply_group = parser.add_mutually_exclusive_group()
+    apply_group.add_argument("--apply", action="store_true", help="Apply the amend after validation succeeds.")
+    apply_group.add_argument("--dry-run", action="store_true", help="Validate only and emit a dry-run apply summary.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo).resolve()
+    artifact_root = create_artifact_root(repo_root)
+    run_id = artifact_root.name
+    validation_path = artifact_root / VALIDATION_FILE
+    apply_result_path = artifact_root / APPLY_RESULT_FILE
+    eval_log_path = artifact_root / EVAL_LOG_FILE
+
+    try:
+        message = load_message(args, repo_root)
+        rules, context, repo_state, validation = validation_result(repo_root, message)
+        write_json(artifact_root / RULES_FILE, rules)
+        write_json(artifact_root / CONTEXT_FILE, context)
+        write_json(validation_path, validation)
+        if not bool(validation.get("valid")):
+            apply_result = invalid_result(
+                context=context,
+                validation=validation,
+                repo_state=repo_state,
+                dry_run=not bool(args.apply),
+            )
+        elif bool(args.apply):
+            apply_result = apply_message(repo_root, artifact_root, context, validation)
+        else:
+            apply_result = dry_run_result(repo_root, context, validation)
+        write_json(apply_result_path, apply_result)
+        eval_log = evaluation_log(
+            run_id=run_id,
+            context=context,
+            validation=validation,
+            apply_result=apply_result,
+            artifact_root=artifact_root,
+        )
+        write_json(eval_log_path, eval_log)
+        print(
+            json.dumps(
+                summary_payload(
+                    artifact_root=artifact_root,
+                    validation_path=validation_path,
+                    apply_result_path=apply_result_path,
+                    eval_log_path=eval_log_path,
+                    validation=validation,
+                    apply_result=apply_result,
+                ),
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+        return 0 if str(apply_result.get("status")) in {"dry-run", "ok"} else 1
+    except Exception as exc:
+        payload = {
+            "status": "failed",
+            "next_action": "inspect_error",
+            "artifact_root": str(artifact_root),
+            "validation_path": str(validation_path),
+            "apply_result_path": str(apply_result_path),
+            "evaluation_log_path": str(eval_log_path),
+            "error_message": str(exc),
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-head-commit/scripts/smoke_reword_head_commit.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/scripts/smoke_reword_head_commit.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Smoke-test reword-head-commit through the express driver."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DRIVER_PATH = SCRIPT_DIR / "reword_head_commit.py"
+
+
+def run_git(repo: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
+def main() -> int:
+    smoke_root = Path(tempfile.gettempdir()) / "reword-head-commit-smoke"
+    if smoke_root.exists():
+        shutil.rmtree(smoke_root)
+    smoke_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(dir=smoke_root, prefix="workspace-") as tmp:
+        repo = Path(tmp) / "repo"
+        repo.mkdir()
+        run_git(repo, "init")
+        run_git(repo, "config", "user.name", "Codex")
+        run_git(repo, "config", "user.email", "codex@example.com")
+
+        rules_path = repo / ".github" / "instructions" / "commit-message.instructions.md"
+        rules_path.parent.mkdir(parents=True, exist_ok=True)
+        rules_path.write_text(
+            "\n".join(
+                [
+                    "## Format",
+                    "`<type>(<scope>): <subject>`",
+                    "## Types",
+                    "- `fix`",
+                    "## Scopes",
+                    "scope is required",
+                    "## Subject Rules",
+                    "50 characters or fewer",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        run_git(repo, "add", ".")
+        run_git(repo, "commit", "--no-gpg-sign", "-m", "fix(repo): add commit rules")
+
+        app_path = repo / "src" / "app.py"
+        app_path.parent.mkdir(parents=True, exist_ok=True)
+        app_path.write_text("print('hi')\n", encoding="utf-8")
+        run_git(repo, "add", "src/app.py")
+        run_git(repo, "commit", "--no-gpg-sign", "-m", "fix(app): seed")
+
+        message_path = repo / ".codex" / "tmp" / "packet-workflow" / "reword-head-commit" / "message.txt"
+        message_path.parent.mkdir(parents=True, exist_ok=True)
+        message_path.write_text("fix(app): rename seed\n", encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, "-B", str(DRIVER_PATH), "--repo", str(repo), "--message-file", str(message_path), "--apply"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "smoke failed")
+        payload = json.loads(result.stdout)
+        persisted_eval_log = smoke_root / "eval-log.json"
+        eval_log_path = Path(str(payload["evaluation_log_path"]))
+        persisted_eval_log.write_text(eval_log_path.read_text(encoding="utf-8"), encoding="utf-8", newline="\n")
+        print(
+            json.dumps(
+                {
+                    "status": payload["status"],
+                    "force_push_likely": payload["force_push_likely"],
+                    "new_head": payload["new_head"],
+                    "evaluation_log_path": str(persisted_eval_log),
+                },
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-head-commit/tests/reword_head_commit_test_support.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/tests/reword_head_commit_test_support.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = TEST_DIR.parent
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+SHARED_REWORD_SCRIPTS_DIR = SKILL_ROOT.parent / "reword-recent-commits" / "scripts"
+AMBIGUOUS_MODULES = (
+    "apply_reword_plan",
+    "collect_commit_rules",
+    "collect_recent_commits",
+    "reword_head_commit",
+    "reword_plan_contract",
+)
+for module_name in AMBIGUOUS_MODULES:
+    sys.modules.pop(module_name, None)
+for candidate in (str(TEST_DIR), str(SCRIPTS_DIR), str(SHARED_REWORD_SCRIPTS_DIR)):
+    while candidate in sys.path:
+        sys.path.remove(candidate)
+for candidate in (str(TEST_DIR), str(SCRIPTS_DIR), str(SHARED_REWORD_SCRIPTS_DIR)):
+    sys.path.insert(0, candidate)
+importlib.invalidate_caches()
+
+
+def run_git(
+    repo: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
+def make_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    temp_dir = tempfile.TemporaryDirectory()
+    repo = Path(temp_dir.name)
+    run_git(repo, "init")
+    run_git(repo, "config", "user.name", "Codex")
+    run_git(repo, "config", "user.email", "codex@example.com")
+    return temp_dir, repo
+
+
+def commit_file(
+    repo: Path,
+    rel_path: str,
+    content: str,
+    message: str,
+    *,
+    author_name: str = "Codex",
+    author_email: str = "codex@example.com",
+    author_date: str = "2026-03-27T00:00:00Z",
+    committer_name: str | None = None,
+    committer_email: str | None = None,
+    committer_date: str | None = None,
+) -> str:
+    path = repo / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    run_git(repo, "add", rel_path)
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = author_name
+    env["GIT_AUTHOR_EMAIL"] = author_email
+    env["GIT_AUTHOR_DATE"] = author_date
+    env["GIT_COMMITTER_NAME"] = committer_name or author_name
+    env["GIT_COMMITTER_EMAIL"] = committer_email or author_email
+    env["GIT_COMMITTER_DATE"] = committer_date or author_date
+    run_git(repo, "commit", "--no-gpg-sign", "-m", message, env=env)
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def write_rules_file(repo: Path, body: str) -> Path:
+    path = repo / ".github" / "instructions" / "commit-message.instructions.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_driver.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_driver.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from reword_head_commit_test_support import commit_file, load_json, make_repo, run_git, write_rules_file
+
+import reword_head_commit  # type: ignore  # noqa: E402
+
+
+class RewordHeadCommitDriverTests(unittest.TestCase):
+    def seed_repo(self) -> tuple[object, Path]:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        rules_text = "\n".join(
+            [
+                "## Format",
+                "`<type>(<scope>): <subject>`",
+                "## Types",
+                "- `fix`",
+                "## Scopes",
+                "scope is required",
+                "## Subject Rules",
+                "50 characters or fewer",
+            ]
+        )
+        write_rules_file(repo, rules_text)
+        commit_file(
+            repo,
+            ".github/instructions/commit-message.instructions.md",
+            rules_text,
+            "fix(repo): add commit rules",
+        )
+        commit_file(
+            repo,
+            "src/app.py",
+            "print('hi')\n",
+            "fix(app): seed",
+            author_name="Author",
+            author_email="author@example.com",
+            author_date="2026-03-27T00:00:00Z",
+        )
+        return temp_dir, repo
+
+    def run_driver(self, *args: str, cwd: Path | None = None) -> tuple[int, dict]:
+        stdout = io.StringIO()
+        chdir_context = contextlib.chdir(cwd) if cwd is not None else contextlib.nullcontext()
+        with (
+            mock.patch.object(sys, "argv", ["reword_head_commit.py", *args]),
+            chdir_context,
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = reword_head_commit.main()
+        return exit_code, json.loads(stdout.getvalue())
+
+    def test_dry_run_reports_force_push_likely_when_upstream_exists(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        with tempfile.TemporaryDirectory() as tmp:
+            remote = Path(tmp) / "remote.git"
+            remote.mkdir()
+            run_git(remote, "init", "--bare")
+            run_git(repo, "remote", "add", "origin", str(remote))
+            run_git(repo, "push", "-u", "origin", "HEAD")
+
+            message_path = repo / ".codex" / "tmp" / "packet-workflow" / "reword-head-commit" / "message.txt"
+            message_path.parent.mkdir(parents=True, exist_ok=True)
+            message_path.write_text("fix(app): rename seed\n", encoding="utf-8")
+
+            exit_code, summary = self.run_driver("--repo", str(repo), "--message-file", str(message_path))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "dry-run")
+        validation = load_json(Path(summary["validation_path"]))
+        apply_result = load_json(Path(summary["apply_result_path"]))
+        self.assertTrue(validation["force_push_likely"])
+        self.assertTrue(apply_result["force_push_likely"])
+
+    def test_apply_amends_head_without_changing_parent_or_tree(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        old_head = run_git(repo, "rev-parse", "HEAD")
+        old_parent = run_git(repo, "show", "-s", "--format=%P", old_head)
+        old_tree = run_git(repo, "show", "-s", "--format=%T", old_head)
+        old_author = run_git(repo, "show", "-s", "--format=%an|%ae|%aI", old_head)
+        old_committer = run_git(repo, "show", "-s", "--format=%cn|%ce|%cI", old_head)
+        message_path = repo / ".codex" / "tmp" / "packet-workflow" / "reword-head-commit" / "message.txt"
+        message_path.parent.mkdir(parents=True, exist_ok=True)
+        message_path.write_text(
+            "fix(app): rename seed\n\n- clarify the head commit message\n",
+            encoding="utf-8",
+        )
+
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message-file", str(message_path), "--apply")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "ok")
+        new_head = summary["new_head"]
+        self.assertIsInstance(new_head, str)
+        self.assertNotEqual(new_head, old_head)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%P", new_head), old_parent)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%T", new_head), old_tree)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%an|%ae|%aI", new_head), old_author)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%cn|%ce|%cI", new_head), old_committer)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%B", new_head), "fix(app): rename seed\n\n- clarify the head commit message")
+        apply_result = load_json(Path(summary["apply_result_path"]))
+        self.assertTrue(apply_result["amend_succeeded"])
+        self.assertTrue(apply_result["tree_unchanged"])
+
+    def test_apply_exports_committer_identity_for_amend(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        commit_file(
+            repo,
+            "src/committer.py",
+            "print('committer')\n",
+            "fix(app): add committer coverage",
+            author_name="Author",
+            author_email="author@example.com",
+            author_date="2026-03-28T00:00:00Z",
+            committer_name="Committer",
+            committer_email="committer@example.com",
+            committer_date="2026-03-29T00:00:00Z",
+        )
+        message_path = repo / ".codex" / "tmp" / "packet-workflow" / "reword-head-commit" / "message.txt"
+        message_path.parent.mkdir(parents=True, exist_ok=True)
+        message_path.write_text("fix(app): rename committer coverage\n", encoding="utf-8")
+
+        captured_env: dict[str, str] = {}
+
+        def fake_git_result(
+            repo_root: Path,
+            args: list[str],
+            *,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            captured_env.clear()
+            captured_env.update(env or {})
+            self.assertEqual(args[:2], ["commit", "--amend"])
+            return subprocess.CompletedProcess(["git", *args], 0, "", "")
+
+        with mock.patch.object(reword_head_commit, "git_result", side_effect=fake_git_result):
+            exit_code, summary = self.run_driver(
+                "--repo",
+                str(repo),
+                "--message-file",
+                str(message_path),
+                "--apply",
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "ok")
+        apply_result = load_json(Path(summary["apply_result_path"]))
+        self.assertTrue(apply_result["amend_succeeded"])
+        head_commit = run_git(repo, "rev-parse", "HEAD")
+        expected_author = run_git(repo, "show", "-s", "--format=%an|%ae|%aI", head_commit).split("|")
+        expected_committer = run_git(repo, "show", "-s", "--format=%cn|%ce|%cI", head_commit).split("|")
+        self.assertEqual(captured_env["GIT_AUTHOR_NAME"], expected_author[0])
+        self.assertEqual(captured_env["GIT_AUTHOR_EMAIL"], expected_author[1])
+        self.assertEqual(captured_env["GIT_AUTHOR_DATE"], expected_author[2])
+        self.assertEqual(captured_env["GIT_COMMITTER_NAME"], expected_committer[0])
+        self.assertEqual(captured_env["GIT_COMMITTER_EMAIL"], expected_committer[1])
+        self.assertEqual(captured_env["GIT_COMMITTER_DATE"], expected_committer[2])
+
+    def test_apply_preserves_distinct_committer_metadata(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        old_head = commit_file(
+            repo,
+            "src/committer.py",
+            "print('committer')\n",
+            "fix(app): add committer coverage",
+            author_name="Author",
+            author_email="author@example.com",
+            author_date="2026-03-28T00:00:00Z",
+            committer_name="Committer",
+            committer_email="committer@example.com",
+            committer_date="2026-03-29T00:00:00Z",
+        )
+        old_author = run_git(repo, "show", "-s", "--format=%an|%ae|%aI", old_head)
+        old_committer = run_git(repo, "show", "-s", "--format=%cn|%ce|%cI", old_head)
+        message_path = repo / ".codex" / "tmp" / "packet-workflow" / "reword-head-commit" / "message.txt"
+        message_path.parent.mkdir(parents=True, exist_ok=True)
+        message_path.write_text("fix(app): rename committer coverage\n", encoding="utf-8")
+
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message-file", str(message_path), "--apply")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "ok")
+        new_head = summary["new_head"]
+        self.assertIsInstance(new_head, str)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%an|%ae|%aI", new_head), old_author)
+        self.assertEqual(run_git(repo, "show", "-s", "--format=%cn|%ce|%cI", new_head), old_committer)
+
+    def test_express_path_rejects_non_explicit_rules(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(repo, "src/app.py", "print('hi')\n", "fix(app): seed")
+        commit_file(repo, "src/worker.py", "print('bye')\n", "fix(app): follow-up")
+        commit_file(repo, "src/final.py", "print('done')\n", "fix(app): latest")
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message", "fix(app): rename latest")
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "invalid")
+        validation = load_json(Path(summary["validation_path"]))
+        self.assertEqual(validation["rules_reliability"], "derived")
+        self.assertIn("explicit_rules_required", {item["code"] for item in validation["errors"]})
+
+    def test_dirty_worktree_blocks_validation(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        (repo / "src" / "app.py").write_text("print('changed')\n", encoding="utf-8")
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message", "fix(app): rename seed")
+
+        self.assertEqual(exit_code, 1)
+        validation = load_json(Path(summary["validation_path"]))
+        self.assertIn("dirty_worktree", {item["code"] for item in validation["errors"]})
+
+    def test_active_git_operation_blocks_validation(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        git_dir = Path(run_git(repo, "rev-parse", "--git-dir"))
+        if not git_dir.is_absolute():
+            git_dir = repo / git_dir
+        (git_dir / "MERGE_HEAD").write_text("deadbeef\n", encoding="utf-8")
+        self.addCleanup(lambda: (git_dir / "MERGE_HEAD").unlink(missing_ok=True))
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message", "fix(app): rename seed")
+
+        self.assertEqual(exit_code, 1)
+        validation = load_json(Path(summary["validation_path"]))
+        self.assertIn("active_git_operation", {item["code"] for item in validation["errors"]})
+
+    def test_invalid_message_returns_validation_summary_instead_of_generic_failure(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message", "")
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "invalid")
+        validation = load_json(Path(summary["validation_path"]))
+        apply_result = load_json(Path(summary["apply_result_path"]))
+        self.assertIn("missing_new_message", {item["code"] for item in validation["errors"]})
+        self.assertEqual(apply_result["status"], "blocked")
+        self.assertIsNone(apply_result["operation"]["new_subject"])
+
+    def test_invalid_apply_does_not_report_attempted_amend(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+
+        exit_code, summary = self.run_driver("--repo", str(repo), "--message", "", "--apply")
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "invalid")
+        apply_result = load_json(Path(summary["apply_result_path"]))
+        eval_log = load_json(Path(summary["evaluation_log_path"]))
+        self.assertTrue(apply_result["apply_requested"])
+        self.assertFalse(apply_result["apply_attempted"])
+        self.assertEqual(apply_result["mutation_type"], "none")
+        self.assertFalse(eval_log["safety"]["apply_attempted"])
+        self.assertEqual(eval_log["safety"]["mutation_type"], "none")
+
+    def test_relative_message_file_is_resolved_from_repo_root(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        message_path = repo / ".codex" / "tmp" / "packet-workflow" / "reword-head-commit" / "message.txt"
+        message_path.parent.mkdir(parents=True, exist_ok=True)
+        message_path.write_text("fix(app): rename seed\n", encoding="utf-8")
+        with tempfile.TemporaryDirectory() as outside_dir:
+            exit_code, summary = self.run_driver(
+                "--repo",
+                str(repo),
+                "--message-file",
+                ".codex/tmp/packet-workflow/reword-head-commit/message.txt",
+                cwd=Path(outside_dir),
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "dry-run")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_smoke.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_smoke.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+class RewordHeadCommitSmokeTests(unittest.TestCase):
+    def test_smoke_helper_prints_stable_summary_shape(self) -> None:
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "smoke_reword_head_commit.py"
+        result = subprocess.run(
+            [sys.executable, "-B", str(script_path)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            set(payload.keys()),
+            {"status", "force_push_likely", "new_head", "evaluation_log_path"},
+        )
+        self.assertEqual(payload["status"], "ok")
+        self.assertFalse(payload["force_push_likely"])
+        self.assertIsInstance(payload["new_head"], str)
+        self.assertTrue(Path(payload["evaluation_log_path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reword-recent-commits
-description: Rewrite or reword the latest n Git commit messages to the active repository's commit-message rules. Use when Codex needs to inspect repo-specific commit guidance, draft replacement commit messages for recent local commits, and optionally apply the rewrite safely without hand-driving an interactive rebase. Keep orchestration, final message synthesis, confirmation, and ref updates local while offloading narrow read-only packet analysis to gpt-5.4-mini workers when the rewrite spans multiple commits or areas.
+description: Rewrite or reword a recent range of Git commit messages to the active repository's commit-message rules. Use when Codex needs replay-style safety, packet/audit artifacts, or anything broader than a trivial HEAD-only amend path.
 ---
 
 # Reword Recent Commits
@@ -18,8 +18,18 @@ Boundary:
 - Keep reusable packet-workflow semantics in `references/core-contract.md`.
 - Keep default repo bindings and review-doc ownership in `profiles/default/profile.json`.
 - Keep vendored repo overrides data-only in `.codex/project/profiles/`.
+- Keep the trivial HEAD-only amend path in `reword-head-commit`; this skill
+  remains the fuller replay-based workflow.
 
 Read `references/architecture-note.md` before changing the packet/result model or the flat/generic contract.
+
+## Decision Guide
+
+- Use `reword-head-commit` when the target is exactly `HEAD`, the worktree is
+  clean, repo guidance is explicit, and no packet/audit trail is needed.
+- Use `reword-recent-commits` when `count > 1`, the target is not exactly
+  `HEAD`, the repo rules are only derived or fallback, or replay-style safety
+  is preferred over a direct amend.
 
 ## Execution Roots
 
@@ -40,13 +50,15 @@ Read `references/architecture-note.md` before changing the packet/result model o
 - Add `--apply` only after confirmation. Without `--apply`, the driver validates and runs `apply_reword_plan.py --dry-run`.
 - Use `--temp-root <path>` when `git worktree add` needs a known-writable parent path. Resolution order is `--temp-root`, then `REWORD_RECENT_COMMITS_TEMP_ROOT`, then `~/.codex/tmp/packet-workflow/reword-recent-commits/temp/<repo-name>`.
 - Artifacts default to `<repo-root>/.codex/tmp/packet-workflow/reword-recent-commits/<run-id>`, and the workflow excludes the managed `.codex/tmp/` prefix from dirty-worktree checks.
+- Keep any repo-local temporary, helper, or ad hoc input file for this workflow under `<repo-root>/.codex/tmp/` rather than the repo root or another tracked directory.
 - Read `<artifact-root>/packets/orchestrator.json` first.
 - Keep `<artifact-root>/packets/global_packet.json` in view before reading any focused packet.
 - Read `rules_packet.json` locally before drafting, then keep `rules_packet.json + one commit packet at a time` as the common path.
 - Re-check `rules_packet.json` immediately before confirming the final replacement messages.
 
 2. Follow the review mode from `orchestrator.json`.
-- `local-only`: keep the rewrite fully local.
+- `local-only`: keep the rewrite fully local, but still run the same
+  collect/build/validate/apply driver path. This is not an amend fast path.
 - `targeted-delegation`: use the routed mini workers for `rules_packet.json` and the commit packets.
 - `broad-delegation`: use the routed mini workers and add QA only when findings conflict or the rewrite spans many areas.
 - Treat `packet_worker_map` as the routing authority and `preferred_worker_families` as explanatory metadata.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: reword-recent-commits
+description: Rewrite or reword the latest n Git commit messages to the active repository's commit-message rules. Use when Codex needs to inspect repo-specific commit guidance, draft replacement commit messages for recent local commits, and optionally apply the rewrite safely without hand-driving an interactive rebase. Keep orchestration, final message synthesis, confirmation, and ref updates local while offloading narrow read-only packet analysis to gpt-5.4-mini workers when the rewrite spans multiple commits or areas.
+---
+
+# Reword Recent Commits
+
+Use this skill as the packet-driven orchestration layer for rewriting recent commit messages against the repository's own rules.
+
+This workflow follows the packet-workflow standard:
+- collect rules and commit history deterministically before drafting replacements
+- build flat packets and keep final message synthesis local
+- treat worker output as proposal-grade only
+- use `gpt-5.4-mini` only for narrow packet analysis when review mode says to delegate
+- keep ref updates local and stop on low confidence or rewrite safety blockers
+
+Boundary:
+- Keep reusable packet-workflow semantics in `references/core-contract.md`.
+- Keep default repo bindings and review-doc ownership in `profiles/default/profile.json`.
+- Keep vendored repo overrides data-only in `.codex/project/profiles/`.
+
+Read `references/architecture-note.md` before changing the packet/result model or the flat/generic contract.
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+
+## Workflow
+
+1. Use the single driver for the normal path.
+- Run `<python-bin> -B <skill-dir>/scripts/reword_recent_commits.py --repo <repo-root> --count <n> --prepare-only`.
+- Edit the emitted `message-template.json` by filling `commits[*].new_message`.
+- Run `<python-bin> -B <skill-dir>/scripts/reword_recent_commits.py --repo <repo-root> --count <n> --messages-file <message-template-json>`.
+- Add `--apply` only after confirmation. Without `--apply`, the driver validates and runs `apply_reword_plan.py --dry-run`.
+- Use `--temp-root <path>` when `git worktree add` needs a known-writable parent path. Resolution order is `--temp-root`, then `REWORD_RECENT_COMMITS_TEMP_ROOT`, then `~/.codex/tmp/packet-workflow/reword-recent-commits/temp/<repo-name>`.
+- Artifacts default to `<repo-root>/.codex/tmp/packet-workflow/reword-recent-commits/<run-id>`, and the workflow excludes the managed `.codex/tmp/` prefix from dirty-worktree checks.
+- Read `<artifact-root>/packets/orchestrator.json` first.
+- Keep `<artifact-root>/packets/global_packet.json` in view before reading any focused packet.
+- Read `rules_packet.json` locally before drafting, then keep `rules_packet.json + one commit packet at a time` as the common path.
+- Re-check `rules_packet.json` immediately before confirming the final replacement messages.
+
+2. Follow the review mode from `orchestrator.json`.
+- `local-only`: keep the rewrite fully local.
+- `targeted-delegation`: use the routed mini workers for `rules_packet.json` and the commit packets.
+- `broad-delegation`: use the routed mini workers and add QA only when findings conflict or the rewrite spans many areas.
+- Treat `packet_worker_map` as the routing authority and `preferred_worker_families` as explanatory metadata.
+- This pass is a metadata/doc refresh. Keep the current `task_packet_names` and `task_packet_ids` shapes; naming migration is intentionally out of scope.
+- If `spawn_agent` is unavailable or fails, stay local on the same packet workflow.
+
+3. Respect the flat packet contract.
+- `decision_ready_packets=false`
+- `worker_return_contract=generic`
+- `worker_output_shape=flat`
+- Workers return proposal-grade summaries only.
+- `commit-XX.json` packets summarize one commit at a time.
+- Raw rereads stay exception-only after packet generation.
+- `raw_reread_reasons` must use the enum from `scripts/reword_plan_contract.py`.
+
+4. Keep the critical path local.
+- Draft the replacement messages yourself, in oldest-to-newest order.
+- Show the proposed messages to the user and confirm immediately before rewriting history.
+- Run `reword_recent_commits.py --messages-file ... --apply` only after confirmation.
+- Validate the result with `git log -n <n> --format=fuller` and `git status --short --branch`.
+- Stop before applying if the branch tip moved, a merge commit appears in scope, `base_commit` is null, the worktree is dirty, or another git operation is already in progress.
+
+## Delegation Rules
+
+- Pass `global_packet.json` plus one focused packet per worker.
+- Keep workers narrow and read-only.
+- Prefer these roles:
+  - `docs_verifier` for `rules_packet.json`
+  - `repo_mapper` for rewrite-scope and blocker checks when helpful
+  - `evidence_summarizer` for `commit-XX.json`
+  - `large_diff_auditor` for any QA pass
+- Require flat proposal output from each worker:
+  - `commit indexes`
+  - `primary intent`
+  - `suggested type/scope`
+  - `body needed`
+  - `evidence files`
+  - `ambiguity`
+  - `confidence`
+  - `reread_control`
+- Read `references/delegation-playbook.md` when `review_mode` is not `local-only`.
+- Read `references/architecture-note.md` before changing the packet/result model.
+
+## Scripts
+
+- `scripts/reword_recent_commits.py`
+  - Normal entrypoint for prepare, validate, dry-run apply, real apply, and evaluation-log finalization.
+- `scripts/reword_runtime_paths.py`
+  - Resolve the fixed repo-local `.codex/tmp/packet-workflow/reword-recent-commits/` artifact root and replay temp-root parent path.
+- `scripts/collect_commit_rules.py`
+  - Collect canonical commit-message rules, repo defaults, recent scope vocabulary, and source paths.
+- `scripts/collect_recent_commits.py`
+  - Collect the recent target commits into a rewrite plan file in oldest-to-newest order and attach the canonical `context_fingerprint`.
+- `scripts/build_reword_packets.py`
+  - Build `global_packet.json`, `rules_packet.json`, the commit packets, `packet_metrics.json`, orchestrator metadata, and an optional build-result artifact.
+- `scripts/validate_reword_plan.py`
+  - Validate drafted `new_message` values, normalize the rewrite order, and emit the canonical apply envelope.
+- `scripts/apply_reword_plan.py`
+  - Replay the selected commits in a temporary worktree and move the branch ref only if the validated envelope still matches the current context.
+- `scripts/write_evaluation_log.py`
+  - Record the shared evaluation log for efficiency, quality, and safety tracking.
+- `scripts/reword_plan_contract.py`
+  - Shared source of truth for fingerprints, builder metadata, reread reasons, packet metrics, validation codes, stop categories, and normalized rewrite ordering.
+- `scripts/smoke_reword_recent_commits.py`
+  - Run the temp-repo smoke path through the single driver and print a compact JSON summary.
+
+## Debugging And Manual Recovery
+
+- If the driver flow blocks, fall back to the low-level scripts in order: `collect_commit_rules.py`, `collect_recent_commits.py`, `build_reword_packets.py`, `validate_reword_plan.py`, `apply_reword_plan.py`, and `write_evaluation_log.py`.
+- Keep `message-template.json` shape fixed:
+  - root keys: `context_fingerprint`, `branch`, `head_commit`, `commits`
+  - commit keys: `index`, `hash`, `current_subject`, `new_message`
+- Ignore any extra keys when using `--messages-file`; only `new_message` is consumed from the user-edited commit entries.
+
+## Evaluation
+
+- The driver initializes the evaluation log after packet generation, merges build/validation/apply phase results, and finalizes the run.
+- Use `--final-observations <json>` to merge extra finalize payload fields when needed.
+- Low-level debugging still uses `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init|phase|finalize ...`.
+- Read `references/evaluation-log-contract.md` for the shared envelope, `references/reword-recent-commits-contract.md` for the rewrite-plan contract, and `references/reword-recent-commits-evaluation-contract.md` for rewrite-specific fields.
+
+## Maintenance Notes
+
+- Prefer `<python-bin> -B ...` when running bundled scripts so local verification does not leave fresh bytecode artifacts in the distributable skill folder.
+- Keep distributable bundles free of `__pycache__/` directories and `.pyc` files.
+- Re-read `references/architecture-note.md` before changing the flat/generic contract or expanding this skill into a naming-migration pass.
+
+## Safety
+
+- Stop if a target commit is a merge commit.
+- Stop if another git operation is already in progress.
+- Stop if `base_commit` is null. Root-commit rewrites remain out of scope for this skill.
+- Stop if the worktree is dirty.
+- Do not apply the rewrite without explicit confirmation.
+- Do not hand-drive interactive rebase when the plan/apply scripts are sufficient.
+- Read `references/rule-discovery.md` when the repo rules are unclear.
+- Read `references/history-rewrite-safety.md` when the branch is shared, upstream divergence matters, or the replay script refuses to proceed.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Reword Recent Commits"
-  short_description: "Reword recent commits to repo conventions"
-  default_prompt: "Use $reword-recent-commits to rewrite the last 3 commit messages to the repo rules."
+  short_description: "Reword recent commit ranges with replay safety"
+  default_prompt: "Use $reword-recent-commits to rewrite a recent commit range when replay-style safety or packet evidence is needed."

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reword Recent Commits"
+  short_description: "Reword recent commits to repo conventions"
+  default_prompt: "Use $reword-recent-commits to rewrite the last 3 commit messages to the repo rules."

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/builder-spec.json
@@ -1,0 +1,83 @@
+{
+  "skill_name": "reword-recent-commits",
+  "description": "Rewrite or reword the latest n Git commit messages to the active repository's commit-message rules. Use when Codex needs to inspect repo-specific commit guidance, draft replacement commit messages for recent local commits, and optionally apply the rewrite safely without hand-driving an interactive rebase. Keep orchestration, final message synthesis, confirmation, and ref updates local while offloading narrow read-only packet analysis to gpt-5.4-mini workers when the rewrite spans multiple commits or areas.",
+  "domain_slug": "reword_recent_commits",
+  "workflow_family": "git-history",
+  "archetype": "plan-validate-apply",
+  "primary_goal": "rewrite recent commit messages against repo rules while keeping final wording and history mutation local",
+  "trigger_phrases": [
+    "reword recent commits",
+    "rewrite commit messages",
+    "fix recent commit subjects",
+    "repair recent commit messages"
+  ],
+  "task_packet_names": [
+    "rules",
+    "commit"
+  ],
+  "needs_validate": true,
+  "needs_apply": true,
+  "decision_ready_packets": false,
+  "worker_return_contract": "generic",
+  "worker_output_shape": "flat",
+  "packet_worker_map": {
+    "rules": [
+      "docs_verifier"
+    ],
+    "commit": [
+      "evidence_summarizer"
+    ]
+  },
+  "repo_profile": {
+    "name": "default",
+    "summary": "Default reusable profile scaffold for commit-message rewording. Replace with project-local commit-guidance docs and path hints when vendored.",
+    "repo_match": {
+      "root_markers": [
+        ".git",
+        "README.md"
+      ],
+      "remote_patterns": []
+    },
+    "bindings": {
+      "primary_readme_path": "README.md",
+      "settings_source_path": null,
+      "publish_config_path": null
+    },
+    "packet_defaults": {
+      "review_docs": {
+        "rules": [
+          "CONTRIBUTING.md",
+          "README.md"
+        ],
+        "commit": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ]
+      },
+      "source_path_globs": {
+        "rules": [
+          ".github/**",
+          "*.md"
+        ],
+        "commit": [
+          "**/*"
+        ]
+      }
+    },
+    "lint_rules": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "notes": [
+      "Keep repo-specific commit-message guidance and source-path hints in project-local profile data.",
+      "Do not place rewrite safety policy, confirmation rules, or apply semantics in the profile."
+    ]
+  },
+  "builder_versioning": {
+    "builder_family": "packet-workflow",
+    "builder_semver": "0.1.0",
+    "compatibility_epoch": 1,
+    "builder_spec_schema_version": 1,
+    "repo_profile_schema_version": 1
+  }
+}

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/migration-worksheet.md
@@ -1,0 +1,58 @@
+# Migration Worksheet: reword-recent-commits
+
+## Workflow Snapshot
+- `workflow_family`: `git-history`
+- Current runtime shape: `standard`, `generic`, `flat`, validator/apply split
+- Primary packets: `global_packet`, `rules_packet`, `commit-*`
+- Current authoritative files:
+  - references: `reword-recent-commits-contract.md`, `history-rewrite-safety.md`, `rule-discovery.md`
+  - scripts: `collect_commit_rules.py`, `collect_recent_commits.py`, `build_reword_packets.py`, `validate_reword_plan.py`, `apply_reword_plan.py`
+  - tests: build/validate/apply/smoke coverage exists
+
+## Repo-Specific Inputs Seen In Legacy Skill
+- repo-specific commit-guidance docs
+- path-to-area heuristics used for review depth
+- source vocabulary hints derived from current repo history
+
+## Migration Classification
+- `core`
+  - validator/apply split and stale-context guard semantics
+  - review-mode semantics
+  - worker-family semantics and packet-routing authority
+- `profiles/default/profile.json`
+  - commit-guidance doc paths
+  - source-path globs and repo markers
+  - declarative review-doc ownership
+- Skill-local
+  - rewrite plan schema
+  - confirmation-before-history-mutation rule
+  - replay/apply behavior and rewrite safety rules
+
+## Legacy Inventory Mapping
+- references kept as domain-local: `reword-recent-commits-contract.md`, `history-rewrite-safety.md`
+- new retained interface additions: `builder-spec.json`, `references/core-contract.md`, `profiles/default/profile.json`
+- scripts to update for profile metadata wiring: `collect_recent_commits.py`, `build_reword_packets.py`
+
+## Retained vs Consumer-Local 판정
+- Data-only profile로 표현 가능한 repo-specific 차이:
+  - commit-guidance file paths
+  - review-doc ownership and path hints
+  - repo markers
+- 실행 의미/정책/행동 계약까지 건드리는 차이:
+  - 없음. rewrite safety, confirmation, and apply behavior remain reusable skill-local contracts.
+- Decision: `retained`
+
+## Core 승격 기준
+- 반복 shared gap 여부:
+  - profile loading and profile metadata propagation repeat across retained skills
+  - generic path/area heuristics repeat across Git-oriented retained skills
+- 일회성 우회 여부:
+  - rewrite-plan semantics and replay safety remain one-skill logic
+- Decision:
+  - shared profile-loading boundary is foundry-wide
+  - rewrite-specific safety rules stay local
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/profiles/default/profile.json
@@ -1,0 +1,54 @@
+{
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "publish_config_path": null,
+    "settings_source_path": null
+  },
+  "lint_rules": {
+    "missing_review_docs_are_errors": false,
+    "require_readme_settings_table": false
+  },
+  "name": "default",
+  "notes": [
+    "Keep repo-specific commit-message guidance and source-path hints in project-local profile data.",
+    "Do not place rewrite safety policy, confirmation rules, or apply semantics in the profile."
+  ],
+  "packet_defaults": {
+    "review_docs": {
+      "commit": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "rules": [
+        "CONTRIBUTING.md",
+        "README.md"
+      ]
+    },
+    "source_path_globs": {
+      "commit": [
+        "**/*"
+      ],
+      "rules": [
+        ".github/**",
+        "*.md"
+      ]
+    }
+  },
+  "profile_path": "profiles/default/profile.json",
+  "repo_match": {
+    "remote_patterns": [],
+    "root_markers": [
+      ".git",
+      "README.md"
+    ]
+  },
+  "summary": "Default reusable profile scaffold for commit-message rewording. Replace with project-local commit-guidance docs and path hints when vendored.",
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/architecture-note.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/architecture-note.md
@@ -1,0 +1,28 @@
+# Reword Recent Commits Architecture Note
+
+This note records why `reword-recent-commits` now uses a flat/generic worker contract and when that choice should be revisited.
+This pass is a metadata/doc refresh; naming migration for `task_packet_names` and `task_packet_ids` is intentionally out of scope.
+
+## Why Flat Stays
+
+- The real output is a local ordered rewrite plan, not a reusable cross-packet candidate inventory.
+- Workers summarize rules and commit intent, but the local agent still drafts the final commit text, confirms with the user, validates the final set, and performs the history rewrite.
+- There is no real runtime consumer for hierarchical `candidates[] + footer`; that metadata added ceremony without closing a safety boundary.
+- The workflow gains more from a strong `collect -> build -> validate -> apply` contract than from a hierarchy that the local orchestrator never truly consumes.
+
+## What The Flat Contract Means
+
+- `decision_ready_packets=false`
+- `worker_return_contract=generic`
+- `worker_output_shape=flat`
+- workers return proposal-grade summaries only
+- final message synthesis, confirmation, and ref mutation stay local
+
+## When To Revisit Hierarchy
+
+Revisit a hierarchical model only if two or more of these become normal:
+
+- local code repeatedly reassembles multiple worker outputs into competing per-commit candidates
+- commit-level reread control becomes a recurring candidate-management problem
+- one final commit message regularly depends on merging multiple packet findings into a scored candidate set
+- apply-time logic starts reconstructing an intermediate candidate inventory before mutation

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/core-contract.md
@@ -110,6 +110,7 @@ Stop conditions:
 
 - Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/core-contract.md
@@ -1,0 +1,119 @@
+# Reword Recent Commits Core Contract
+
+This file captures the reusable packet-workflow core for the generated `reword-recent-commits` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+
+## Core Metadata
+
+- `workflow_family`: `git-history`
+- `archetype`: `plan-validate-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `false`
+- `worker_return_contract`: `generic`
+- `worker_output_shape`: `flat`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `rules.json`
+- `commit.json`
+- No additional orchestrator-profile-specific runtime packet is required.
+
+Review mode overrides inherited by default:
+- diff churn exceeds a configured threshold
+- core runtime, config, or process files span multiple groups
+- generated files are present but are not the majority of the change
+
+Authority order:
+- tracked repo materials
+- structured workflow packets
+- optional local helper
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale context
+- ambiguous packet or ownership match
+
+## Generic Worker Contract
+
+## Generic Adjudication Structure
+
+- This scaffold uses the `generic` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing required evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Generic flat mode does not require hierarchical `candidates[]` plus `footer` worker output.
+
+## Worker Families
+
+- The builder keeps worker-family structure generic and reusable across packet-driven workflows.
+- Preferred worker families for this scaffold:
+- `context_findings`: mapping, packet-scoped code analysis, touched-surface, and packet-membership findings
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `verifiers`: narrow claim or version-sensitive verification
+  - `docs_verifier`
+
+- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:
+- `repo_mapper`
+- `packet_explorer`
+- `docs_verifier`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- The same agent type may appear on multiple packets when those assignments are intentional.
+- `rules`
+  - `docs_verifier`
+- `commit`
+  - `evidence_summarizer`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+- Guidance notes:
+  - Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.
+  - Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.
+  - Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.
+  - Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.
+  - Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.
+  - Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.
+  - Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Summary: Default reusable profile scaffold for commit-message rewording. Replace with project-local commit-guidance docs and path hints when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `rules`
+    - `CONTRIBUTING.md`
+    - `README.md`
+  - `commit`
+    - `README.md`
+    - `CONTRIBUTING.md`
+- source path globs:
+  - `rules`
+    - `.github/**`
+    - `*.md`
+  - `commit`
+    - `**/*`
+- Default lint rules:
+- `require_readme_settings_table`: false
+- `missing_review_docs_are_errors`: false
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes
+
+- Optional local helpers remain non-authoritative even when collected.
+- Final plan confidence is recomputed locally even when worker confidence signals are present.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/delegation-playbook.md
@@ -1,0 +1,66 @@
+# Delegation Playbook
+
+Read this file when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`: no workers
+- `targeted-delegation`: 2 workers
+- `broad-delegation`: 3-4 workers
+- Optional QA worker: only when commit coverage is broad or worker findings conflict
+
+## Local Gates
+
+- Read `rules_packet.json` locally before drafting replacement messages.
+- Treat builder-style efficiency metadata as supporting context only; the flat/generic worker contract remains the runtime boundary.
+- This pass does not rename `task_packet_names` or `task_packet_ids`; use the emitted packet names as-is.
+- Re-check the final message set against `rules_packet.json` locally before confirmation and before applying the rewrite.
+
+## Preferred Worker Mapping
+
+- `global_packet.json`
+  - Every worker reads this first
+  - Purpose: keep rewrite safety, required message rules, and routing metadata in view
+- `rules_packet.json`
+  - Prefer `docs_verifier`
+  - Purpose: extract hard commit-message rules, allowed types, scope requirements, subject/body constraints, and scope vocabulary
+- `commit-XX.json`
+  - Prefer `evidence_summarizer`
+  - If you need an explicit model override, use `gpt-5.4-mini`
+  - Purpose: summarize commit intent, touched areas, suggested type/scope, and whether a body is needed
+- Optional QA pass
+  - Prefer `large_diff_auditor`
+  - If you need an explicit model override, use `gpt-5.4-mini`
+  - Purpose: compare the drafted replacement messages against the rules and per-commit evidence
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use [$reword-recent-commits](<skill-path>/SKILL.md) to analyze one commit packet.
+
+Read only:
+- <global-packet>
+- <rules-or-commit-packet>
+- <specific changed files if needed>
+
+Return exactly:
+- commit indexes
+- primary intent
+- evidence files
+- suggested type/scope
+- body needed
+- ambiguity
+- confidence
+- reread_control
+```
+
+Keep each worker narrow. Do not hand a worker intended final commit messages.
+
+## Integration Rules
+
+- Start workers, then keep reading the current plan locally instead of waiting immediately.
+- Treat worker output as evidence, not as the final commit text.
+- If workers disagree, inspect only the conflicting commits locally and add the optional QA worker if the disagreement changes the final message set.
+- Keep `apply_reword_plan.py` local. Do not delegate `git worktree`, `git update-ref`, or any ref-changing command.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/history-rewrite-safety.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/history-rewrite-safety.md
@@ -1,0 +1,52 @@
+# History Rewrite Safety
+
+Use this note when you are about to apply the rewritten messages.
+
+## Preconditions
+
+- Rewrite only recent linear commits unless the user explicitly wants a more
+  complex history edit.
+- Stop if a merge commit is in scope.
+- Stop if the worktree is dirty.
+- Stop if `.git/rebase-merge`, `.git/rebase-apply`, `.git/CHERRY_PICK_HEAD`,
+  `.git/MERGE_HEAD`, or `.git/BISECT_LOG` indicates another git operation is in
+  progress.
+- Stop if `base_commit` is null. Root-commit rewrites are not supported by this
+  workflow.
+- Confirm immediately before changing refs.
+
+## Plan File Expectations
+
+`scripts/collect_recent_commits.py` writes a JSON plan. Before applying:
+
+- keep `commits` in oldest-to-newest order
+- leave `hash` values unchanged
+- fill every `new_message` with the full replacement commit message
+- keep the plan tied to the same branch tip; if `HEAD` moved, regenerate
+- pass only the validated envelope to `apply_reword_plan.py`
+- keep `context_fingerprint` stable from collect through apply
+
+## Apply Strategy
+
+`scripts/apply_reword_plan.py` uses a temporary worktree:
+
+1. Start from the commit before the oldest targeted commit.
+2. Cherry-pick each targeted commit in order.
+3. Commit the same content with the replacement message.
+4. Update the branch ref only if the current tip still matches the plan.
+
+This avoids editing the main worktree during replay.
+
+## Failure And Cleanup Contract
+
+- If cherry-pick replay fails, the branch ref must remain unchanged.
+- Temporary worktree removal and temp-directory cleanup must always be attempted.
+- Cleanup outcome must be reported separately from the primary stop category.
+- Primary replay failure stays `replay_failed` even when cleanup also leaves leftovers.
+
+## After Rewriting
+
+- Check `git log -n <n> --format=fuller`.
+- Check `git status --short --branch`.
+- If the branch already exists on a remote, tell the user that a force-push
+  such as `git push --force-with-lease` will be required.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/reword-recent-commits-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/reword-recent-commits-contract.md
@@ -1,0 +1,142 @@
+# Reword Recent Commits Contract
+
+Use this file when drafting, validating, or evaluating the rewrite workflow built from `scripts/collect_recent_commits.py`.
+
+The authoritative runtime source is `scripts/reword_plan_contract.py`.
+
+## Packet Interface
+
+- This workflow stays flat/generic by design:
+  - `decision_ready_packets=false`
+  - `worker_return_contract=generic`
+  - `worker_output_shape=flat`
+- Workers read `global_packet.json` first, then `rules_packet.json` or one `commit-XX.json` packet.
+- The common path is `rules_packet.json + one commit packet at a time`.
+- `raw_reread_reasons` must use only the enum from `scripts/reword_plan_contract.py`.
+- This pass is a metadata/doc refresh; naming migration for `task_packet_names` and `task_packet_ids` is intentionally out of scope.
+
+## Build Artifacts
+
+`scripts/build_reword_packets.py` produces:
+
+- collected input:
+  - `plan.json` from `collect_recent_commits.py`
+  - `rules.json` from `collect_commit_rules.py`
+- packet artifacts:
+  - `global_packet.json`
+  - `rules_packet.json`
+  - `commit-XX.json`
+  - `orchestrator.json`
+  - `packet_metrics.json`
+- optional build artifact:
+  - `build-result.json` when `--result-output` is supplied
+
+## Builder Metadata
+
+`global_packet.json` and `orchestrator.json` should carry the shared builder metadata from `scripts/reword_plan_contract.py`:
+
+- flat/generic contract fields
+- `common_path_contract`
+- `task_packet_names`
+- `task_packet_ids`
+- `packet_worker_map`
+- `preferred_worker_families`
+- `worker_selection_guidance`
+- `worker_output_fields`
+- `reread_reason_values`
+- `packet_metric_fields`
+- `xhigh_reread_policy`
+
+## Collected Plan Shape
+
+Top-level fields:
+
+- `repo_root`
+- `branch`
+- `detached_head`
+- `count`
+- `head_commit`
+- `base_commit`
+- `active_operation`
+- `context_fingerprint`
+- `rules_reliability`
+- `commits`
+
+Each item in `commits` must include:
+
+- `index`
+- `hash`
+- `short_hash`
+- `parent_hashes`
+- `subject`
+- `body`
+- `full_message`
+- `author_name`
+- `author_email`
+- `author_date`
+- `files`
+- `shortstat`
+- `new_message`
+
+## Build Result Shape
+
+`build-result.json` must expose:
+
+- `review_mode`
+- `recommended_worker_count`
+- `recommended_workers`
+- `packet_files`
+- `active_packets`
+- `active_packet_count`
+- `commit_packet_count`
+- `applied_override_signals`
+- `common_path_sufficient`
+- `raw_reread_count`
+- `raw_reread_reasons`
+- `packet_metrics`
+
+`packet_metrics` must use this calculation policy:
+
+- local-only baseline: `rules.json + collected plan.json`
+- packet-path estimate: `rules_packet.json + largest commit packet`
+- `global_packet.json` is not part of the packet-path estimate
+
+## Validation Envelope
+
+`scripts/validate_reword_plan.py` must emit:
+
+- `valid`
+- `errors`
+- `warnings`
+- `counters`
+- `context_fingerprint`
+- `message_set_fingerprint`
+- `normalized_rewrite_actions`
+
+`normalized_rewrite_actions` entries keep:
+
+- `index`
+- `hash`
+- `new_message`
+
+They must always sort by:
+
+- `index`
+- `hash`
+
+## Apply Boundary
+
+- `scripts/apply_reword_plan.py` consumes only the validated envelope plus the collected context file.
+- Raw drafted plans are never valid apply input.
+- `--dry-run` must follow the same validation boundary and return structured operations without moving refs.
+- Apply must reject stale `context_fingerprint` values and keep the branch ref unchanged on replay failure.
+- Temp worktree removal and temp dir cleanup must always be attempted and reported in the result payload.
+
+## Rewrite Expectations
+
+- Keep commits in oldest-to-newest order.
+- Treat `new_message` as empty until the replacement message is drafted.
+- Stop when a target commit is a merge commit.
+- Stop when the branch tip moved or another git operation is already in progress.
+- `base_commit=null` is a collect-time exception shape only; validator and apply must fail it with `root_rewrite_unsupported`.
+- Preserve the real behavior and intent of each original commit even when the wording changes.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/reword-recent-commits-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/reword-recent-commits-evaluation-contract.md
@@ -1,0 +1,58 @@
+# Commit Reword Evaluation Contract
+
+Use this file for `reword-recent-commits` evaluation logs.
+
+## Skill-Specific Focus
+
+Record the signals that matter for history rewrite safety, build efficiency, and rewrite quality:
+
+- commit count and branch identity
+- planned versus applied commit hashes
+- validation commands that actually ran
+- whether the branch ref moved cleanly
+- packet routing and flat/generic metadata
+- packet-efficiency estimates from the build phase
+
+## Skill-Specific Data
+
+Keep these values in `skill_specific.data` when they are available:
+
+- `branch`
+- `count`
+- `commit_packet_count`
+- `decision_ready_packets`
+- `worker_return_contract`
+- `worker_output_shape`
+- `base_commit`
+- `head_commit`
+- `new_head`
+- `rewrite_mode`
+- `validation_commands`
+- `applied_commit_hashes`
+- `rules_reliability`
+- `context_fingerprint`
+- `force_push_needed`
+- `commits_rewritten`
+- `cleanup_succeeded`
+- `packet_count`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+- `common_path_sufficient`
+- `raw_reread_count`
+- `raw_reread_reasons`
+
+## Phase Guidance
+
+- `init`
+  - capture the collected commit plan and orchestrator snapshot
+- `phase=build`
+  - record `packet_metrics`
+  - record `common_path_sufficient`
+  - record `raw_reread_count` and `raw_reread_reasons`
+  - populate baseline token estimates from the build result
+- `phase=validate`
+  - record `fingerprint_match`, stop reasons, and rules reliability
+- `phase=apply`
+  - record `new_head`, `applied_commit_hashes`, `commits_rewritten`, and cleanup outcome
+- `finalize`
+  - record the final rewritten tip and any remaining caution

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/references/rule-discovery.md
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/references/rule-discovery.md
@@ -1,0 +1,45 @@
+# Rule Discovery
+
+Use this checklist before drafting replacement commit messages.
+
+## Discovery Order
+
+1. Read a repo-local commit instruction file if it exists.
+   Common locations:
+   - `.github/instructions/commit-message.instructions.md`
+   - `.github/copilot-instructions.md`
+   - `docs/` or `instructions/` files that mention commits or PR titles
+2. Read contributor docs such as `CONTRIBUTING.md`.
+3. Read maintainer docs only if contributor docs point there or they contain
+   stricter writing rules.
+4. Inspect recent `git log --oneline` output for recurring scopes and subjects.
+
+## What To Extract
+
+- Required subject format, such as `type(scope): subject`
+- Allowed `type` values
+- Whether `scope` is required and how specific it should be
+- Subject length limit
+- Imperative-mood requirements
+- Body and footer rules
+- Repo-specific defaults, such as preferring `fix` over `feat`
+- Example scopes already used in the repo
+
+## Commit Intent Heuristics
+
+- Title the primary behavior or workflow change, not the file list.
+- If runtime logic changed and tests or docs changed with it, keep the title on
+  the logic change and mention the supporting work in the body.
+- Prefer a narrower scope taken from the repo's module vocabulary over a broad
+  catch-all scope.
+- If the repo's rules say to prefer `fix` when uncertain, follow that instead
+  of generic Conventional Commit advice.
+
+## Subagent Split
+
+When subagents are available:
+
+- Ask one read-only subagent to summarize the rules and scope vocabulary.
+- Ask another read-only subagent to summarize the last `n` commits from
+  subjects, diffstats, and touched files.
+- Keep both prompts artifact-driven. Do not hand them the message you want.

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/apply_reword_plan.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/apply_reword_plan.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Apply a validated JSON plan of rewritten commit messages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from reword_runtime_paths import (
+    TEMP_ROOT_ENV_VAR,
+    create_temp_runtime_dir,
+    ensure_repo_codex_tmp_excluded,
+    resolve_temp_root,
+)
+from reword_plan_contract import (
+    branch_state,
+    detect_operation,
+    load_json,
+    load_normalized_plan_envelope,
+    recent_hashes,
+    run_git,
+)
+
+
+def write_json_output(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def git_result(
+    repo: Path,
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def replay_temp_root_error(message: str, *, temp_root_parent: Path, temp_root: Path | None = None) -> str:
+    details = [message.strip() or "replay failed"]
+    if temp_root is not None:
+        details.append(f"selected temp root: {temp_root}")
+    details.append(f"temp root parent: {temp_root_parent}")
+    details.append("retry with --temp-root <writable-parent-path>")
+    return ". ".join(details)
+
+
+def runtime_warnings(repo_state: dict[str, Any]) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    if repo_state.get("upstream_branch"):
+        warnings.append({"level": "warning", "code": "upstream_configured", "message": "branch has an upstream and rewritten history will require coordination"})
+    if int(repo_state.get("ahead_count") or 0) > 0:
+        warnings.append({"level": "warning", "code": "branch_ahead", "message": "branch is ahead of upstream; force-push is likely after rewrite"})
+    if int(repo_state.get("behind_count") or 0) > 0:
+        warnings.append({"level": "warning", "code": "branch_behind", "message": "branch is behind upstream; rewrite may diverge from the remote history"})
+    if repo_state.get("force_push_likely"):
+        warnings.append({"level": "warning", "code": "force_push_likely", "message": "history rewrite will likely require force-push-with-lease"})
+    return warnings
+
+
+def commit_lookup(context: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(commit.get("hash")): commit
+        for commit in context.get("commits", [])
+        if isinstance(commit, dict) and str(commit.get("hash") or "").strip()
+    }
+
+
+def build_operations(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    operations = []
+    for action in actions:
+        subject, _sep, body = str(action.get("new_message") or "").partition("\n")
+        operations.append(
+            {
+                "index": int(action.get("index") or 0),
+                "hash": str(action.get("hash") or ""),
+                "operation": "rewrite_commit",
+                "new_subject": subject,
+                "has_body": bool(body.strip()),
+            }
+        )
+    return operations
+
+
+def cleanup_artifacts(repo_root: Path, temp_root: Path, worktree_path: Path) -> tuple[bool, list[str]]:
+    leftover_paths: list[str] = []
+    cleanup_succeeded = True
+    remove = git_result(repo_root, ["worktree", "remove", "--force", str(worktree_path)])
+    if remove.returncode != 0 and worktree_path.exists():
+        cleanup_succeeded = False
+        leftover_paths.append(str(worktree_path))
+    shutil.rmtree(temp_root, ignore_errors=True)
+    if temp_root.exists():
+        cleanup_succeeded = False
+        leftover_paths.append(str(temp_root))
+    return cleanup_succeeded, leftover_paths
+
+
+def build_base_payload(
+    context: dict[str, Any],
+    validated: dict[str, Any],
+    repo_state: dict[str, Any],
+    *,
+    dry_run: bool,
+) -> dict[str, Any]:
+    actions = list(validated["normalized_rewrite_actions"])
+    return {
+        "status": "dry-run" if dry_run else "pending",
+        "dry_run": dry_run,
+        "apply_succeeded": None if dry_run else False,
+        "fingerprint_match": bool(validated.get("fingerprint_match")),
+        "context_fingerprint": validated.get("context_fingerprint"),
+        "message_set_fingerprint": validated.get("message_set_fingerprint"),
+        "warnings": list(validated.get("warnings", [])) + runtime_warnings(repo_state),
+        "counters": dict(validated.get("counters", {})),
+        "normalized_rewrite_actions": actions,
+        "operations": build_operations(actions),
+        "mutation_type": "rewrite_history",
+        "mutations": [] if dry_run else [{"kind": "rewrite_history", "branch": context.get("branch")}],
+        "branch": context.get("branch"),
+        "base_commit": context.get("base_commit"),
+        "head_commit": context.get("head_commit"),
+        "new_head": None,
+        "commit_count": len(actions),
+        "applied_commit_hashes": [],
+        "stop_reasons": [],
+        "rules_reliability": validated.get("rules_reliability"),
+        "force_push_needed": bool(repo_state.get("force_push_likely")),
+        "cleanup_attempted": False,
+        "cleanup_succeeded": None,
+        "leftover_paths": [],
+        "ref_updated": False,
+        "temp_root_parent": None,
+        "temp_root_source": None,
+        "selected_temp_root": None,
+    }
+
+
+def check_runtime_blockers(repo_root: Path, context: dict[str, Any], actions: list[dict[str, Any]]) -> tuple[list[str], dict[str, Any]]:
+    repo_state = branch_state(repo_root)
+    stop_reasons: list[str] = []
+    if bool(context.get("detached_head")) or not str(context.get("branch") or "").strip():
+        stop_reasons.append("detached_head")
+    operation = detect_operation(repo_root) or str(context.get("active_operation") or "").strip()
+    if operation:
+        stop_reasons.append("active_git_operation")
+    if repo_state.get("working_tree_dirty"):
+        stop_reasons.append("dirty_worktree")
+    if not str(context.get("base_commit") or "").strip():
+        stop_reasons.append("root_rewrite_unsupported")
+    if any(len(commit.get("parent_hashes", []) or []) > 1 for commit in context.get("commits", []) if isinstance(commit, dict)):
+        stop_reasons.append("merge_commit_in_scope")
+
+    expected_hashes = [str(action["hash"]) for action in actions]
+    current_hashes = recent_hashes(repo_root, len(expected_hashes))
+    if current_hashes != expected_hashes:
+        stop_reasons.append("recent_hash_drift")
+    current_head = run_git(repo_root, ["rev-parse", "HEAD"]).strip()
+    if current_head != str(context.get("head_commit") or "").strip():
+        stop_reasons.append("head_commit_drift")
+    return sorted(dict.fromkeys(stop_reasons)), repo_state
+
+
+def rewrite_commits(
+    repo_root: Path,
+    context: dict[str, Any],
+    actions: list[dict[str, Any]],
+    *,
+    cli_temp_root: Path | None,
+) -> dict[str, Any]:
+    branch = str(context.get("branch") or "").strip()
+    base_commit = str(context.get("base_commit") or "").strip()
+    head_commit = str(context.get("head_commit") or "").strip()
+    commits_by_hash = commit_lookup(context)
+    ensure_repo_codex_tmp_excluded(repo_root)
+    temp_root_parent, temp_root_source = resolve_temp_root(repo_root, cli_temp_root=cli_temp_root)
+
+    new_hashes: list[str] = []
+    outcome: dict[str, Any] = {
+        "ok": False,
+        "new_head": None,
+        "applied_commit_hashes": new_hashes,
+        "ref_updated": False,
+        "cleanup_succeeded": None,
+        "leftover_paths": [],
+        "error_message": None,
+        "temp_root_parent": str(temp_root_parent),
+        "temp_root_source": temp_root_source,
+        "selected_temp_root": None,
+    }
+
+    temp_root: Path | None = None
+    worktree_path = Path()
+
+    try:
+        temp_root = create_temp_runtime_dir(temp_root_parent)
+        outcome["selected_temp_root"] = str(temp_root)
+        worktree_path = temp_root / "worktree"
+        message_path = temp_root / "message.txt"
+
+        worktree_add = git_result(repo_root, ["worktree", "add", "--detach", str(worktree_path), base_commit])
+        if worktree_add.returncode != 0:
+            cleanup_succeeded, leftover_paths = cleanup_artifacts(repo_root, temp_root, worktree_path)
+            outcome["cleanup_succeeded"] = cleanup_succeeded
+            outcome["leftover_paths"] = leftover_paths
+            outcome["error_message"] = replay_temp_root_error(
+                (worktree_add.stderr or worktree_add.stdout).strip() or "git worktree add failed",
+                temp_root_parent=temp_root_parent,
+                temp_root=temp_root,
+            )
+            return outcome
+
+        for action in actions:
+            commit_hash = str(action["hash"])
+            source_commit = commits_by_hash[commit_hash]
+            cherry_pick = git_result(worktree_path, ["cherry-pick", "--no-commit", commit_hash])
+            if cherry_pick.returncode != 0:
+                cleanup_succeeded, leftover_paths = cleanup_artifacts(repo_root, temp_root, worktree_path)
+                outcome["cleanup_succeeded"] = cleanup_succeeded
+                outcome["leftover_paths"] = leftover_paths
+                outcome["error_message"] = replay_temp_root_error(
+                    (cherry_pick.stderr or cherry_pick.stdout).strip() or "cherry-pick failed",
+                    temp_root_parent=temp_root_parent,
+                    temp_root=temp_root,
+                )
+                return outcome
+
+            message = str(action["new_message"]).strip("\n") + "\n"
+            message_path.write_text(message, encoding="utf-8")
+            env = os.environ.copy()
+            env["GIT_AUTHOR_NAME"] = str(source_commit.get("author_name", ""))
+            env["GIT_AUTHOR_EMAIL"] = str(source_commit.get("author_email", ""))
+            env["GIT_AUTHOR_DATE"] = str(source_commit.get("author_date", ""))
+            commit_result = git_result(
+                worktree_path,
+                ["commit", "--no-gpg-sign", "-F", str(message_path)],
+                env=env,
+            )
+            if commit_result.returncode != 0:
+                cleanup_succeeded, leftover_paths = cleanup_artifacts(repo_root, temp_root, worktree_path)
+                outcome["cleanup_succeeded"] = cleanup_succeeded
+                outcome["leftover_paths"] = leftover_paths
+                outcome["error_message"] = replay_temp_root_error(
+                    (commit_result.stderr or commit_result.stdout).strip() or "commit failed",
+                    temp_root_parent=temp_root_parent,
+                    temp_root=temp_root,
+                )
+                return outcome
+            new_hashes.append(run_git(worktree_path, ["rev-parse", "HEAD"]).strip())
+
+        outcome["new_head"] = run_git(worktree_path, ["rev-parse", "HEAD"]).strip()
+        run_git(repo_root, ["update-ref", f"refs/heads/{branch}", str(outcome["new_head"]), head_commit])
+        outcome["ref_updated"] = True
+        cleanup_succeeded, leftover_paths = cleanup_artifacts(repo_root, temp_root, worktree_path)
+        outcome["ok"] = True
+        outcome["cleanup_succeeded"] = cleanup_succeeded
+        outcome["leftover_paths"] = leftover_paths
+        return outcome
+    except Exception as exc:
+        if temp_root is None:
+            outcome["cleanup_succeeded"] = False
+            outcome["leftover_paths"] = []
+            outcome["error_message"] = replay_temp_root_error(
+                str(exc),
+                temp_root_parent=temp_root_parent,
+            )
+            return outcome
+        cleanup_succeeded, leftover_paths = cleanup_artifacts(repo_root, temp_root, worktree_path)
+        outcome["cleanup_succeeded"] = cleanup_succeeded
+        outcome["leftover_paths"] = leftover_paths
+        outcome["error_message"] = replay_temp_root_error(
+            str(exc),
+            temp_root_parent=temp_root_parent,
+            temp_root=temp_root,
+        )
+        return outcome
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply a validated reword plan.")
+    parser.add_argument("--context", type=Path, required=True, help="Path to collected plan JSON from collect_recent_commits.py")
+    parser.add_argument("--plan", type=Path, required=True, help="Path to validated envelope from validate_reword_plan.py")
+    parser.add_argument("--dry-run", action="store_true", help="Validate runtime safety and print planned operations without mutating refs")
+    parser.add_argument("--result-output", type=Path, help="Optional path to write the JSON result payload.")
+    parser.add_argument("--temp-root", type=Path, help="Optional parent directory for the replay temp worktree.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload: dict[str, Any] | None = None
+    exit_code = 1
+
+    try:
+        context = load_json(args.context)
+        plan = load_json(args.plan)
+        repo_root = Path(str(context.get("repo_root") or ".")).resolve()
+        validated = load_normalized_plan_envelope(context, plan)
+        stop_reasons, repo_state = check_runtime_blockers(
+            repo_root,
+            context,
+            list(validated["normalized_rewrite_actions"]),
+        )
+        payload = build_base_payload(context, validated, repo_state, dry_run=args.dry_run)
+        payload["stop_reasons"] = stop_reasons
+        payload["counters"]["commits_rewritten"] = 0
+
+        if stop_reasons:
+            payload["status"] = "failed"
+            payload["apply_succeeded"] = False if not args.dry_run else None
+            write_json_output(args.result_output, payload)
+            print(json.dumps(payload, indent=2, ensure_ascii=True))
+            return 1
+
+        if args.dry_run:
+            payload["status"] = "dry-run"
+            payload["apply_succeeded"] = None
+            write_json_output(args.result_output, payload)
+            print(json.dumps(payload, indent=2, ensure_ascii=True))
+            return 0
+
+        rewrite_result = rewrite_commits(
+            repo_root,
+            context,
+            list(validated["normalized_rewrite_actions"]),
+            cli_temp_root=args.temp_root,
+        )
+        payload["cleanup_attempted"] = rewrite_result["selected_temp_root"] is not None
+        payload["cleanup_succeeded"] = rewrite_result["cleanup_succeeded"]
+        payload["leftover_paths"] = rewrite_result["leftover_paths"]
+        payload["ref_updated"] = bool(rewrite_result["ref_updated"])
+        payload["temp_root_parent"] = rewrite_result["temp_root_parent"]
+        payload["temp_root_source"] = rewrite_result["temp_root_source"]
+        payload["selected_temp_root"] = rewrite_result["selected_temp_root"]
+
+        if rewrite_result["ok"]:
+            payload["status"] = "ok"
+            payload["apply_succeeded"] = True
+            payload["new_head"] = rewrite_result["new_head"]
+            payload["applied_commit_hashes"] = rewrite_result["applied_commit_hashes"]
+            payload["counters"]["commits_rewritten"] = len(rewrite_result["applied_commit_hashes"])
+            exit_code = 0
+        else:
+            payload["status"] = "failed"
+            payload["apply_succeeded"] = False
+            payload["stop_reasons"] = ["replay_failed"]
+            payload["error_message"] = rewrite_result["error_message"]
+            payload["applied_commit_hashes"] = rewrite_result["applied_commit_hashes"]
+            payload["counters"]["commits_rewritten"] = len(rewrite_result["applied_commit_hashes"])
+
+        write_json_output(args.result_output, payload)
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+        return exit_code
+    except Exception as exc:
+        if payload is None:
+            payload = {
+                "status": "failed",
+                "dry_run": bool(args.dry_run),
+                "apply_succeeded": False if not args.dry_run else None,
+                "stop_reasons": ["replay_failed"],
+                "error_message": str(exc),
+            }
+        write_json_output(args.result_output, payload)
+        print(json.dumps(payload, indent=2, ensure_ascii=True))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/apply_reword_plan.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/apply_reword_plan.py
@@ -296,7 +296,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--plan", type=Path, required=True, help="Path to validated envelope from validate_reword_plan.py")
     parser.add_argument("--dry-run", action="store_true", help="Validate runtime safety and print planned operations without mutating refs")
     parser.add_argument("--result-output", type=Path, help="Optional path to write the JSON result payload.")
-    parser.add_argument("--temp-root", type=Path, help="Optional parent directory for the replay temp worktree.")
+    parser.add_argument(
+        "--temp-root",
+        type=Path,
+        help="Optional parent directory for the replay temp worktree. Repo-local overrides must live under .codex/tmp/.",
+    )
     return parser.parse_args()
 
 

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/build_reword_packets.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/build_reword_packets.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""Build compact packet artifacts for token-efficient commit-message rewording."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from reword_plan_contract import (
+    COMMON_PATH_CONTRACT,
+    DECISION_READY_PACKETS,
+    PACKET_METRIC_FIELDS,
+    RAW_REREAD_ALLOWED_REASONS,
+    WORKER_OUTPUT_SHAPE,
+    WORKER_RETURN_CONTRACT,
+    XHIGH_REREAD_POLICY,
+    branch_state,
+    build_packet_worker_map,
+    build_task_packet_ids,
+    build_task_packet_names,
+    build_context_fingerprint,
+    compute_packet_metrics,
+    dedupe_preserve,
+    detect_operation,
+    load_json,
+    parse_subject_line,
+    packet_id,
+    rules_reliability,
+)
+
+
+LOCAL_COMMIT_LIMIT = 2
+LOCAL_FILE_LIMIT = 8
+LOCAL_AREA_LIMIT = 2
+BROAD_COMMIT_LIMIT = 5
+BROAD_AREA_LIMIT = 4
+CHURN_OVERRIDE_LIMIT = 200
+MEANINGFUL_GENERATED_FILE_MIN_COUNT = 3
+MEANINGFUL_GENERATED_FILE_MIN_RATIO = 0.2
+GENERATED_FILE_PATTERNS = (
+    re.compile(r"(^|/)(bin|obj|dist|build|coverage|generated|gen)/"),
+    re.compile(r"\.(g|generated)\.[^.]+$"),
+    re.compile(r"\.designer\.[^.]+$"),
+    re.compile(r"(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|poetry\.lock|cargo\.lock)$"),
+    re.compile(r"\.min\.(js|css)$"),
+)
+
+
+def parse_shortstat(shortstat: str) -> dict[str, int]:
+    files = re.search(r"(\d+)\s+files?\s+changed", shortstat)
+    insertions = re.search(r"(\d+)\s+insertions?\(\+\)", shortstat)
+    deletions = re.search(r"(\d+)\s+deletions?\(-\)", shortstat)
+    return {
+        "files_changed": int(files.group(1)) if files else 0,
+        "insertions": int(insertions.group(1)) if insertions else 0,
+        "deletions": int(deletions.group(1)) if deletions else 0,
+        "churn": (int(insertions.group(1)) if insertions else 0)
+        + (int(deletions.group(1)) if deletions else 0),
+    }
+
+
+def classify_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    lower = normalized.lower()
+    if (
+        "/tests/" in lower
+        or lower.endswith("_test.py")
+        or lower.endswith(".tests.cs")
+        or lower.endswith(".spec.ts")
+        or lower.startswith(".github/scripts/tests/")
+    ):
+        return "tests"
+    if (
+        lower.startswith(".github/workflows/")
+        or lower.startswith(".github/scripts/")
+        or lower.startswith(".github/issue_template/")
+    ):
+        return "automation"
+    if lower.endswith(".md") or lower.startswith("docs/"):
+        return "docs"
+    if lower.endswith((".yml", ".yaml", ".toml", ".json", ".csproj", ".props", ".targets")):
+        return "config"
+    if lower.endswith((".cs", ".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java")):
+        return "runtime"
+    return "other"
+
+
+def is_generated_file(path: str) -> bool:
+    lowered = path.replace("\\", "/").lower()
+    return any(pattern.search(lowered) for pattern in GENERATED_FILE_PATTERNS)
+
+
+def core_area_for_path(path: str) -> str | None:
+    lowered = path.replace("\\", "/").lower()
+    runtime_prefixes = (
+        "src/",
+        "lib/",
+        "app/",
+        "server/",
+        "client/",
+    )
+    runtime_files: set[str] = set()
+    process_prefixes = (
+        ".github/workflows/",
+        ".github/scripts/",
+        ".github/issue_template/",
+        ".github/instructions/",
+    )
+    process_files = {
+        ".github/pull_request_template.md",
+        "contributing.md",
+        "maintaining.md",
+    }
+    config_files = {
+        "pyproject.toml",
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "poetry.lock",
+        "cargo.lock",
+    }
+
+    if lowered.startswith(runtime_prefixes) or lowered in runtime_files:
+        return "runtime"
+    if lowered.startswith(process_prefixes) or lowered in process_files:
+        return "process"
+    if lowered.endswith((".csproj", ".props", ".targets")) or lowered in config_files:
+        return "config"
+    return None
+
+
+def candidate_scopes(files: list[str], rules: dict, current_subject: str) -> list[str]:
+    candidates: list[str] = []
+    known_scopes = list(rules.get("recent_scope_vocabulary", [])) + list(
+        rules.get("rules", {}).get("scope_suggestions", [])
+    )
+    seen = set()
+
+    parsed_subject = parse_subject_line(current_subject)
+    if parsed_subject and parsed_subject.get("scope"):
+        scope = str(parsed_subject["scope"])
+        candidates.append(scope)
+        seen.add(scope)
+
+    for path in files:
+        lower = path.replace("\\", "/").lower()
+        derived = None
+        if "/systems/" in lower:
+            derived = "systems"
+        elif "/patches/" in lower:
+            derived = "patches"
+        elif lower.startswith(".github/") or lower.endswith((".yml", ".yaml")):
+            derived = "infra"
+        elif lower.endswith(".md") or lower.startswith("docs/"):
+            derived = "docs"
+        elif lower.endswith((".csproj", ".props", ".targets", ".toml", ".json")):
+            derived = "config"
+        elif "/tests/" in lower or lower.endswith("_test.py"):
+            derived = "test"
+        elif lower.endswith(".lock"):
+            derived = "deps"
+        if derived and derived not in seen:
+            candidates.append(derived)
+            seen.add(derived)
+
+    for scope in known_scopes:
+        if scope in seen:
+            continue
+        if any(scope.lower() in path.replace("\\", "/").lower() for path in files):
+            candidates.append(scope)
+            seen.add(scope)
+
+    return candidates[:6]
+
+
+def body_needed_reason(commit: dict) -> tuple[bool, str]:
+    files = commit.get("files", []) or []
+    if len(files) > 1:
+        return True, "More than one file changed."
+    if str(commit.get("body", "")).strip():
+        return True, "The current commit already carries a body."
+    return False, "Single-file change with no existing body."
+
+
+def current_message_checks(commit: dict, rules: dict, body_recommended: bool) -> dict[str, object]:
+    subject = str(commit.get("subject", "")).strip()
+    body = str(commit.get("body", "")).rstrip("\n")
+    allowed_types = rules.get("rules", {}).get("allowed_types", [])
+    scope_is_required = rules.get("rules", {}).get("scope_required")
+    subject_limit = rules.get("rules", {}).get("subject_length_limit")
+    expected_format = str(rules.get("rules", {}).get("format") or "<type>(<scope>): <subject>")
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    parsed_subject = parse_subject_line(subject)
+    if not parsed_subject:
+        errors.append(f"Subject does not match the repo format anchor `{expected_format}`.")
+    else:
+        message_type = str(parsed_subject["type"])
+        scope = str(parsed_subject.get("scope", ""))
+        if allowed_types and message_type not in allowed_types:
+            errors.append(f"Type `{message_type}` is not in the allowed type list.")
+        if scope_is_required and not scope:
+            errors.append("Scope is required by repo rules.")
+
+    if subject_limit and len(subject) > int(subject_limit):
+        warnings.append(f"Subject exceeds the repo limit of {subject_limit} characters.")
+    if body_recommended and not body.strip():
+        warnings.append("Body is recommended by repo rules or commit shape but is empty.")
+
+    return {
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def commit_quality_escape_hints(commit: dict[str, Any]) -> list[dict[str, Any]]:
+    hints: list[dict[str, Any]] = []
+    commit_index = int(commit.get("index") or 0)
+    subject = str(commit.get("subject") or "").strip()
+    files = [str(path).strip() for path in commit.get("files", []) or [] if str(path).strip()]
+    if not subject:
+        hints.append(
+            {
+                "reason": "missing_required_evidence",
+                "detail": "Commit subject is missing, so packet evidence is not sufficient for common-path drafting.",
+                "commit_index": commit_index,
+                "common_path_blocking": True,
+            }
+        )
+    if not files:
+        hints.append(
+            {
+                "reason": "missing_required_evidence",
+                "detail": "Commit file coverage is missing, so packet evidence is not sufficient for common-path drafting.",
+                "commit_index": commit_index,
+                "common_path_blocking": True,
+            }
+        )
+    return hints
+
+
+def determine_review_mode(
+    commit_count: int,
+    unique_file_count: int,
+    active_area_count: int,
+    override_signals: list[dict[str, str]],
+) -> tuple[str, int]:
+    if commit_count <= LOCAL_COMMIT_LIMIT and unique_file_count <= LOCAL_FILE_LIMIT and active_area_count <= LOCAL_AREA_LIMIT:
+        review_mode = "local-only"
+    elif commit_count > BROAD_COMMIT_LIMIT or active_area_count >= BROAD_AREA_LIMIT:
+        review_mode = "broad-delegation"
+    else:
+        review_mode = "targeted-delegation"
+
+    if override_signals and review_mode == "local-only":
+        review_mode = "targeted-delegation"
+    elif override_signals and review_mode == "targeted-delegation":
+        review_mode = "broad-delegation"
+
+    if review_mode == "local-only":
+        return review_mode, 0
+    if review_mode == "targeted-delegation":
+        return review_mode, 2
+    return review_mode, 3 if commit_count <= 6 else 4
+
+
+def chunk_commit_indexes(commit_indexes: list[int], chunks: int) -> list[list[int]]:
+    if chunks <= 0:
+        return []
+    result: list[list[int]] = [[] for _ in range(chunks)]
+    for index, commit_index in enumerate(commit_indexes):
+        result[index % chunks].append(commit_index)
+    return [chunk for chunk in result if chunk]
+
+
+def packet_name_for_commit(commit_index: int) -> str:
+    return f"commit-{commit_index:02d}.json"
+
+
+def build_result_payload(
+    *,
+    review_mode: str,
+    recommended_workers: list[dict[str, Any]],
+    packet_files: list[str],
+    active_packets: list[str],
+    applied_override_signals: list[str],
+    commit_packet_count: int,
+    packet_metrics: dict[str, int],
+    common_path_sufficient: bool,
+    raw_reread_reasons: list[str],
+) -> dict[str, Any]:
+    return {
+        "review_mode": review_mode,
+        "recommended_worker_count": len(recommended_workers),
+        "recommended_workers": recommended_workers,
+        "packet_files": packet_files,
+        "active_packets": active_packets,
+        "active_packet_count": len(active_packets),
+        "commit_packet_count": commit_packet_count,
+        "applied_override_signals": applied_override_signals,
+        "common_path_sufficient": common_path_sufficient,
+        "raw_reread_count": len(raw_reread_reasons),
+        "raw_reread_reasons": raw_reread_reasons,
+        "packet_metrics": packet_metrics,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build packet artifacts for token-efficient commit-message rewording."
+    )
+    parser.add_argument("--rules", type=Path, required=True, help="Path to rules JSON from collect_commit_rules.py")
+    parser.add_argument("--plan", type=Path, required=True, help="Path to plan JSON from collect_recent_commits.py")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory for generated packets")
+    parser.add_argument("--result-output", type=Path, help="Optional path to write build result JSON.")
+    args = parser.parse_args()
+
+    rules = load_json(args.rules)
+    plan = load_json(args.plan)
+    repo_root = Path(str(plan.get("repo_root", "")))
+    commits = plan.get("commits", [])
+    if not isinstance(commits, list) or not commits:
+        print("build_reword_packets.py: plan does not contain commits", file=sys.stderr)
+        return 1
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    branch_info = branch_state(repo_root)
+    active_operation = detect_operation(repo_root)
+    context_fingerprint_value = build_context_fingerprint(plan, rules)
+    rules_reliability_value = rules_reliability(rules)
+    unique_files = sorted({path for commit in commits for path in commit.get("files", [])})
+    unique_file_count = len(unique_files)
+    generated_file_count = sum(1 for path in unique_files if is_generated_file(path))
+    generated_file_ratio = (generated_file_count / unique_file_count) if unique_file_count else 0.0
+    area_names = sorted({classify_path(path) for path in unique_files if classify_path(path) != "other"})
+    core_areas_touched = sorted(
+        {
+            area
+            for path in unique_files
+            if (area := core_area_for_path(path)) is not None
+        }
+    )
+
+    total_insertions = 0
+    total_deletions = 0
+    total_churn = 0
+    merge_commit_indexes: list[int] = []
+    commit_packet_names: list[str] = []
+    commit_payloads: dict[str, dict[str, Any]] = {}
+    commit_quality_hints: list[dict[str, Any]] = []
+
+    global_packet = {
+        "purpose": "Shared context every worker should keep in view before reading its packet.",
+        "task_intent": "Rewrite recent commit messages to repo rules without losing each commit's real behavior or workflow intent.",
+        "repo_profile_name": plan.get("repo_profile_name"),
+        "repo_profile_path": plan.get("repo_profile_path"),
+        "repo_profile_summary": plan.get("repo_profile_summary"),
+        "repo_profile": plan.get("repo_profile"),
+        "rewrite_scope": {
+            "count": plan.get("count"),
+            "branch": plan.get("branch"),
+            "head_commit": plan.get("head_commit"),
+            "base_commit": plan.get("base_commit"),
+        },
+        "context_fingerprint": context_fingerprint_value,
+        "rewrite_safety": {
+            "detached_head": plan.get("detached_head"),
+            "active_operation": active_operation or plan.get("active_operation"),
+            "working_tree_dirty": branch_info["working_tree_dirty"],
+            "upstream_branch": branch_info["upstream_branch"],
+            "ahead_count": branch_info["ahead_count"],
+            "behind_count": branch_info["behind_count"],
+            "force_push_likely": branch_info["force_push_likely"],
+        },
+        "rules_reliability": rules_reliability_value,
+        "required_message_rules": {
+            "format": rules.get("rules", {}).get("format"),
+            "allowed_types": rules.get("rules", {}).get("allowed_types", []),
+            "scope_required": rules.get("rules", {}).get("scope_required"),
+            "subject_length_limit": rules.get("rules", {}).get("subject_length_limit"),
+            "body_rules": rules.get("rules", {}).get("body_rules", []),
+            "references_rules": rules.get("rules", {}).get("references_rules", []),
+        },
+        "disallowed_rewrite_actions": [
+            "Do not change refs or run apply_reword_plan.py without explicit user confirmation.",
+            "Do not hand-drive interactive rebase when the plan/apply scripts are sufficient.",
+            "Do not rewrite merge commits with this workflow.",
+            "Do not proceed while another git operation is already in progress.",
+            "Do not invent issue references or body bullets that are not supported by the commit content or repo context.",
+        ],
+        "recent_scope_vocabulary": rules.get("recent_scope_vocabulary", []),
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+    }
+    (output_dir / "global_packet.json").write_text(
+        json.dumps(global_packet, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    rules_packet = {
+        "purpose": "Extract hard commit-message rules and preferred scope vocabulary.",
+        "local_gate": "Read this packet locally before drafting replacement messages, and re-check the final draft set against it before applying the rewrite.",
+        "context_fingerprint": context_fingerprint_value,
+        "rules_reliability": rules_reliability_value,
+        "rule_files": rules.get("rule_files", {}),
+        "rules": rules.get("rules", {}),
+        "rule_derivation": rules.get("rule_derivation", {}),
+        "recent_scope_vocabulary": rules.get("recent_scope_vocabulary", []),
+        "recent_subject_samples": rules.get("recent_subject_samples", []),
+        "instruction_snippets": rules.get("instruction_snippets", {}),
+        "doc_mentions": rules.get("doc_mentions", {}),
+    }
+    (output_dir / "rules_packet.json").write_text(
+        json.dumps(rules_packet, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    for commit in commits:
+        commit_index = int(commit["index"])
+        shortstat = parse_shortstat(str(commit.get("shortstat", "")))
+        total_insertions += shortstat["insertions"]
+        total_deletions += shortstat["deletions"]
+        total_churn += shortstat["churn"]
+        if len(commit.get("parent_hashes", [])) > 1:
+            merge_commit_indexes.append(commit_index)
+
+        files = commit.get("files", []) or []
+        areas = sorted({classify_path(path) for path in files if classify_path(path) != "other"})
+        body_needed, reason = body_needed_reason(commit)
+        quality_escape_hints = commit_quality_escape_hints(commit)
+        commit_quality_hints.extend(quality_escape_hints)
+        packet = {
+            "purpose": "Summarize one commit's real intent before drafting a replacement message.",
+            "commit": {
+                "index": commit_index,
+                "hash": commit.get("hash"),
+                "short_hash": commit.get("short_hash"),
+                "subject": commit.get("subject"),
+                "body": commit.get("body"),
+                "full_message": commit.get("full_message"),
+                "parent_hashes": commit.get("parent_hashes"),
+                "new_message": commit.get("new_message", ""),
+            },
+            "files": files,
+            "shortstat": shortstat,
+            "inferred_areas": areas,
+            "scope_candidates": candidate_scopes(files, rules, str(commit.get("subject", ""))),
+            "body_guidance": {
+                "body_recommended": body_needed,
+                "reason": reason,
+            },
+            "current_message_checks": current_message_checks(commit, rules, body_needed),
+            "quality_escape_hints": quality_escape_hints,
+            "rules_reliability": rules_reliability_value,
+        }
+        packet_name = packet_name_for_commit(commit_index)
+        (output_dir / packet_name).write_text(
+            json.dumps(packet, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+        commit_packet_names.append(packet_name)
+        commit_payloads[packet_name] = packet
+
+    override_signals: list[dict[str, str]] = []
+    if total_churn >= CHURN_OVERRIDE_LIMIT:
+        override_signals.append(
+            {
+                "reason": "aggregate_churn_threshold",
+                "detail": f"Aggregate shortstat churn reached {total_churn} lines (threshold {CHURN_OVERRIDE_LIMIT}).",
+            }
+        )
+    if len(core_areas_touched) >= 2:
+        override_signals.append(
+            {
+                "reason": "core_files_across_groups",
+                "detail": "Core runtime/config/process files were touched across multiple areas: "
+                + ", ".join(core_areas_touched),
+            }
+        )
+    if (
+        generated_file_count >= MEANINGFUL_GENERATED_FILE_MIN_COUNT
+        and MEANINGFUL_GENERATED_FILE_MIN_RATIO <= generated_file_ratio < 0.5
+    ):
+        override_signals.append(
+            {
+                "reason": "generated_files_meaningful_minor_slice",
+                "detail": "Generated files are a meaningful minority slice "
+                f"({generated_file_count}/{unique_file_count}) of the touched files.",
+            }
+        )
+
+    review_mode, worker_count = determine_review_mode(
+        commit_count=len(commits),
+        unique_file_count=unique_file_count,
+        active_area_count=len(area_names),
+        override_signals=override_signals,
+    )
+
+    raw_reread_reasons = dedupe_preserve(
+        [
+            str(item.get("reason"))
+            for item in commit_quality_hints
+            if item.get("common_path_blocking")
+        ]
+    )
+    unexpected_reread_reasons = [
+        reason
+        for reason in raw_reread_reasons
+        if reason not in RAW_REREAD_ALLOWED_REASONS
+    ]
+    if unexpected_reread_reasons:
+        print(
+            "build_reword_packets.py: unsupported reread reasons generated: "
+            + ", ".join(unexpected_reread_reasons),
+            file=sys.stderr,
+        )
+        return 1
+    common_path_sufficient = not raw_reread_reasons
+
+    task_packet_names = build_task_packet_names(commit_packet_names)
+    task_packet_ids = build_task_packet_ids(commit_packet_names)
+    packet_worker_map = build_packet_worker_map(commit_packet_names)
+    preferred_worker_families = {
+        "context_findings": ["repo_mapper", "docs_verifier", "evidence_summarizer"],
+        "verifiers": ["docs_verifier"],
+    }
+    worker_selection_guidance = [
+        "docs_verifier: use for rules_packet and hard commit-message constraints.",
+        "evidence_summarizer: use for commit packets that summarize one commit's intent and rewrite constraints.",
+        "large_diff_auditor: use for QA when the rewrite spans many commits or the evidence disagrees.",
+        "repo_mapper: keep local for rewrite-scope and blocker inspection before final synthesis.",
+    ]
+    worker_output_fields = [
+        "commit_indexes",
+        "primary_intent",
+        "suggested_type_scope",
+        "body_needed",
+        "evidence_files",
+        "ambiguity",
+        "confidence",
+        "reread_control",
+    ]
+    global_packet.update(
+        {
+            "decision_ready_packets": DECISION_READY_PACKETS,
+            "worker_return_contract": WORKER_RETURN_CONTRACT,
+            "worker_output_shape": WORKER_OUTPUT_SHAPE,
+            "common_path_contract": COMMON_PATH_CONTRACT,
+            "task_packet_names": task_packet_names,
+            "task_packet_ids": task_packet_ids,
+            "worker_selection_guidance": worker_selection_guidance,
+            "preferred_worker_families": preferred_worker_families,
+            "packet_worker_map": packet_worker_map,
+            "worker_output_fields": worker_output_fields,
+            "reread_reason_values": RAW_REREAD_ALLOWED_REASONS,
+            "packet_metric_fields": PACKET_METRIC_FIELDS,
+            "xhigh_reread_policy": XHIGH_REREAD_POLICY,
+            "common_path_sufficient": common_path_sufficient,
+            "raw_reread_reasons": raw_reread_reasons,
+        }
+    )
+    (output_dir / "global_packet.json").write_text(
+        json.dumps(global_packet, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    recommended_workers: list[dict[str, object]] = []
+    optional_workers: list[dict[str, object]] = []
+    commit_indexes = [int(commit["index"]) for commit in commits]
+
+    if review_mode == "targeted-delegation":
+        recommended_workers.append(
+            {
+                "name": "rules",
+                "agent_type": "docs_verifier",
+                "packets": ["global_packet.json", "rules_packet.json"],
+                "responsibility": "Extract hard commit-message rules and preferred scope vocabulary.",
+                "reasoning_effort": "medium",
+            }
+        )
+        recommended_workers.append(
+            {
+                "name": "commit-intent",
+                "agent_type": "evidence_summarizer",
+                "packets": ["global_packet.json", *commit_packet_names],
+                "responsibility": "Summarize each targeted commit's primary intent and rewrite constraints.",
+                "reasoning_effort": "medium",
+                "model": "gpt-5.4-mini",
+            }
+        )
+    elif review_mode == "broad-delegation":
+        recommended_workers.append(
+            {
+                "name": "rules",
+                "agent_type": "docs_verifier",
+                "packets": ["global_packet.json", "rules_packet.json"],
+                "responsibility": "Extract hard commit-message rules and preferred scope vocabulary.",
+                "reasoning_effort": "medium",
+            }
+        )
+        commit_worker_count = max(1, worker_count - 1)
+        for batch_index, batch in enumerate(chunk_commit_indexes(commit_indexes, commit_worker_count), start=1):
+            packets = ["global_packet.json"] + [packet_name_for_commit(index) for index in batch]
+            recommended_workers.append(
+                {
+                    "name": f"commit-batch-{batch_index}",
+                    "agent_type": "evidence_summarizer",
+                    "packets": packets,
+                    "responsibility": "Summarize commit intent and rewrite constraints for this commit batch.",
+                    "reasoning_effort": "medium",
+                    "model": "gpt-5.4-mini",
+                }
+            )
+        optional_workers.append(
+            {
+                "name": "qa",
+                "agent_type": "large_diff_auditor",
+                "packets": ["global_packet.json", "rules_packet.json", *commit_packet_names],
+                    "responsibility": "Compare the drafted replacement messages against the rules and per-commit evidence.",
+                    "reasoning_effort": "medium",
+                    "when": "Only add this pass when the rewrite covers many areas or worker findings conflict.",
+                }
+        )
+
+    orchestrator = {
+        "rewrite_scope": {
+            "count": len(commits),
+            "branch": plan.get("branch"),
+            "head_commit": plan.get("head_commit"),
+        },
+        "repo_profile_name": plan.get("repo_profile_name"),
+        "repo_profile_path": plan.get("repo_profile_path"),
+        "repo_profile_summary": plan.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "worker_budget": len(recommended_workers),
+        "recommended_worker_count": len(recommended_workers),
+        "optional_worker_count": len(optional_workers),
+        "shared_packet": "global_packet.json",
+        "shared_packet_name": "global_packet.json",
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "common_path_contract": COMMON_PATH_CONTRACT,
+        "task_packet_names": task_packet_names,
+        "task_packet_ids": task_packet_ids,
+        "commit_packet_count": len(commit_packet_names),
+        "worker_selection_guidance": worker_selection_guidance,
+        "preferred_worker_families": preferred_worker_families,
+        "packet_worker_map": packet_worker_map,
+        "worker_output_fields": worker_output_fields,
+        "reread_reason_values": RAW_REREAD_ALLOWED_REASONS,
+        "packet_metric_fields": PACKET_METRIC_FIELDS,
+        "xhigh_reread_policy": XHIGH_REREAD_POLICY,
+        "active_areas": area_names,
+        "context_fingerprint": context_fingerprint_value,
+        "rules_reliability": rules_reliability_value,
+        "common_path_sufficient": common_path_sufficient,
+        "raw_reread_reasons": raw_reread_reasons,
+        "rewrite_blockers": {
+            "active_operation": active_operation or plan.get("active_operation"),
+            "detached_head": bool(plan.get("detached_head")),
+            "merge_commit_indexes": merge_commit_indexes,
+            "root_rewrite_unsupported": not bool(plan.get("base_commit")),
+        },
+        "diff_summary": {
+            "commit_count": len(commits),
+            "unique_file_count": unique_file_count,
+            "aggregate_shortstat": {
+                "insertions": total_insertions,
+                "deletions": total_deletions,
+                "churn": total_churn,
+            },
+            "generated_file_count": generated_file_count,
+            "generated_file_ratio": round(generated_file_ratio, 3),
+            "core_areas_touched": core_areas_touched,
+        },
+        "review_overrides": override_signals,
+        "local_responsibilities": [
+            "Read rules_packet.json locally before drafting replacement messages.",
+            "Draft the final replacement commit messages locally.",
+            "Keep commits in oldest-to-newest order.",
+            "Re-check the final message set against rules_packet.json locally before asking for confirmation.",
+            "Ask for confirmation immediately before rewriting history.",
+            "Run apply_reword_plan.py only after confirmation.",
+        ],
+        "packet_files": ["global_packet.json", "rules_packet.json", *commit_packet_names, "orchestrator.json"],
+        "recommended_workers": recommended_workers,
+        "optional_workers": optional_workers,
+    }
+    (output_dir / "orchestrator.json").write_text(
+        json.dumps(orchestrator, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    packet_payloads: dict[str, dict[str, Any]] = {
+        "global_packet.json": global_packet,
+        "rules_packet.json": rules_packet,
+        **commit_payloads,
+    }
+    packet_metrics = compute_packet_metrics(
+        packet_payloads,
+        local_only_sources={"rules": rules, "plan": plan},
+        shared_packets=COMMON_PATH_CONTRACT["shared_packets"],
+    )
+    (output_dir / "packet_metrics.json").write_text(
+        json.dumps(packet_metrics, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    active_packets = ["rules_packet.json", *commit_packet_names]
+    build_result = build_result_payload(
+        review_mode=review_mode,
+        recommended_workers=recommended_workers,
+        packet_files=orchestrator["packet_files"],
+        active_packets=active_packets,
+        applied_override_signals=[str(item.get("reason")) for item in override_signals if str(item.get("reason") or "").strip()],
+        commit_packet_count=len(commit_packet_names),
+        packet_metrics=packet_metrics,
+        common_path_sufficient=common_path_sufficient,
+        raw_reread_reasons=raw_reread_reasons,
+    )
+    if args.result_output:
+        args.result_output.parent.mkdir(parents=True, exist_ok=True)
+        args.result_output.write_text(
+            json.dumps(build_result, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output_dir),
+                "review_mode": review_mode,
+                "packet_files": orchestrator["packet_files"],
+                "recommended_worker_count": len(recommended_workers),
+                "common_path_sufficient": common_path_sufficient,
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_commit_rules.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_commit_rules.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Collect repo-specific commit-message rules into a compact JSON artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from reword_plan_contract import rules_reliability
+
+RULE_TEXT_SUFFIXES = (".md", ".txt", ".json", ".yml", ".yaml", ".js", ".cjs", ".mjs", ".ts")
+SUBJECT_RE = re.compile(
+    r"^(?P<type>[a-z][a-z0-9-]*)(?:\((?P<scope>[A-Za-z0-9._/-]+)\))?(?P<breaking>!)?: (?P<summary>.+)$"
+)
+FIXED_RULE_FILES = {
+    "commit_message_instructions": ".github/instructions/commit-message.instructions.md",
+    "copilot_instructions": ".github/copilot-instructions.md",
+    "contributing": "CONTRIBUTING.md",
+    "maintaining": "MAINTAINING.md",
+}
+
+
+def run_git(repo: Path, args: list[str], check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout
+
+
+def read_text_if_exists(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def parse_heading_blocks(markdown_text: str | None) -> dict[str, str]:
+    if not markdown_text:
+        return {}
+    blocks: dict[str, str] = {}
+    current = None
+    buffer: list[str] = []
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            if current is not None:
+                blocks[current] = "\n".join(buffer).strip()
+            current = line[3:].strip()
+            buffer = []
+        elif current is not None:
+            buffer.append(line)
+    if current is not None:
+        blocks[current] = "\n".join(buffer).strip()
+    return blocks
+
+
+def find_block(blocks: dict[str, str], prefix: str) -> str | None:
+    for heading, body in blocks.items():
+        if heading.lower().startswith(prefix.lower()):
+            return "## " + heading + ("\n" + body if body else "")
+    return None
+
+
+def extract_bullets(block: str | None) -> list[str]:
+    if not block:
+        return []
+    bullets: list[str] = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+    return bullets
+
+
+def extract_backtick_tokens(block: str | None) -> list[str]:
+    if not block:
+        return []
+    seen: list[str] = []
+    for token in re.findall(r"`([^`]+)`", block):
+        if token not in seen:
+            seen.append(token)
+    return seen
+
+
+def normalize_token_list(tokens: list[str]) -> list[str]:
+    seen: list[str] = []
+    for token in tokens:
+        cleaned = token.strip().strip("`").strip()
+        lowered = cleaned.lower()
+        if not re.fullmatch(r"[a-z][a-z0-9-]*", lowered):
+            continue
+        if lowered not in seen:
+            seen.append(lowered)
+    return seen
+
+
+def subject_length_limit(subject_block: str | None) -> int | None:
+    if not subject_block:
+        return None
+    match = re.search(r"(\d+)\s+characters?\s+or\s+fewer", subject_block, flags=re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def explicit_scope_requirement(format_block: str | None, scopes_block: str | None) -> bool | None:
+    combined = "\n".join(part for part in (format_block, scopes_block) if part)
+    if not combined:
+        return None
+    if re.search(r"scope`?\s+(?:is\s+)?optional", combined, flags=re.IGNORECASE):
+        return False
+    if re.search(r"scope`?\s+(?:is\s+)?not required", combined, flags=re.IGNORECASE):
+        return False
+    if re.search(r"scope`?\s+is\s+required", combined, flags=re.IGNORECASE):
+        return True
+    if "<type>(<scope>): <subject>" in combined:
+        return True
+    if re.search(r"(?:<type>|type)\s*!?\s*:\s*(?:<subject>|subject)", combined, flags=re.IGNORECASE):
+        return False
+    return None
+
+
+def commit_related_excerpt(text: str | None) -> list[str]:
+    if not text:
+        return []
+    matches: list[str] = []
+    for line in text.splitlines():
+        lowered = line.lower()
+        if "commit" in lowered or "conventional commit" in lowered or "subject" in lowered:
+            stripped = line.strip()
+            if stripped and stripped not in matches:
+                matches.append(stripped)
+        if len(matches) >= 8:
+            break
+    return matches
+
+
+def parse_subject_line(subject: str) -> dict[str, str | bool] | None:
+    match = SUBJECT_RE.match(subject.strip())
+    if not match:
+        return None
+    return {
+        "type": match.group("type"),
+        "scope": match.group("scope") or "",
+        "breaking": bool(match.group("breaking")),
+        "summary": match.group("summary"),
+    }
+
+
+def recent_subjects(repo_root: Path, count: int = 20) -> list[str]:
+    output = run_git(repo_root, ["log", f"-n{count}", "--format=%s"], check=False)
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def recent_scopes(subjects: list[str]) -> list[str]:
+    seen: list[str] = []
+    for subject in subjects:
+        parsed = parse_subject_line(subject)
+        scope = str(parsed.get("scope", "")) if parsed else ""
+        if scope and scope not in seen:
+            seen.append(scope)
+    return seen
+
+
+def tracked_files(repo_root: Path) -> list[str]:
+    output = run_git(repo_root, ["ls-files"], check=False)
+    return [line.strip().replace("\\", "/") for line in output.splitlines() if line.strip()]
+
+
+def rule_file_key(rel_path: str) -> str | None:
+    lowered = rel_path.lower()
+    basename = Path(rel_path).name.lower()
+    for key, fixed_path in FIXED_RULE_FILES.items():
+        if lowered == fixed_path.lower():
+            return key
+
+    commitlint_names = {
+        ".commitlintrc",
+        ".commitlintrc.json",
+        ".commitlintrc.yml",
+        ".commitlintrc.yaml",
+        ".commitlintrc.js",
+        ".commitlintrc.cjs",
+        ".commitlintrc.mjs",
+        ".commitlintrc.ts",
+        "commitlint.config.js",
+        "commitlint.config.cjs",
+        "commitlint.config.mjs",
+        "commitlint.config.ts",
+    }
+    if basename in commitlint_names:
+        return "commitlint_config"
+    if basename in {".gitmessage", ".gitmessage.txt", "gitmessage.txt"}:
+        return "gitmessage_template"
+    if basename == "package.json":
+        return "package_json"
+    if not lowered.endswith(RULE_TEXT_SUFFIXES):
+        return None
+    if any(token in lowered for token in ("commit", "conventional", "semantic-release", "gitmessage")):
+        sanitized = re.sub(r"[^a-z0-9]+", "_", rel_path.lower()).strip("_")
+        return f"extra_rule_file_{sanitized}"
+    return None
+
+
+def discover_rule_files(repo_root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    seen_paths: set[str] = set()
+    for key, rel_path in FIXED_RULE_FILES.items():
+        path = (repo_root / rel_path).resolve()
+        if path.exists():
+            normalized_path = str(path)
+            result[key] = normalized_path
+            seen_paths.add(normalized_path)
+    for rel_path in tracked_files(repo_root):
+        key = rule_file_key(rel_path)
+        if key is None:
+            continue
+        normalized_path = str((repo_root / rel_path).resolve())
+        if normalized_path in seen_paths:
+            continue
+        unique_key = key
+        suffix = 2
+        while unique_key in result:
+            unique_key = f"{key}_{suffix}"
+            suffix += 1
+        result[unique_key] = normalized_path
+        seen_paths.add(normalized_path)
+    return result
+
+
+def load_rule_texts(files: dict[str, str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key, path_str in files.items():
+        text = read_text_if_exists(Path(path_str))
+        if text:
+            result[key] = text
+    return result
+
+
+def infer_format_from_text(text: str | None) -> str | None:
+    if not text:
+        return None
+    normalized = " ".join(text.split())
+    if re.search(
+        r"(?:<type>|type)\s*\(\s*(?:<scope>|scope)\s*\)\s*!?\s*:\s*(?:<subject>|subject)",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        return "<type>(<scope>): <subject>"
+    if re.search(
+        r"(?:<type>|type)\s*!?\s*:\s*(?:<subject>|subject)",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        return "<type>: <subject>"
+    return None
+
+
+def infer_format_from_recent_subjects(subjects: list[str]) -> str | None:
+    parsed = [item for subject in subjects if (item := parse_subject_line(subject)) is not None]
+    if len(parsed) < 3:
+        return None
+    if any(str(item.get("scope", "")) for item in parsed):
+        return "<type>(<scope>): <subject>"
+    return "<type>: <subject>"
+
+
+def infer_allowed_types(types_block: str | None, texts: dict[str, str], subjects: list[str]) -> tuple[list[str], str | None]:
+    explicit_tokens = normalize_token_list(extract_backtick_tokens(types_block))
+    if explicit_tokens:
+        return explicit_tokens, "commit_message_instructions"
+
+    commitlint_pattern = re.compile(
+        r"type-enum['\"]?\s*:\s*\[\s*\d+\s*,\s*['\"]always['\"]\s*,\s*\[(?P<body>.*?)\]\s*\]",
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    for key, text in texts.items():
+        match = commitlint_pattern.search(text)
+        if not match:
+            continue
+        tokens = normalize_token_list(re.findall(r"['\"]([A-Za-z0-9-]+)['\"]", match.group("body")))
+        if tokens:
+            return tokens, key
+
+    recent_types: list[str] = []
+    for subject in subjects:
+        parsed = parse_subject_line(subject)
+        if not parsed:
+            continue
+        message_type = str(parsed["type"]).lower()
+        if message_type not in recent_types:
+            recent_types.append(message_type)
+    return recent_types[:12], ("recent_subjects" if recent_types else None)
+
+
+def infer_scope_requirement(
+    format_block: str | None,
+    scopes_block: str | None,
+    texts: dict[str, str],
+    subjects: list[str],
+) -> tuple[bool | None, str | None]:
+    explicit = explicit_scope_requirement(format_block, scopes_block)
+    if explicit is not None:
+        return explicit, "commit_message_instructions"
+
+    for key, text in texts.items():
+        required_match = re.search(
+            r"scope-empty['\"]?\s*:\s*\[\s*\d+\s*,\s*['\"](?P<mode>always|never)['\"]",
+            text,
+            flags=re.IGNORECASE,
+        )
+        if required_match:
+            return required_match.group("mode").lower() == "never", key
+
+    parsed = [item for subject in subjects if (item := parse_subject_line(subject)) is not None]
+    if len(parsed) >= 5:
+        with_scope = sum(1 for item in parsed if str(item.get("scope", "")))
+        if with_scope == len(parsed):
+            return True, "recent_subjects"
+        if with_scope == 0:
+            return False, "recent_subjects"
+    return None, None
+
+
+def infer_subject_length_limit(subject_block: str | None, texts: dict[str, str]) -> tuple[int | None, str | None]:
+    explicit = subject_length_limit(subject_block)
+    if explicit is not None:
+        return explicit, "commit_message_instructions"
+
+    header_limit_pattern = re.compile(
+        r"header-max-length['\"]?\s*:\s*\[\s*\d+\s*,\s*['\"]always['\"]\s*,\s*(?P<limit>\d+)\s*\]",
+        flags=re.IGNORECASE,
+    )
+    prose_limit_pattern = re.compile(r"(?P<limit>\d+)\s+characters?\s+or\s+fewer", flags=re.IGNORECASE)
+    for key, text in texts.items():
+        config_match = header_limit_pattern.search(text)
+        if config_match:
+            return int(config_match.group("limit")), key
+        prose_match = prose_limit_pattern.search(text)
+        if prose_match:
+            return int(prose_match.group("limit")), key
+    return None, None
+
+
+def derive_repo_defaults(type_selection_block: str | None, texts: dict[str, str]) -> tuple[list[str], str | None]:
+    defaults = extract_bullets(type_selection_block)
+    if defaults:
+        return defaults, "commit_message_instructions"
+
+    keywords = ("prefer ", "when uncertain", "default to ", "use `fix`", "use `feat`")
+    derived: list[str] = []
+    for key, text in texts.items():
+        for line in commit_related_excerpt(text):
+            lowered = line.lower()
+            if any(keyword in lowered for keyword in keywords) and line not in derived:
+                derived.append(line)
+        if derived:
+            return derived, key
+    return [], None
+
+
+def build_doc_mentions(texts: dict[str, str]) -> dict[str, list[str]]:
+    return {
+        key: commit_related_excerpt(text)
+        for key, text in texts.items()
+        if commit_related_excerpt(text)
+    }
+
+
+def build_rules(repo_root: Path) -> dict[str, object]:
+    repo_root = Path(run_git(repo_root, ["rev-parse", "--show-toplevel"]).strip())
+    files = discover_rule_files(repo_root)
+    texts = load_rule_texts(files)
+
+    instructions_text = texts.get("commit_message_instructions")
+
+    blocks = parse_heading_blocks(instructions_text)
+    format_block = find_block(blocks, "Format")
+    types_block = find_block(blocks, "Types")
+    type_selection_block = find_block(blocks, "Type Selection")
+    scopes_block = find_block(blocks, "Scopes")
+    subject_block = find_block(blocks, "Subject Rules")
+    body_block = find_block(blocks, "Body Rules")
+    refs_block = find_block(blocks, "References")
+
+    subjects = recent_subjects(repo_root)
+    recent_scope_words = recent_scopes(subjects)
+    format_from_instructions = infer_format_from_text(format_block)
+    inferred_format, format_source = (
+        (format_from_instructions, "commit_message_instructions")
+        if format_from_instructions
+        else (None, None)
+    )
+    if inferred_format is None:
+        for key, text in texts.items():
+            if key == "commit_message_instructions":
+                continue
+            candidate = infer_format_from_text(text)
+            if candidate:
+                inferred_format = candidate
+                format_source = key
+                break
+    if inferred_format is None:
+        recent_format = infer_format_from_recent_subjects(subjects)
+        inferred_format = recent_format or "<type>(<scope>): <subject>"
+        format_source = "recent_subjects" if recent_format else "fallback_default"
+
+    scope_suggestions = normalize_token_list(extract_backtick_tokens(scopes_block))
+    for scope in recent_scope_words:
+        if scope not in scope_suggestions:
+            scope_suggestions.append(scope)
+
+    allowed_types, allowed_types_source = infer_allowed_types(types_block, texts, subjects)
+    scope_is_required, scope_required_source = infer_scope_requirement(
+        format_block,
+        scopes_block,
+        texts,
+        subjects,
+    )
+    subject_limit, subject_limit_source = infer_subject_length_limit(subject_block, texts)
+    repo_defaults, repo_defaults_source = derive_repo_defaults(type_selection_block, texts)
+
+    payload = {
+        "repo_root": str(repo_root),
+        "rule_files": files,
+        "rules": {
+            "format": inferred_format,
+            "allowed_types": allowed_types,
+            "scope_required": scope_is_required,
+            "scope_suggestions": scope_suggestions,
+            "subject_length_limit": subject_limit,
+            "subject_rules": extract_bullets(subject_block),
+            "body_rules": extract_bullets(body_block),
+            "references_rules": extract_bullets(refs_block),
+            "repo_defaults": repo_defaults,
+        },
+        "rule_derivation": {
+            "format_source": format_source,
+            "allowed_types_source": allowed_types_source,
+            "scope_required_source": scope_required_source,
+            "subject_length_limit_source": subject_limit_source,
+            "repo_defaults_source": repo_defaults_source,
+        },
+        "recent_scope_vocabulary": recent_scope_words,
+        "recent_subject_samples": subjects[:12],
+        "instruction_snippets": {
+            "format": format_block,
+            "types": types_block,
+            "type_selection": type_selection_block,
+            "scopes": scopes_block,
+            "subject_rules": subject_block,
+            "body_rules": body_block,
+            "references": refs_block,
+        },
+        "doc_mentions": build_doc_mentions(texts),
+    }
+    payload["rules_reliability"] = rules_reliability(payload)
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect repo-specific commit-message rules into JSON."
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository path. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the JSON artifact. Prints JSON to stdout when omitted.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = build_rules(args.repo)
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(f"collect_commit_rules.py: {exc}", file=sys.stderr)
+        return 1
+
+    serialized = json.dumps(payload, indent=2, ensure_ascii=True) + "\n"
+    if args.output:
+        args.output.write_text(serialized, encoding="utf-8")
+        print(f"Wrote commit rules to {args.output}")
+    else:
+        sys.stdout.write(serialized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_recent_commits.py
@@ -1,0 +1,285 @@
+﻿#!/usr/bin/env python3
+"""Collect the latest n commits into a JSON plan for message rewording."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+from reword_plan_contract import build_context_fingerprint, load_json, rules_reliability
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.is_file():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise RuntimeError(f"missing repo profile: {searched}")
+
+
+def load_repo_profile_document(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("repo profile must be a JSON object")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def run_git(repo: Path, args: list[str], check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout
+
+
+def detect_operation(git_dir: Path) -> str | None:
+    markers = {
+        "rebase": [git_dir / "rebase-merge", git_dir / "rebase-apply"],
+        "cherry-pick": [git_dir / "CHERRY_PICK_HEAD"],
+        "merge": [git_dir / "MERGE_HEAD"],
+        "bisect": [git_dir / "BISECT_LOG"],
+    }
+    for name, paths in markers.items():
+        if any(path.exists() for path in paths):
+            return name
+    return None
+
+
+def shortstat_for_commit(repo: Path, commit: str) -> str:
+    output = run_git(repo, ["show", "--shortstat", "--format=", commit]).strip().splitlines()
+    return output[-1].strip() if output else ""
+
+
+def files_for_commit(repo: Path, commit: str) -> list[str]:
+    output = run_git(repo, ["show", "--format=", "--name-only", "--no-renames", commit])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def build_plan(repo: Path, count: int, rules: dict[str, object] | None = None) -> dict[str, object]:
+    repo_root = Path(run_git(repo, ["rev-parse", "--show-toplevel"]).strip())
+    git_dir = Path(run_git(repo_root, ["rev-parse", "--git-dir"]).strip())
+    if not git_dir.is_absolute():
+        git_dir = repo_root / git_dir
+
+    branch = run_git(repo_root, ["branch", "--show-current"]).strip()
+    head_commit = run_git(repo_root, ["rev-parse", "HEAD"]).strip()
+    commits_output = run_git(
+        repo_root,
+        ["rev-list", "--max-count", str(count), "--reverse", "HEAD"],
+    ).strip()
+    commit_hashes = [line.strip() for line in commits_output.splitlines() if line.strip()]
+    if not commit_hashes:
+        raise RuntimeError("no commits found")
+
+    oldest_commit = commit_hashes[0]
+    base_candidate = run_git(repo_root, ["rev-parse", f"{oldest_commit}^"], check=False).strip()
+    base_commit = base_candidate if re.fullmatch(r"[0-9a-fA-F]{40}", base_candidate) else None
+
+    commits: list[dict[str, object]] = []
+    for index, commit in enumerate(commit_hashes, start=1):
+        parents = run_git(repo_root, ["show", "-s", "--format=%P", commit]).strip().split()
+        full_message = run_git(repo_root, ["show", "-s", "--format=%B", commit]).rstrip("\n")
+        commits.append(
+            {
+                "index": index,
+                "hash": commit,
+                "short_hash": commit[:12],
+                "parent_hashes": parents,
+                "subject": run_git(repo_root, ["show", "-s", "--format=%s", commit]).strip(),
+                "body": run_git(repo_root, ["show", "-s", "--format=%b", commit]).rstrip("\n"),
+                "full_message": full_message,
+                "author_name": run_git(repo_root, ["show", "-s", "--format=%an", commit]).strip(),
+                "author_email": run_git(repo_root, ["show", "-s", "--format=%ae", commit]).strip(),
+                "author_date": run_git(repo_root, ["show", "-s", "--format=%aI", commit]).strip(),
+                "files": files_for_commit(repo_root, commit),
+                "shortstat": shortstat_for_commit(repo_root, commit),
+                "new_message": "",
+            }
+        )
+
+    payload = {
+        "repo_root": str(repo_root),
+        "branch": branch,
+        "detached_head": branch == "",
+        "count": len(commit_hashes),
+        "head_commit": head_commit,
+        "base_commit": base_commit,
+        "active_operation": detect_operation(git_dir),
+        "commits": commits,
+    }
+    if isinstance(rules, dict):
+        payload["rules_reliability"] = rules_reliability(rules)
+        payload["context_fingerprint"] = build_context_fingerprint(payload, rules)
+    return payload
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect the latest n commits into a JSON plan for rewording."
+    )
+    parser.add_argument("--count", type=int, required=True, help="Number of recent commits to collect.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the JSON plan. Prints JSON to stdout when omitted.",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository path. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--rules",
+        type=Path,
+        help="Optional rules JSON from collect_commit_rules.py to attach rules_reliability and context_fingerprint.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.count <= 0:
+        print("--count must be positive", file=sys.stderr)
+        return 2
+
+    try:
+        repo_root = Path(args.repo).resolve()
+        profile_path = resolve_profile_path(args.profile, repo_root)
+        repo_profile = load_repo_profile_document(profile_path)
+        rules = load_json(args.rules) if args.rules else None
+        plan = build_plan(args.repo, args.count, rules)
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(f"collect_recent_commits.py: {exc}", file=sys.stderr)
+        return 1
+    plan["repo_profile_name"] = repo_profile.get("name")
+    plan["repo_profile_path"] = profile_path.as_posix()
+    plan["repo_profile_summary"] = repo_profile.get("summary")
+    plan["repo_profile"] = repo_profile
+    plan["builder_compatibility"] = build_builder_compatibility(repo_profile)
+    if plan["builder_compatibility"].get("status") != "current":
+        print(format_runtime_warning(plan["builder_compatibility"]), file=sys.stderr)
+
+    payload = json.dumps(plan, indent=2, ensure_ascii=True) + "\n"
+    if args.output:
+        args.output.write_text(payload, encoding="utf-8")
+        print(
+            f"Wrote reword plan for {plan['count']} commits to {args.output}",
+            file=sys.stdout,
+        )
+    else:
+        sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_plan_contract.py
@@ -1,0 +1,694 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+SUBJECT_WITH_SCOPE_RE = re.compile(
+    r"^(?P<type>[a-z][a-z0-9-]*)(?:\((?P<scope>[A-Za-z0-9._/-]+)\))?(?P<breaking>!)?: (?P<summary>.+)$"
+)
+SUBJECT_WITHOUT_SCOPE_RE = re.compile(
+    r"^(?P<type>[a-z][a-z0-9-]*)(?P<breaking>!)?: (?P<summary>.+)$"
+)
+
+RULES_RELIABILITY_VALUES = ("explicit", "derived", "fallback")
+VALIDATION_ERROR_CODES = {
+    "invalid_plan_shape",
+    "missing_commit",
+    "missing_new_message",
+    "duplicate_commit",
+    "unknown_commit",
+    "invalid_subject_format",
+    "invalid_type",
+    "missing_required_scope",
+    "subject_too_long",
+    "dirty_worktree",
+    "detached_head",
+    "active_git_operation",
+    "merge_commit_in_scope",
+    "root_rewrite_unsupported",
+    "stale_context_fingerprint",
+}
+VALIDATION_WARNING_CODES = {
+    "derived_rules_only",
+    "fallback_rules_only",
+    "body_recommended_missing",
+    "upstream_configured",
+    "branch_ahead",
+    "branch_behind",
+    "force_push_likely",
+    "unchanged_message",
+}
+STOP_CATEGORIES = {
+    "active_git_operation",
+    "detached_head",
+    "dirty_worktree",
+    "merge_commit_in_scope",
+    "root_rewrite_unsupported",
+    "stale_context_fingerprint",
+    "head_commit_drift",
+    "recent_hash_drift",
+    "replay_failed",
+}
+
+DECISION_READY_PACKETS = False
+WORKER_RETURN_CONTRACT = "generic"
+WORKER_OUTPUT_SHAPE = "flat"
+COMMON_PATH_CONTRACT = {
+    "shared_packets": ["rules_packet.json"],
+    "focused_packet_mode": "read one commit packet at a time while keeping rules_packet.json in view",
+    "goal": "Draft replacement messages without rereading raw commit history on the common path.",
+}
+RAW_REREAD_ALLOWED_REASONS = [
+    "conflicting_signals",
+    "missing_required_evidence",
+    "schema_mismatch",
+    "insufficient_excerpt_quality",
+    "branch_tip_changed",
+    "merge_commit_in_scope",
+]
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+XHIGH_REREAD_POLICY = (
+    "Packet-first local adjudication is required on the common path; raw rereads are only allowed for explicit exception reasons."
+)
+RUNTIME_STATUS_IGNORE_PREFIXES = (".codex/tmp/",)
+
+
+def _stringify(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_path(value: Any) -> str:
+    return _stringify(value).replace("\\", "/")
+
+
+def _status_line_paths(line: str) -> list[str]:
+    payload = line[3:].strip()
+    if not payload:
+        return []
+    parts = payload.split(" -> ") if " -> " in payload else [payload]
+    return [_normalize_path(part.strip().strip('"')) for part in parts if part.strip()]
+
+
+def _is_runtime_status_line(line: str) -> bool:
+    paths = _status_line_paths(line)
+    return bool(paths) and all(
+        any(path.startswith(prefix) for prefix in RUNTIME_STATUS_IGNORE_PREFIXES)
+        for path in paths
+    )
+
+
+def _normalize_string_list(value: Any, *, sort_values: bool = False) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    items = []
+    for item in value:
+        text = _stringify(item)
+        if text:
+            items.append(text)
+    if sort_values:
+        items = sorted(dict.fromkeys(items))
+    return items
+
+
+def _normalize_rules_section(value: Any) -> dict[str, Any]:
+    payload = value if isinstance(value, dict) else {}
+    normalized = {
+        "format": _stringify(payload.get("format")) or None,
+        "allowed_types": _normalize_string_list(payload.get("allowed_types")),
+        "scope_required": None if payload.get("scope_required") is None else bool(payload.get("scope_required")),
+        "scope_suggestions": _normalize_string_list(payload.get("scope_suggestions")),
+        "subject_length_limit": None if payload.get("subject_length_limit") in {None, ""} else int(payload.get("subject_length_limit")),
+        "subject_rules": _normalize_string_list(payload.get("subject_rules")),
+        "body_rules": _normalize_string_list(payload.get("body_rules")),
+        "references_rules": _normalize_string_list(payload.get("references_rules")),
+        "repo_defaults": _normalize_string_list(payload.get("repo_defaults")),
+    }
+    return normalized
+
+
+def _normalize_rule_derivation(value: Any) -> dict[str, Any]:
+    payload = value if isinstance(value, dict) else {}
+    keys = (
+        "format_source",
+        "allowed_types_source",
+        "scope_required_source",
+        "subject_length_limit_source",
+        "repo_defaults_source",
+    )
+    return {key: _stringify(payload.get(key)) or None for key in keys}
+
+
+def _normalize_rules_snapshot(rules: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "rules": _normalize_rules_section(rules.get("rules")),
+        "rule_derivation": _normalize_rule_derivation(rules.get("rule_derivation")),
+        "recent_scope_vocabulary": _normalize_string_list(rules.get("recent_scope_vocabulary")),
+        "recent_subject_samples": _normalize_string_list(rules.get("recent_subject_samples")),
+    }
+
+
+def _normalize_commit_snapshot(commit: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "index": int(commit.get("index") or 0),
+        "hash": _stringify(commit.get("hash")),
+        "parent_hashes": _normalize_string_list(commit.get("parent_hashes")),
+        "subject": _stringify(commit.get("subject")),
+        "files": [_normalize_path(path) for path in _normalize_string_list(commit.get("files"))],
+        "shortstat": _stringify(commit.get("shortstat")),
+    }
+
+
+def _normalize_plan_snapshot(plan: dict[str, Any]) -> dict[str, Any]:
+    commits = [
+        _normalize_commit_snapshot(commit)
+        for commit in plan.get("commits", [])
+        if isinstance(commit, dict)
+    ]
+    commits.sort(key=lambda item: (int(item["index"]), item["hash"]))
+    return {
+        "branch": _stringify(plan.get("branch")),
+        "head_commit": _stringify(plan.get("head_commit")),
+        "base_commit": _stringify(plan.get("base_commit")) or None,
+        "detached_head": bool(plan.get("detached_head")),
+        "active_operation": _stringify(plan.get("active_operation")) or None,
+        "count": int(plan.get("count") or len(commits)),
+        "commits": commits,
+    }
+
+
+def stable_json_dumps(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+
+
+def _sha256(payload: Any) -> str:
+    return hashlib.sha256(stable_json_dumps(payload).encode("utf-8")).hexdigest()
+
+
+def packet_id(name: str) -> str:
+    return Path(name).stem
+
+
+def build_task_packet_names(commit_packet_names: list[str]) -> list[str]:
+    return ["rules_packet.json", *commit_packet_names]
+
+
+def build_task_packet_ids(commit_packet_names: list[str]) -> list[str]:
+    return ["rules_packet", *[packet_id(name) for name in commit_packet_names]]
+
+
+def build_packet_worker_map(commit_packet_names: list[str]) -> dict[str, list[str]]:
+    return {
+        "rules_packet": ["docs_verifier"],
+        **{packet_id(name): ["evidence_summarizer"] for name in commit_packet_names},
+    }
+
+
+def dedupe_preserve(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def json_bytes(payload: Any) -> int:
+    return len(json.dumps(payload, ensure_ascii=True, sort_keys=True).encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return max(1, int(round(byte_count / 4.0)))
+
+
+def compute_packet_metrics(
+    packet_payloads: dict[str, Any],
+    *,
+    local_only_sources: dict[str, Any],
+    shared_packets: list[str] | None = None,
+) -> dict[str, int]:
+    shared_packet_names = shared_packets or COMMON_PATH_CONTRACT["shared_packets"]
+    packet_sizes = {
+        name: json_bytes(payload)
+        for name, payload in packet_payloads.items()
+    }
+    total_packet_bytes = sum(packet_sizes.values())
+    largest_sizes = sorted(packet_sizes.values(), reverse=True)
+    focused_sizes = [
+        size
+        for name, size in packet_sizes.items()
+        if name.startswith("commit-")
+    ]
+    common_path_packet_bytes = sum(packet_sizes.get(name, 0) for name in shared_packet_names)
+    if focused_sizes:
+        common_path_packet_bytes += max(focused_sizes)
+    local_only_bytes = sum(json_bytes(payload) for payload in local_only_sources.values())
+    estimated_local_only_tokens = estimate_tokens_from_bytes(local_only_bytes)
+    estimated_packet_tokens = estimate_tokens_from_bytes(common_path_packet_bytes)
+    return {
+        "packet_count": len(packet_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "largest_packet_bytes": largest_sizes[0] if largest_sizes else 0,
+        "largest_two_packets_bytes": sum(largest_sizes[:2]),
+        "estimated_local_only_tokens": estimated_local_only_tokens,
+        "estimated_packet_tokens": estimated_packet_tokens,
+        "estimated_delegation_savings": max(0, estimated_local_only_tokens - estimated_packet_tokens),
+    }
+
+
+def rules_reliability(rules: dict[str, Any]) -> str:
+    sources = [value for value in _normalize_rule_derivation(rules.get("rule_derivation")).values() if value]
+    if any(source not in {"recent_subjects", "fallback_default"} for source in sources):
+        return "explicit"
+    if any(source == "recent_subjects" for source in sources):
+        return "derived"
+    return "fallback"
+
+
+def build_context_fingerprint(plan: dict[str, Any], rules: dict[str, Any]) -> str:
+    payload = {
+        "plan": _normalize_plan_snapshot(plan),
+        "rules": _normalize_rules_snapshot(rules),
+    }
+    return _sha256(payload)
+
+
+def context_fingerprint(plan: dict[str, Any], rules: dict[str, Any] | None = None) -> str:
+    existing = _stringify(plan.get("context_fingerprint"))
+    if existing:
+        return existing
+    if rules is None:
+        raise RuntimeError("context_fingerprint is missing and rules were not provided")
+    return build_context_fingerprint(plan, rules)
+
+
+def normalize_rewrite_actions(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized = []
+    for action in actions:
+        normalized.append(
+            {
+                "index": int(action.get("index") or 0),
+                "hash": _stringify(action.get("hash")),
+                "new_message": str(action.get("new_message") or "").strip("\n"),
+            }
+        )
+    normalized.sort(key=lambda item: (int(item["index"]), item["hash"]))
+    return normalized
+
+
+def build_message_set_fingerprint(actions: list[dict[str, Any]]) -> str:
+    return _sha256(normalize_rewrite_actions(actions))
+
+
+def message_set_fingerprint(actions: list[dict[str, Any]], existing: str | None = None) -> str:
+    text = _stringify(existing)
+    return text or build_message_set_fingerprint(actions)
+
+
+def parse_subject_line(subject: str, format_hint: str | None = None) -> dict[str, Any] | None:
+    subject = _stringify(subject)
+    if not subject:
+        return None
+    parser = SUBJECT_WITH_SCOPE_RE if format_hint != "<type>: <subject>" else SUBJECT_WITHOUT_SCOPE_RE
+    match = parser.match(subject)
+    if not match and parser is SUBJECT_WITH_SCOPE_RE:
+        match = SUBJECT_WITH_SCOPE_RE.match(subject)
+    if not match:
+        return None
+    return {
+        "type": match.group("type"),
+        "scope": match.groupdict().get("scope") or "",
+        "breaking": bool(match.groupdict().get("breaking")),
+        "summary": match.group("summary"),
+    }
+
+
+def validation_message(code: str, *, commit_hash: str | None = None, index: int | None = None) -> str:
+    prefix = ""
+    if index is not None:
+        prefix += f"commit #{index}"
+    if commit_hash:
+        prefix += f" ({commit_hash})" if prefix else f"commit {commit_hash}"
+    if prefix:
+        prefix += ": "
+    mapping = {
+        "invalid_plan_shape": "plan JSON must be an object with a `commits` list",
+        "missing_commit": "raw plan must include every collected commit exactly once",
+        "missing_new_message": "new_message is required for every commit",
+        "duplicate_commit": "duplicate commit entry detected in raw plan",
+        "unknown_commit": "commit is not present in the collected context",
+        "invalid_subject_format": "new_message subject does not match the repo format",
+        "invalid_type": "new_message type is not allowed by repo rules",
+        "missing_required_scope": "new_message is missing a required scope",
+        "subject_too_long": "new_message subject exceeds the repo limit",
+        "dirty_worktree": "working tree must be clean before applying a history rewrite",
+        "detached_head": "detached HEAD rewrites are not supported",
+        "active_git_operation": "another git operation is already in progress",
+        "merge_commit_in_scope": "merge commits are not supported by this workflow",
+        "root_rewrite_unsupported": "root-commit rewrite is not supported because base_commit is null",
+        "stale_context_fingerprint": "context_fingerprint does not match the current rules + context snapshot",
+        "derived_rules_only": "repo rules were derived from recent history instead of explicit repo guidance",
+        "fallback_rules_only": "repo rules fell back to the default format because explicit guidance was not found",
+        "body_recommended_missing": "message body is recommended for this commit shape but is empty",
+        "upstream_configured": "branch has an upstream and rewritten history will require coordination",
+        "branch_ahead": "branch is ahead of upstream; force-push is likely after rewrite",
+        "branch_behind": "branch is behind upstream; rewrite may diverge from the remote history",
+        "force_push_likely": "history rewrite will likely require force-push-with-lease",
+        "unchanged_message": "new_message matches the original commit message",
+    }
+    return prefix + mapping.get(code, code)
+
+
+def build_issue(
+    level: str,
+    code: str,
+    *,
+    commit_hash: str | None = None,
+    index: int | None = None,
+) -> dict[str, Any]:
+    issue = {
+        "level": level,
+        "code": code,
+        "message": validation_message(code, commit_hash=commit_hash, index=index),
+    }
+    if commit_hash:
+        issue["hash"] = commit_hash
+    if index is not None:
+        issue["index"] = index
+    return issue
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def run_git(repo: Path, args: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout
+
+
+def detect_operation(repo_root: Path) -> str | None:
+    git_dir = Path(run_git(repo_root, ["rev-parse", "--git-dir"]).strip())
+    if not git_dir.is_absolute():
+        git_dir = repo_root / git_dir
+    markers = {
+        "rebase": [git_dir / "rebase-merge", git_dir / "rebase-apply"],
+        "cherry-pick": [git_dir / "CHERRY_PICK_HEAD"],
+        "merge": [git_dir / "MERGE_HEAD"],
+        "bisect": [git_dir / "BISECT_LOG"],
+    }
+    for name, paths in markers.items():
+        if any(path.exists() for path in paths):
+            return name
+    return None
+
+
+def branch_state(repo_root: Path) -> dict[str, Any]:
+    branch = run_git(repo_root, ["branch", "--show-current"]).strip()
+    status_porcelain = run_git(repo_root, ["status", "--porcelain", "--untracked-files=all"], check=False)
+    status_branch = run_git(repo_root, ["status", "--short", "--branch"], check=False)
+    upstream = run_git(
+        repo_root,
+        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        check=False,
+    ).strip()
+    ahead = 0
+    behind = 0
+    if upstream:
+        counts = run_git(repo_root, ["rev-list", "--left-right", "--count", f"{upstream}...HEAD"], check=False).strip()
+        if counts:
+            parts = counts.split()
+            if len(parts) == 2:
+                behind = int(parts[0])
+                ahead = int(parts[1])
+    dirty_lines = [
+        line
+        for line in status_porcelain.splitlines()
+        if line.strip() and not _is_runtime_status_line(line)
+    ]
+    return {
+        "branch": branch,
+        "status_branch_line": status_branch.splitlines()[0] if status_branch.splitlines() else "",
+        "working_tree_dirty": bool(dirty_lines),
+        "upstream_branch": upstream or None,
+        "ahead_count": ahead,
+        "behind_count": behind,
+        "force_push_likely": bool(upstream),
+    }
+
+
+def recent_hashes(repo_root: Path, count: int) -> list[str]:
+    output = run_git(repo_root, ["rev-list", "--max-count", str(count), "--reverse", "HEAD"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _raw_plan_commits(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    commits = payload.get("commits")
+    if isinstance(commits, list):
+        return [commit for commit in commits if isinstance(commit, dict)]
+    raise RuntimeError("plan JSON must be an object with a `commits` list")
+
+
+def _validate_runtime_state(
+    context: dict[str, Any],
+    *,
+    repo_state: dict[str, Any] | None = None,
+    active_operation: str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    stop_reasons: list[str] = []
+
+    if bool(context.get("detached_head")):
+        errors.append(build_issue("error", "detached_head"))
+        stop_reasons.append("detached_head")
+    operation = _stringify(active_operation or context.get("active_operation"))
+    if operation:
+        errors.append(build_issue("error", "active_git_operation"))
+        stop_reasons.append("active_git_operation")
+    if not _stringify(context.get("base_commit")):
+        errors.append(build_issue("error", "root_rewrite_unsupported"))
+        stop_reasons.append("root_rewrite_unsupported")
+    merge_indexes = [
+        int(commit.get("index") or 0)
+        for commit in context.get("commits", [])
+        if isinstance(commit, dict) and len(commit.get("parent_hashes", []) or []) > 1
+    ]
+    if merge_indexes:
+        errors.append(build_issue("error", "merge_commit_in_scope"))
+        stop_reasons.append("merge_commit_in_scope")
+
+    state = repo_state or {}
+    if state.get("working_tree_dirty"):
+        errors.append(build_issue("error", "dirty_worktree"))
+        stop_reasons.append("dirty_worktree")
+    if state.get("upstream_branch"):
+        warnings.append(build_issue("warning", "upstream_configured"))
+    if int(state.get("ahead_count") or 0) > 0:
+        warnings.append(build_issue("warning", "branch_ahead"))
+    if int(state.get("behind_count") or 0) > 0:
+        warnings.append(build_issue("warning", "branch_behind"))
+    if state.get("force_push_likely"):
+        warnings.append(build_issue("warning", "force_push_likely"))
+    return errors, warnings, stop_reasons
+
+
+def validate_reword_plan_payload(
+    context: dict[str, Any],
+    rules: dict[str, Any],
+    raw_plan: dict[str, Any],
+    *,
+    repo_state: dict[str, Any] | None = None,
+    active_operation: str | None = None,
+) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    stop_reasons: list[str] = []
+
+    expected_context_fingerprint = build_context_fingerprint(context, rules)
+    actual_context_fingerprint = context_fingerprint(context, rules)
+    fingerprint_match = expected_context_fingerprint == actual_context_fingerprint
+    if not fingerprint_match:
+        errors.append(build_issue("error", "stale_context_fingerprint"))
+        stop_reasons.append("stale_context_fingerprint")
+
+    runtime_errors, runtime_warnings, runtime_stop_reasons = _validate_runtime_state(
+        context,
+        repo_state=repo_state,
+        active_operation=active_operation,
+    )
+    errors.extend(runtime_errors)
+    warnings.extend(runtime_warnings)
+    stop_reasons.extend(runtime_stop_reasons)
+
+    reliability = rules_reliability(rules)
+    if reliability == "derived":
+        warnings.append(build_issue("warning", "derived_rules_only"))
+    elif reliability == "fallback":
+        warnings.append(build_issue("warning", "fallback_rules_only"))
+
+    context_commits = [
+        commit
+        for commit in context.get("commits", [])
+        if isinstance(commit, dict)
+    ]
+    context_by_hash = {_stringify(commit.get("hash")): commit for commit in context_commits}
+    context_by_index = {int(commit.get("index") or 0): commit for commit in context_commits}
+
+    try:
+        raw_commits = _raw_plan_commits(raw_plan)
+    except RuntimeError:
+        raw_commits = []
+        errors.append(build_issue("error", "invalid_plan_shape"))
+
+    seen_hashes: set[str] = set()
+    seen_indexes: set[int] = set()
+    normalized_actions: list[dict[str, Any]] = []
+
+    for raw_commit in raw_commits:
+        commit_hash = _stringify(raw_commit.get("hash"))
+        index = int(raw_commit.get("index") or 0)
+        if not commit_hash or commit_hash not in context_by_hash:
+            errors.append(build_issue("error", "unknown_commit", commit_hash=commit_hash or None, index=index or None))
+            continue
+        if index and index not in context_by_index:
+            errors.append(build_issue("error", "unknown_commit", commit_hash=commit_hash, index=index))
+            continue
+        if commit_hash in seen_hashes or index in seen_indexes:
+            errors.append(build_issue("error", "duplicate_commit", commit_hash=commit_hash, index=index))
+            continue
+        seen_hashes.add(commit_hash)
+        seen_indexes.add(index)
+
+        context_commit = context_by_hash[commit_hash]
+        actual_index = int(context_commit.get("index") or index)
+        new_message = str(raw_commit.get("new_message") or "").strip("\n")
+        if not new_message.strip():
+            errors.append(build_issue("error", "missing_new_message", commit_hash=commit_hash, index=actual_index))
+            continue
+
+        normalized_actions.append(
+            {
+                "index": actual_index,
+                "hash": commit_hash,
+                "new_message": new_message,
+            }
+        )
+
+    if len(raw_commits) != len(context_commits):
+        errors.append(build_issue("error", "missing_commit"))
+    elif len(seen_hashes) != len(context_commits):
+        errors.append(build_issue("error", "missing_commit"))
+
+    rules_section = _normalize_rules_section(rules.get("rules"))
+    format_hint = rules_section.get("format")
+    allowed_types = set(rules_section.get("allowed_types") or [])
+    scope_required = rules_section.get("scope_required")
+    subject_length_limit = rules_section.get("subject_length_limit")
+
+    normalized_actions = normalize_rewrite_actions(normalized_actions)
+    for action in normalized_actions:
+        commit_hash = action["hash"]
+        index = int(action["index"])
+        new_message = str(action["new_message"])
+        subject, _sep, body = new_message.partition("\n")
+        parsed_subject = parse_subject_line(subject, format_hint)
+        if parsed_subject is None:
+            errors.append(build_issue("error", "invalid_subject_format", commit_hash=commit_hash, index=index))
+            continue
+        message_type = _stringify(parsed_subject.get("type"))
+        scope = _stringify(parsed_subject.get("scope"))
+        if allowed_types and message_type not in allowed_types:
+            errors.append(build_issue("error", "invalid_type", commit_hash=commit_hash, index=index))
+        if scope_required and not scope:
+            errors.append(build_issue("error", "missing_required_scope", commit_hash=commit_hash, index=index))
+        if subject_length_limit and len(subject.strip()) > int(subject_length_limit):
+            errors.append(build_issue("error", "subject_too_long", commit_hash=commit_hash, index=index))
+
+        context_commit = context_by_hash.get(commit_hash, {})
+        original_message = str(context_commit.get("full_message") or "").strip("\n")
+        if original_message == new_message.strip("\n"):
+            warnings.append(build_issue("warning", "unchanged_message", commit_hash=commit_hash, index=index))
+        body_recommended = False
+        files = context_commit.get("files", []) or []
+        if len(files) > 1:
+            body_recommended = True
+        elif str(context_commit.get("body") or "").strip():
+            body_recommended = True
+        if body_recommended and not body.strip():
+            warnings.append(build_issue("warning", "body_recommended_missing", commit_hash=commit_hash, index=index))
+
+    counters = {
+        "entry_count": len(raw_commits),
+        "normalized_entry_count": len(normalized_actions),
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "commits_validated": len(normalized_actions),
+        "rules_reliability": reliability,
+        "force_push_needed": bool((repo_state or {}).get("force_push_likely")),
+    }
+    envelope = {
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "counters": counters,
+        "context_fingerprint": expected_context_fingerprint,
+        "message_set_fingerprint": build_message_set_fingerprint(normalized_actions),
+        "normalized_rewrite_actions": normalized_actions,
+        "rewrite_scope": {
+            "branch": _stringify(context.get("branch")),
+            "count": int(context.get("count") or len(context_commits)),
+            "head_commit": _stringify(context.get("head_commit")),
+            "base_commit": _stringify(context.get("base_commit")) or None,
+        },
+        "rules_reliability": reliability,
+        "fingerprint_match": fingerprint_match,
+        "stop_reasons": sorted(dict.fromkeys(stop_reasons)),
+    }
+    return envelope
+
+
+def load_normalized_plan_envelope(context: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(plan, dict):
+        raise RuntimeError("validated plan must be a JSON object")
+    actions = plan.get("normalized_rewrite_actions")
+    if not isinstance(actions, list):
+        raise RuntimeError("validated plan is missing normalized_rewrite_actions")
+    if not bool(plan.get("valid")):
+        raise RuntimeError("validated plan is not valid")
+    expected_fingerprint = context_fingerprint(context)
+    actual_fingerprint = _stringify(plan.get("context_fingerprint"))
+    if expected_fingerprint != actual_fingerprint:
+        raise RuntimeError(validation_message("stale_context_fingerprint"))
+    return {
+        "context_fingerprint": actual_fingerprint,
+        "message_set_fingerprint": message_set_fingerprint(actions, existing=_stringify(plan.get("message_set_fingerprint"))),
+        "fingerprint_match": True,
+        "normalized_rewrite_actions": normalize_rewrite_actions(actions),
+        "warnings": plan.get("warnings", []),
+        "counters": plan.get("counters", {}),
+        "rewrite_scope": plan.get("rewrite_scope", {}),
+        "rules_reliability": _stringify(plan.get("rules_reliability")) or None,
+        "stop_reasons": plan.get("stop_reasons", []),
+    }

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_recent_commits.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""High-level driver for the reword-recent-commits workflow."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from reword_runtime_paths import (
+    build_run_id,
+    ensure_repo_codex_tmp_excluded,
+    resolve_artifact_root,
+    resolve_existing_artifact_root,
+    resolve_repo_root,
+)
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RULES_FILE = "rules.json"
+PLAN_FILE = "plan.json"
+RAW_PLAN_FILE = "raw-plan.json"
+VALIDATED_FILE = "validated.json"
+BUILD_RESULT_FILE = "build-result.json"
+APPLY_RESULT_FILE = "apply-result.json"
+EVAL_LOG_FILE = "eval-log.json"
+MESSAGE_TEMPLATE_FILE = "message-template.json"
+FINAL_FILE = "final-observations.json"
+
+
+class DriverFailure(RuntimeError):
+    def __init__(self, payload: dict[str, Any], exit_code: int = 1) -> None:
+        super().__init__(str(payload.get("error_message") or payload.get("status") or "driver failed"))
+        self.payload = payload
+        self.exit_code = exit_code
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+
+
+def script_path(name: str) -> Path:
+    return SCRIPT_DIR / name
+
+
+def run_python(
+    script_name: str,
+    args: list[str],
+    *,
+    repo_root: Path,
+    allowed_exit_codes: set[int] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    allowed = allowed_exit_codes if allowed_exit_codes is not None else {0}
+    result = subprocess.run(
+        [sys.executable, "-B", str(script_path(script_name)), *args],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode not in allowed:
+        message = (result.stderr or result.stdout or "").strip() or f"{script_name} failed"
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": f"{script_name}: {message}",
+                "step": script_name,
+            }
+        )
+    return result
+
+
+def message_template_from_context(context: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "context_fingerprint": context.get("context_fingerprint"),
+        "branch": context.get("branch"),
+        "head_commit": context.get("head_commit"),
+        "commits": [
+            {
+                "index": int(commit.get("index") or 0),
+                "hash": str(commit.get("hash") or ""),
+                "current_subject": str(commit.get("subject") or ""),
+                "new_message": "",
+            }
+            for commit in context.get("commits", [])
+            if isinstance(commit, dict)
+        ],
+    }
+
+
+def build_raw_plan(context: dict[str, Any], template: dict[str, Any]) -> dict[str, Any]:
+    if str(template.get("context_fingerprint") or "") != str(context.get("context_fingerprint") or ""):
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "messages-file context_fingerprint does not match the prepared context",
+                "step": "messages-file",
+            }
+        )
+    if str(template.get("branch") or "") != str(context.get("branch") or ""):
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "messages-file branch does not match the prepared context",
+                "step": "messages-file",
+            }
+        )
+    if str(template.get("head_commit") or "") != str(context.get("head_commit") or ""):
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "messages-file head_commit does not match the prepared context",
+                "step": "messages-file",
+            }
+        )
+
+    template_commits = template.get("commits")
+    if not isinstance(template_commits, list):
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "messages-file must contain a commits list",
+                "step": "messages-file",
+            }
+        )
+
+    by_hash: dict[str, dict[str, Any]] = {}
+    by_index: dict[int, dict[str, Any]] = {}
+    for item in template_commits:
+        if not isinstance(item, dict):
+            continue
+        commit_hash = str(item.get("hash") or "").strip()
+        commit_index = int(item.get("index") or 0)
+        if commit_hash:
+            by_hash[commit_hash] = item
+        if commit_index:
+            by_index[commit_index] = item
+
+    raw_plan = copy.deepcopy(context)
+    context_commits = raw_plan.get("commits")
+    if not isinstance(context_commits, list):
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "prepared context is missing commits",
+                "step": "raw-plan",
+            }
+        )
+
+    missing: list[str] = []
+    for commit in context_commits:
+        if not isinstance(commit, dict):
+            continue
+        commit_hash = str(commit.get("hash") or "").strip()
+        commit_index = int(commit.get("index") or 0)
+        template_commit = by_hash.get(commit_hash) or by_index.get(commit_index)
+        if template_commit is None:
+            missing.append(commit_hash or str(commit_index))
+            continue
+        commit["new_message"] = str(template_commit.get("new_message") or "")
+
+    if missing:
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "messages-file is missing entries for commits: " + ", ".join(missing),
+                "step": "raw-plan",
+            }
+        )
+    return raw_plan
+
+
+def merge_dicts(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            merge_dicts(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def minimal_final_payload(validated: dict[str, Any], apply_result: dict[str, Any] | None) -> dict[str, Any]:
+    if not bool(validated.get("valid")):
+        return {
+            "quality": {
+                "result_status": "stopped",
+                "first_pass_usable": False,
+                "human_post_edit_required": True,
+                "human_post_edit_severity": "medium",
+                "final_output_changed_after_review": False,
+            }
+        }
+    if apply_result is None:
+        return {
+            "quality": {
+                "result_status": "stopped",
+                "first_pass_usable": False,
+                "human_post_edit_required": True,
+                "human_post_edit_severity": "medium",
+                "final_output_changed_after_review": False,
+            }
+        }
+    dry_run = bool(apply_result.get("dry_run"))
+    applied = apply_result.get("apply_succeeded")
+    if dry_run:
+        status = "dry-run"
+        usable = True
+        human_edit_required = False
+        severity = "none"
+    elif applied is True:
+        status = "completed"
+        usable = True
+        human_edit_required = False
+        severity = "none"
+    elif apply_result.get("stop_reasons"):
+        status = "stopped"
+        usable = False
+        human_edit_required = True
+        severity = "high"
+    else:
+        status = "failed"
+        usable = False
+        human_edit_required = True
+        severity = "high"
+    return {
+        "quality": {
+            "result_status": status,
+            "first_pass_usable": usable,
+            "human_post_edit_required": human_edit_required,
+            "human_post_edit_severity": severity,
+            "final_output_changed_after_review": False,
+        }
+    }
+
+
+def prepare(repo_root: Path, count: int, artifact_root: Path) -> dict[str, Any]:
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    rules_path = artifact_root / RULES_FILE
+    plan_path = artifact_root / PLAN_FILE
+    packet_dir = artifact_root / "packets"
+    build_result_path = artifact_root / BUILD_RESULT_FILE
+    eval_log_path = artifact_root / EVAL_LOG_FILE
+    message_template_path = artifact_root / MESSAGE_TEMPLATE_FILE
+
+    run_python(
+        "collect_commit_rules.py",
+        ["--repo", str(repo_root), "--output", str(rules_path)],
+        repo_root=repo_root,
+    )
+    run_python(
+        "collect_recent_commits.py",
+        ["--count", str(count), "--repo", str(repo_root), "--rules", str(rules_path), "--output", str(plan_path)],
+        repo_root=repo_root,
+    )
+    run_python(
+        "build_reword_packets.py",
+        ["--rules", str(rules_path), "--plan", str(plan_path), "--output-dir", str(packet_dir), "--result-output", str(build_result_path)],
+        repo_root=repo_root,
+    )
+    run_python(
+        "write_evaluation_log.py",
+        ["init", "--context", str(plan_path), "--orchestrator", str(packet_dir / "orchestrator.json"), "--output", str(eval_log_path)],
+        repo_root=repo_root,
+    )
+    run_python(
+        "write_evaluation_log.py",
+        ["phase", "--log", str(eval_log_path), "--phase", "build", "--result", str(build_result_path)],
+        repo_root=repo_root,
+    )
+
+    context = load_json(plan_path)
+    build_result = load_json(build_result_path)
+    write_json(message_template_path, message_template_from_context(context))
+
+    return {
+        "status": "prepared",
+        "next_action": "fill_message_template",
+        "artifact_root": str(artifact_root),
+        "message_template_path": str(message_template_path),
+        "evaluation_log_path": str(eval_log_path),
+        "review_mode": build_result.get("review_mode"),
+        "common_path_sufficient": bool(build_result.get("common_path_sufficient")),
+    }
+
+
+def execute_messages_flow(
+    repo_root: Path,
+    artifact_root: Path,
+    messages_file: Path,
+    *,
+    apply_changes: bool,
+    dry_run_requested: bool,
+    temp_root: Path | None,
+    final_observations: Path | None,
+) -> dict[str, Any]:
+    rules_path = artifact_root / RULES_FILE
+    plan_path = artifact_root / PLAN_FILE
+    raw_plan_path = artifact_root / RAW_PLAN_FILE
+    validated_path = artifact_root / VALIDATED_FILE
+    apply_result_path = artifact_root / APPLY_RESULT_FILE
+    eval_log_path = artifact_root / EVAL_LOG_FILE
+    final_path = artifact_root / FINAL_FILE
+
+    for required in (rules_path, plan_path, eval_log_path):
+        if not required.is_file():
+            raise DriverFailure(
+                {
+                    "status": "failed",
+                    "error_message": f"missing prepared artifact: {required}",
+                    "step": "artifact-load",
+                }
+            )
+
+    context = load_json(plan_path)
+    raw_plan = build_raw_plan(context, load_json(messages_file))
+    write_json(raw_plan_path, raw_plan)
+
+    run_python(
+        "validate_reword_plan.py",
+        ["--rules", str(rules_path), "--context", str(plan_path), "--plan", str(raw_plan_path), "--output", str(validated_path)],
+        repo_root=repo_root,
+        allowed_exit_codes={0, 1},
+    )
+    if not validated_path.is_file():
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": f"validate_reword_plan.py did not produce {validated_path}",
+                "step": "validate_reword_plan.py",
+            }
+        )
+    run_python(
+        "write_evaluation_log.py",
+        ["phase", "--log", str(eval_log_path), "--phase", "validate", "--result", str(validated_path)],
+        repo_root=repo_root,
+    )
+
+    validated = load_json(validated_path)
+    apply_result: dict[str, Any] | None = None
+
+    if bool(validated.get("valid")):
+        apply_args = ["--context", str(plan_path), "--plan", str(validated_path), "--result-output", str(apply_result_path)]
+        if temp_root is not None:
+            apply_args.extend(["--temp-root", str(temp_root)])
+        if dry_run_requested or not apply_changes:
+            apply_args.append("--dry-run")
+        run_python(
+            "apply_reword_plan.py",
+            apply_args,
+            repo_root=repo_root,
+            allowed_exit_codes={0, 1},
+        )
+        if not apply_result_path.is_file():
+            raise DriverFailure(
+                {
+                    "status": "failed",
+                    "error_message": f"apply_reword_plan.py did not produce {apply_result_path}",
+                    "step": "apply_reword_plan.py",
+                }
+            )
+        run_python(
+            "write_evaluation_log.py",
+            ["phase", "--log", str(eval_log_path), "--phase", "apply", "--result", str(apply_result_path)],
+            repo_root=repo_root,
+        )
+        apply_result = load_json(apply_result_path)
+
+    final_payload = minimal_final_payload(validated, apply_result)
+    if final_observations is not None:
+        merge_dicts(final_payload, load_json(final_observations))
+    write_json(final_path, final_payload)
+    run_python(
+        "write_evaluation_log.py",
+        ["finalize", "--log", str(eval_log_path), "--final", str(final_path)],
+        repo_root=repo_root,
+    )
+
+    if not bool(validated.get("valid")):
+        return {
+            "status": "invalid",
+            "next_action": "fix_messages",
+            "validated_path": str(validated_path),
+            "apply_result_path": None,
+            "evaluation_log_path": str(eval_log_path),
+            "new_head": None,
+        }
+
+    if apply_result is None:
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "apply result is missing after a valid validation step",
+                "step": "apply",
+            }
+        )
+
+    status = str(apply_result.get("status") or "failed")
+    next_action = "apply" if status == "dry-run" else ("done" if status == "ok" else "inspect_apply_result")
+    return {
+        "status": status,
+        "next_action": next_action,
+        "validated_path": str(validated_path),
+        "apply_result_path": str(apply_result_path),
+        "evaluation_log_path": str(eval_log_path),
+        "new_head": apply_result.get("new_head"),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Repository path. Defaults to the current directory.")
+    parser.add_argument("--count", type=int, help="Number of recent commits to reword.")
+    parser.add_argument("--prepare-only", action="store_true", help="Collect artifacts and write message-template.json.")
+    parser.add_argument("--messages-file", type=Path, help="Path to a filled message-template JSON payload.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and run apply_reword_plan.py in dry-run mode.")
+    parser.add_argument("--apply", action="store_true", help="Apply the validated rewrite plan.")
+    parser.add_argument("--artifacts-dir", type=Path, help="Optional artifact directory override.")
+    parser.add_argument("--temp-root", type=Path, help="Optional temp worktree parent directory override.")
+    parser.add_argument("--final-observations", type=Path, help="Optional JSON payload merged before evaluation finalize.")
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if bool(args.prepare_only) == bool(args.messages_file):
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "choose exactly one of --prepare-only or --messages-file",
+                "step": "argument-parse",
+            },
+            exit_code=2,
+        )
+    if args.prepare_only:
+        if args.count is None or args.count <= 0:
+            raise DriverFailure(
+                {
+                    "status": "failed",
+                    "error_message": "--count must be a positive integer with --prepare-only",
+                    "step": "argument-parse",
+                },
+                exit_code=2,
+            )
+        if args.dry_run or args.apply or args.temp_root or args.final_observations:
+            raise DriverFailure(
+                {
+                    "status": "failed",
+                    "error_message": "--prepare-only does not accept --dry-run, --apply, --temp-root, or --final-observations",
+                    "step": "argument-parse",
+                },
+                exit_code=2,
+            )
+        return
+    if args.apply and args.dry_run:
+        raise DriverFailure(
+            {
+                "status": "failed",
+                "error_message": "--apply and --dry-run are mutually exclusive",
+                "step": "argument-parse",
+            },
+            exit_code=2,
+        )
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        validate_args(args)
+        repo_root = resolve_repo_root(Path(args.repo).resolve())
+        ensure_repo_codex_tmp_excluded(repo_root)
+        if args.prepare_only:
+            artifact_root = resolve_artifact_root(
+                repo_root,
+                run_id=build_run_id(),
+                artifacts_dir=args.artifacts_dir,
+            )
+            emit(prepare(repo_root, int(args.count), artifact_root))
+            return 0
+
+        assert args.messages_file is not None
+        artifact_root = resolve_existing_artifact_root(
+            repo_root,
+            messages_file=args.messages_file,
+            artifacts_dir=args.artifacts_dir,
+        )
+        summary = execute_messages_flow(
+            repo_root,
+            artifact_root,
+            args.messages_file.resolve(),
+            apply_changes=bool(args.apply),
+            dry_run_requested=bool(args.dry_run),
+            temp_root=args.temp_root,
+            final_observations=args.final_observations.resolve() if args.final_observations else None,
+        )
+        emit(summary)
+        return 0 if summary["status"] in {"ok", "dry-run"} else 1
+    except DriverFailure as exc:
+        emit(exc.payload)
+        return exc.exit_code
+    except Exception as exc:
+        emit({"status": "failed", "error_message": str(exc)})
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_recent_commits.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from reword_runtime_paths import (
     build_run_id,
+    enforce_repo_local_codex_tmp_path,
     ensure_repo_codex_tmp_excluded,
     resolve_artifact_root,
     resolve_existing_artifact_root,
@@ -426,12 +427,28 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Repository path. Defaults to the current directory.")
     parser.add_argument("--count", type=int, help="Number of recent commits to reword.")
     parser.add_argument("--prepare-only", action="store_true", help="Collect artifacts and write message-template.json.")
-    parser.add_argument("--messages-file", type=Path, help="Path to a filled message-template JSON payload.")
+    parser.add_argument(
+        "--messages-file",
+        type=Path,
+        help="Path to a filled message-template JSON payload. Repo-local temp inputs must live under .codex/tmp/.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Validate and run apply_reword_plan.py in dry-run mode.")
     parser.add_argument("--apply", action="store_true", help="Apply the validated rewrite plan.")
-    parser.add_argument("--artifacts-dir", type=Path, help="Optional artifact directory override.")
-    parser.add_argument("--temp-root", type=Path, help="Optional temp worktree parent directory override.")
-    parser.add_argument("--final-observations", type=Path, help="Optional JSON payload merged before evaluation finalize.")
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        help="Optional artifact directory override. Repo-local overrides must live under .codex/tmp/.",
+    )
+    parser.add_argument(
+        "--temp-root",
+        type=Path,
+        help="Optional temp worktree parent directory override. Repo-local overrides must live under .codex/tmp/.",
+    )
+    parser.add_argument(
+        "--final-observations",
+        type=Path,
+        help="Optional JSON payload merged before evaluation finalize. Repo-local ad hoc inputs must live under .codex/tmp/.",
+    )
     return parser.parse_args()
 
 
@@ -483,29 +500,45 @@ def main() -> int:
         validate_args(args)
         repo_root = resolve_repo_root(Path(args.repo).resolve())
         ensure_repo_codex_tmp_excluded(repo_root)
+        artifacts_dir = (
+            enforce_repo_local_codex_tmp_path(repo_root, args.artifacts_dir, label="artifacts-dir")
+            if args.artifacts_dir
+            else None
+        )
+        temp_root = (
+            enforce_repo_local_codex_tmp_path(repo_root, args.temp_root, label="temp-root")
+            if args.temp_root
+            else None
+        )
+        final_observations = (
+            enforce_repo_local_codex_tmp_path(repo_root, args.final_observations, label="final-observations")
+            if args.final_observations
+            else None
+        )
         if args.prepare_only:
             artifact_root = resolve_artifact_root(
                 repo_root,
                 run_id=build_run_id(),
-                artifacts_dir=args.artifacts_dir,
+                artifacts_dir=artifacts_dir,
             )
             emit(prepare(repo_root, int(args.count), artifact_root))
             return 0
 
         assert args.messages_file is not None
+        messages_file = enforce_repo_local_codex_tmp_path(repo_root, args.messages_file, label="messages-file")
         artifact_root = resolve_existing_artifact_root(
             repo_root,
-            messages_file=args.messages_file,
-            artifacts_dir=args.artifacts_dir,
+            messages_file=messages_file,
+            artifacts_dir=artifacts_dir,
         )
         summary = execute_messages_flow(
             repo_root,
             artifact_root,
-            args.messages_file.resolve(),
+            messages_file,
             apply_changes=bool(args.apply),
             dry_run_requested=bool(args.dry_run),
-            temp_root=args.temp_root,
-            final_observations=args.final_observations.resolve() if args.final_observations else None,
+            temp_root=temp_root,
+            final_observations=final_observations,
         )
         emit(summary)
         return 0 if summary["status"] in {"ok", "dry-run"} else 1

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_runtime_paths.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_runtime_paths.py
@@ -13,6 +13,7 @@ from typing import Mapping
 
 
 ARTIFACT_NAMESPACE = Path(".codex") / "tmp" / "packet-workflow" / "reword-recent-commits"
+CODEX_TMP_NAMESPACE = Path(".codex") / "tmp"
 SMOKE_ROOT_RELATIVE = ARTIFACT_NAMESPACE / "smoke"
 EXCLUDE_PATTERN = ".codex/tmp/"
 TEMP_ROOT_ENV_VAR = "REWORD_RECENT_COMMITS_TEMP_ROOT"
@@ -50,6 +51,25 @@ def resolve_runtime_namespace_root(repo_root: Path) -> Path:
     return resolve_repo_path(repo_root, ARTIFACT_NAMESPACE)
 
 
+def resolve_repo_codex_tmp_root(repo_root: Path) -> Path:
+    return resolve_repo_path(repo_root, CODEX_TMP_NAMESPACE)
+
+
+def enforce_repo_local_codex_tmp_path(repo_root: Path, path: Path, *, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    repo_root_resolved = resolve_repo_root(repo_root)
+    try:
+        resolved.relative_to(repo_root_resolved)
+    except ValueError:
+        return resolved
+    repo_codex_tmp = resolve_repo_codex_tmp_root(repo_root_resolved)
+    try:
+        resolved.relative_to(repo_codex_tmp)
+    except ValueError as exc:
+        raise RuntimeError(f"{label} paths inside the repo must live under .codex/tmp/") from exc
+    return resolved
+
+
 def resolve_smoke_root(workspace_root: Path | None = None) -> Path:
     base_root = workspace_root.resolve() if workspace_root is not None else Path.cwd().resolve()
     smoke_root = (base_root / SMOKE_ROOT_RELATIVE).resolve()
@@ -75,7 +95,7 @@ def resolve_artifact_root(
     artifacts_dir: Path | None = None,
 ) -> Path:
     if artifacts_dir is not None:
-        return artifacts_dir.expanduser().resolve()
+        return enforce_repo_local_codex_tmp_path(repo_root, artifacts_dir, label="artifacts-dir")
     return (resolve_runtime_namespace_root(repo_root) / run_id).resolve()
 
 
@@ -87,7 +107,7 @@ def resolve_existing_artifact_root(
 ) -> Path:
     if artifacts_dir is not None:
         return resolve_artifact_root(repo_root, run_id="unused", artifacts_dir=artifacts_dir)
-    return messages_file.resolve().parent
+    return enforce_repo_local_codex_tmp_path(repo_root, messages_file, label="messages-file").parent
 
 
 def build_run_id(now: datetime | None = None) -> str:
@@ -102,11 +122,17 @@ def resolve_temp_root(
     env: Mapping[str, str] | None = None,
 ) -> tuple[Path, str]:
     if cli_temp_root is not None:
-        return cli_temp_root.expanduser().resolve(), "cli"
+        resolved = cli_temp_root.expanduser().resolve()
+        if repo_root is not None:
+            resolved = enforce_repo_local_codex_tmp_path(repo_root, resolved, label="temp-root")
+        return resolved, "cli"
     environment = env if env is not None else os.environ
     env_value = str(environment.get(TEMP_ROOT_ENV_VAR) or "").strip()
     if env_value:
-        return Path(env_value).expanduser().resolve(), "env"
+        resolved = Path(env_value).expanduser().resolve()
+        if repo_root is not None:
+            resolved = enforce_repo_local_codex_tmp_path(repo_root, resolved, label=TEMP_ROOT_ENV_VAR)
+        return resolved, "env"
     base_root = resolve_repo_root(repo_root) if repo_root is not None else Path.cwd().resolve()
     return (
         Path.home()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_runtime_paths.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_runtime_paths.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Runtime path helpers for reword-recent-commits."""
+
+from __future__ import annotations
+
+import os
+import secrets
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+
+ARTIFACT_NAMESPACE = Path(".codex") / "tmp" / "packet-workflow" / "reword-recent-commits"
+SMOKE_ROOT_RELATIVE = ARTIFACT_NAMESPACE / "smoke"
+EXCLUDE_PATTERN = ".codex/tmp/"
+TEMP_ROOT_ENV_VAR = "REWORD_RECENT_COMMITS_TEMP_ROOT"
+
+
+def run_git(repo: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
+def resolve_repo_root(repo: Path) -> Path:
+    return Path(run_git(repo, ["rev-parse", "--show-toplevel"])).resolve()
+
+
+def resolve_git_metadata_path(repo_root: Path, relative_path: str) -> Path:
+    resolved = Path(run_git(repo_root, ["rev-parse", "--git-path", relative_path]))
+    if not resolved.is_absolute():
+        resolved = resolve_repo_root(repo_root) / resolved
+    return resolved.resolve()
+
+
+def resolve_repo_path(repo_root: Path, relative_path: Path | str) -> Path:
+    return (resolve_repo_root(repo_root) / Path(relative_path)).resolve()
+
+
+def resolve_runtime_namespace_root(repo_root: Path) -> Path:
+    return resolve_repo_path(repo_root, ARTIFACT_NAMESPACE)
+
+
+def resolve_smoke_root(workspace_root: Path | None = None) -> Path:
+    base_root = workspace_root.resolve() if workspace_root is not None else Path.cwd().resolve()
+    smoke_root = (base_root / SMOKE_ROOT_RELATIVE).resolve()
+    smoke_root.mkdir(parents=True, exist_ok=True)
+    return smoke_root
+
+
+def ensure_repo_codex_tmp_excluded(repo_root: Path) -> None:
+    exclude_path = resolve_git_metadata_path(repo_root, "info/exclude")
+    exclude_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+    existing_patterns = {line.strip() for line in existing.splitlines()}
+    if EXCLUDE_PATTERN in existing_patterns:
+        return
+    prefix = "" if not existing or existing.endswith("\n") else "\n"
+    exclude_path.write_text(existing + prefix + EXCLUDE_PATTERN + "\n", encoding="utf-8")
+
+
+def resolve_artifact_root(
+    repo_root: Path,
+    *,
+    run_id: str,
+    artifacts_dir: Path | None = None,
+) -> Path:
+    if artifacts_dir is not None:
+        return artifacts_dir.expanduser().resolve()
+    return (resolve_runtime_namespace_root(repo_root) / run_id).resolve()
+
+
+def resolve_existing_artifact_root(
+    repo_root: Path,
+    *,
+    messages_file: Path,
+    artifacts_dir: Path | None = None,
+) -> Path:
+    if artifacts_dir is not None:
+        return resolve_artifact_root(repo_root, run_id="unused", artifacts_dir=artifacts_dir)
+    return messages_file.resolve().parent
+
+
+def build_run_id(now: datetime | None = None) -> str:
+    timestamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+    return f"{timestamp}-{secrets.token_hex(4)}"
+
+
+def resolve_temp_root(
+    repo_root: Path | None = None,
+    *,
+    cli_temp_root: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> tuple[Path, str]:
+    if cli_temp_root is not None:
+        return cli_temp_root.expanduser().resolve(), "cli"
+    environment = env if env is not None else os.environ
+    env_value = str(environment.get(TEMP_ROOT_ENV_VAR) or "").strip()
+    if env_value:
+        return Path(env_value).expanduser().resolve(), "env"
+    base_root = resolve_repo_root(repo_root) if repo_root is not None else Path.cwd().resolve()
+    return (
+        Path.home()
+        / ".codex"
+        / "tmp"
+        / "packet-workflow"
+        / "reword-recent-commits"
+        / "temp"
+        / base_root.name
+    ).resolve(), "home_codex_tmp"
+
+
+def ensure_directory_writable(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    file_descriptor, probe_name = tempfile.mkstemp(prefix="write-check-", dir=path)
+    os.close(file_descriptor)
+    Path(probe_name).unlink(missing_ok=True)
+
+
+def create_temp_runtime_dir(temp_root_parent: Path) -> Path:
+    ensure_directory_writable(temp_root_parent)
+    return Path(tempfile.mkdtemp(prefix="reword-recent-commits-", dir=temp_root_parent)).resolve()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/smoke_reword_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/smoke_reword_recent_commits.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Smoke-test reword-recent-commits through the single driver."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from reword_runtime_paths import resolve_smoke_root
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DRIVER_PATH = SCRIPT_DIR / "reword_recent_commits.py"
+
+
+def run_python(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, "-B", *args],
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"python {' '.join(args)} failed")
+    return result
+
+
+def run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"git {' '.join(args)} failed")
+    return result
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def create_repo(repo_root: Path) -> None:
+    run_git(repo_root, ["init"])
+    run_git(repo_root, ["config", "user.name", "Smoke Test"])
+    run_git(repo_root, ["config", "user.email", "smoke@example.test"])
+
+    write_text(
+        repo_root / ".github" / "instructions" / "commit-message.instructions.md",
+        "\n".join(
+            [
+                "## Format",
+                "- Use `<type>(<scope>): <subject>`.",
+                "",
+                "## Types",
+                "- `fix`",
+                "- `docs`",
+                "",
+                "## Scopes",
+                "- `core`",
+                "- `parser`",
+            ]
+        )
+        + "\n",
+    )
+    write_text(repo_root / "src" / "parser.py", "print('seed')\n")
+    run_git(repo_root, ["add", "."])
+    run_git(repo_root, ["commit", "--no-gpg-sign", "-m", "docs(repo): add commit rules"])
+
+    write_text(repo_root / "src" / "parser.py", "print('seed')\nprint('next')\n")
+    run_git(repo_root, ["add", "src/parser.py"])
+    run_git(repo_root, ["commit", "--no-gpg-sign", "-m", "fix(core): seed"])
+
+    write_text(repo_root / "docs" / "notes.md", "# Notes\n")
+    run_git(repo_root, ["add", "docs/notes.md"])
+    run_git(repo_root, ["commit", "--no-gpg-sign", "-m", "fix(parser): follow-up"])
+
+
+def main() -> int:
+    smoke_root = resolve_smoke_root(Path.cwd()) / "latest"
+    if smoke_root.exists():
+        shutil.rmtree(smoke_root)
+    smoke_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(dir=smoke_root, prefix="workspace-") as tmp_dir:
+        root = Path(tmp_dir)
+        repo_root = root / "repo"
+        repo_root.mkdir()
+        create_repo(repo_root)
+
+        prepare_result = run_python(
+            [
+                str(DRIVER_PATH),
+                "--repo",
+                str(repo_root),
+                "--count",
+                "2",
+                "--prepare-only",
+            ]
+        )
+        prepare_summary = json.loads(prepare_result.stdout)
+        artifact_root = Path(str(prepare_summary["artifact_root"]))
+        message_template_path = Path(str(prepare_summary["message_template_path"]))
+
+        template = load_json(message_template_path)
+        template["commits"][0]["new_message"] = "fix(core): rewrite seed"
+        template["commits"][1]["new_message"] = "fix(parser): rewrite follow-up"
+        message_template_path.write_text(
+            json.dumps(template, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+
+        apply_result = run_python(
+            [
+                str(DRIVER_PATH),
+                "--repo",
+                str(repo_root),
+                "--count",
+                "2",
+                "--messages-file",
+                str(message_template_path),
+                "--apply",
+            ]
+        )
+        apply_summary = json.loads(apply_result.stdout)
+
+        build_result = load_json(artifact_root / "build-result.json")
+        packet_dir = artifact_root / "packets"
+        packet_metrics = load_json(packet_dir / "packet_metrics.json")
+        if build_result.get("packet_metrics") != packet_metrics:
+            raise RuntimeError("Smoke build result and packet_metrics.json disagree.")
+        persisted_eval_log = smoke_root / "eval-log.json"
+        eval_log_path = Path(str(apply_summary["evaluation_log_path"]))
+        persisted_eval_log.write_text(eval_log_path.read_text(encoding="utf-8"), encoding="utf-8", newline="\n")
+        summary = {
+            "status": "ok",
+            "packet_metrics": packet_metrics,
+            "common_path_sufficient": bool(build_result.get("common_path_sufficient")),
+            "evaluation_log_path": str(persisted_eval_log),
+        }
+        print(json.dumps(summary, indent=2, ensure_ascii=True))
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/validate_reword_plan.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/validate_reword_plan.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate and normalize rewritten commit-message plans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from reword_plan_contract import (
+    branch_state,
+    detect_operation,
+    load_json,
+    validate_reword_plan_payload,
+)
+
+
+def write_json(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate and normalize rewritten commit-message plans."
+    )
+    parser.add_argument("--rules", type=Path, required=True, help="Path to rules JSON from collect_commit_rules.py")
+    parser.add_argument("--context", type=Path, required=True, help="Path to collected plan JSON from collect_recent_commits.py")
+    parser.add_argument("--plan", type=Path, required=True, help="Path to the raw draft plan JSON with new_message values")
+    parser.add_argument("--output", type=Path, help="Optional path to write the validation envelope")
+    args = parser.parse_args()
+
+    try:
+        rules = load_json(args.rules)
+        context = load_json(args.context)
+        raw_plan = load_json(args.plan)
+        repo_root = Path(str(context.get("repo_root") or ".")).resolve()
+        repo_state = branch_state(repo_root)
+        operation = detect_operation(repo_root)
+        payload = validate_reword_plan_payload(
+            context,
+            rules,
+            raw_plan,
+            repo_state=repo_state,
+            active_operation=operation,
+        )
+    except Exception as exc:
+        print(f"validate_reword_plan.py: {exc}", file=sys.stderr)
+        return 1
+
+    write_json(args.output, payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if payload.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/write_evaluation_log.py
@@ -1,0 +1,1066 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def packet_count_hint(orchestrator: dict[str, Any]) -> int | None:
+    for key in ("candidate_batch_count", "commit_packet_count"):
+        detected = safe_int(orchestrator.get(key))
+        if detected is not None:
+            return detected
+    return None
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        raw_reread_reasons = list_of_strings(orchestrator.get("raw_reread_reasons"))
+        commits = context.get("commits", [])
+        return {
+            "branch": context.get("branch"),
+            "count": safe_int(context.get("count")) or (len(commits) if isinstance(commits, list) else 0),
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commit_packet_count": safe_int(orchestrator.get("commit_packet_count")) or (len(commits) if isinstance(commits, list) else 0),
+            "decision_ready_packets": to_bool(orchestrator.get("decision_ready_packets")),
+            "worker_return_contract": orchestrator.get("worker_return_contract"),
+            "worker_output_shape": orchestrator.get("worker_output_shape"),
+            "base_commit": context.get("base_commit"),
+            "head_commit": context.get("head_commit"),
+            "new_head": None,
+            "rewrite_mode": orchestrator.get("review_mode"),
+            "validation_commands": [],
+            "applied_commit_hashes": [],
+            "commits_rewritten": None,
+            "force_push_needed": None,
+            "rules_reliability": context.get("rules_reliability") or orchestrator.get("rules_reliability"),
+            "context_fingerprint": context.get("context_fingerprint"),
+            "cleanup_succeeded": None,
+            "common_path_sufficient": to_bool(orchestrator.get("common_path_sufficient")),
+            "raw_reread_count": len(raw_reread_reasons),
+            "raw_reread_reasons": raw_reread_reasons,
+            "packet_count": None,
+            "estimated_packet_tokens": None,
+            "estimated_delegation_savings": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": safe_int(orchestrator.get("candidate_batch_count")) or 0,
+            "commit_buckets_applied": None,
+            "decision_ready_packets": to_bool(orchestrator.get("decision_ready_packets")),
+            "worker_return_contract": orchestrator.get("worker_return_contract"),
+            "worker_output_shape": orchestrator.get("worker_output_shape"),
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": packet_count_hint(orchestrator) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        if isinstance(result.get("recommended_workers"), list):
+            orchestration["worker_roles"] = worker_roles({"recommended_workers": result.get("recommended_workers")})
+        override_signals = result.get("applied_override_signals")
+        if isinstance(override_signals, list):
+            orchestration["override_signals"] = list_of_strings(override_signals)
+        active_packet_count = safe_int(result.get("active_packet_count"))
+        if active_packet_count is not None:
+            log.setdefault("input_size", {})["active_areas"] = active_packet_count
+        commit_packet_count = safe_int(result.get("commit_packet_count"))
+        if commit_packet_count is not None:
+            log.setdefault("input_size", {})["candidate_batches"] = commit_packet_count
+            log.setdefault("skill_specific", {}).setdefault("data", {})["commit_packet_count"] = commit_packet_count
+        common_path_sufficient = to_bool(result.get("common_path_sufficient"))
+        if common_path_sufficient is not None:
+            log.setdefault("skill_specific", {}).setdefault("data", {})["common_path_sufficient"] = common_path_sufficient
+        raw_reread_reasons = list_of_strings(result.get("raw_reread_reasons"))
+        orchestration["raw_reread_required"] = bool(raw_reread_reasons)
+        orchestration["raw_reread_reason"] = raw_reread_reasons[0] if raw_reread_reasons else None
+        log.setdefault("skill_specific", {}).setdefault("data", {})["raw_reread_count"] = safe_int(result.get("raw_reread_count")) or len(raw_reread_reasons)
+        log.setdefault("skill_specific", {}).setdefault("data", {})["raw_reread_reasons"] = raw_reread_reasons
+        packet_metrics = result.get("packet_metrics")
+        if isinstance(packet_metrics, dict):
+            skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+            skill_specific["packet_count"] = safe_int(packet_metrics.get("packet_count"))
+            skill_specific["estimated_packet_tokens"] = safe_int(packet_metrics.get("estimated_packet_tokens"))
+            skill_specific["estimated_delegation_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            baseline = log.setdefault("baseline", {})
+            baseline["estimated_local_only_tokens"] = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+            baseline["estimated_token_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            baseline["estimated_delegation_savings"] = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            log.setdefault("measurement", {})["efficiency_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+            skill_specific["context_fingerprint"] = result.get("context_fingerprint") or skill_specific.get("context_fingerprint")
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        if log.get("skill", {}).get("name") == "reword-recent-commits":
+            skill_specific["validation_commands"] = ["validate_reword_plan.py"]
+            skill_specific["rules_reliability"] = result.get("rules_reliability") or skill_specific.get("rules_reliability")
+            counters = result.get("counters") or {}
+            commits_validated = safe_int(counters.get("commits_validated"))
+            if commits_validated is not None:
+                skill_specific["commits_in_scope"] = commits_validated
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+            skill_specific["context_fingerprint"] = result.get("context_fingerprint") or skill_specific.get("context_fingerprint")
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+        if log.get("skill", {}).get("name") == "reword-recent-commits":
+            skill_specific["new_head"] = result.get("new_head")
+            skill_specific["applied_commit_hashes"] = list_of_strings(result.get("applied_commit_hashes"))
+            counters = result.get("counters") or {}
+            rewritten = safe_int(counters.get("commits_rewritten"))
+            if rewritten is not None:
+                skill_specific["commits_rewritten"] = rewritten
+            force_push_needed = result.get("force_push_needed")
+            if force_push_needed is not None:
+                skill_specific["force_push_needed"] = to_bool(force_push_needed)
+            cleanup_succeeded = result.get("cleanup_succeeded")
+            if cleanup_succeeded is not None:
+                skill_specific["cleanup_succeeded"] = to_bool(cleanup_succeeded)
+            skill_specific["rules_reliability"] = result.get("rules_reliability") or skill_specific.get("rules_reliability")
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/reword_test_support.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/reword_test_support.py
@@ -1,0 +1,102 @@
+﻿from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SKILL_ROOT = TEST_DIR.parent
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+AMBIGUOUS_MODULES = (
+    "apply_reword_plan",
+    "build_reword_packets",
+    "collect_commit_rules",
+    "collect_recent_commits",
+    "reword_plan_contract",
+    "reword_recent_commits",
+    "reword_runtime_paths",
+    "validate_reword_plan",
+    "write_evaluation_log",
+)
+for module_name in AMBIGUOUS_MODULES:
+    sys.modules.pop(module_name, None)
+for candidate in (str(TEST_DIR), str(SCRIPTS_DIR)):
+    while candidate in sys.path:
+        sys.path.remove(candidate)
+for candidate in (str(TEST_DIR), str(SCRIPTS_DIR)):
+    sys.path.insert(0, candidate)
+importlib.invalidate_caches()
+
+
+def run_git(
+    repo: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
+    return result.stdout.strip()
+
+
+def make_repo() -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    temp_dir = tempfile.TemporaryDirectory()
+    repo = Path(temp_dir.name)
+    run_git(repo, "init")
+    run_git(repo, "config", "user.name", "Codex")
+    run_git(repo, "config", "user.email", "codex@example.com")
+    return temp_dir, repo
+
+
+def commit_file(
+    repo: Path,
+    rel_path: str,
+    content: str,
+    message: str,
+    *,
+    author_name: str = "Codex",
+    author_email: str = "codex@example.com",
+    author_date: str = "2026-03-27T00:00:00Z",
+) -> str:
+    path = repo / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    run_git(repo, "add", rel_path)
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = author_name
+    env["GIT_AUTHOR_EMAIL"] = author_email
+    env["GIT_AUTHOR_DATE"] = author_date
+    env["GIT_COMMITTER_NAME"] = author_name
+    env["GIT_COMMITTER_EMAIL"] = author_email
+    env["GIT_COMMITTER_DATE"] = author_date
+    run_git(repo, "commit", "--no-gpg-sign", "-m", message, env=env)
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+def write_rules_file(repo: Path, body: str) -> Path:
+    path = repo / ".github" / "instructions" / "commit-message.instructions.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_apply_reword_plan.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_apply_reword_plan.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+from reword_test_support import commit_file, load_json, make_repo, run_git, write_json
+
+import apply_reword_plan  # type: ignore  # noqa: E402
+import collect_commit_rules  # type: ignore  # noqa: E402
+import collect_recent_commits  # type: ignore  # noqa: E402
+from reword_plan_contract import branch_state, detect_operation, validate_reword_plan_payload  # noqa: E402
+
+
+class ApplyRewordPlanTests(unittest.TestCase):
+    def assert_utc_timestamp_equal(self, actual: str, expected: str) -> None:
+        def normalize(value: str) -> datetime:
+            text = value.strip()
+            if text.endswith("Z"):
+                text = text[:-1] + "+00:00"
+            return datetime.fromisoformat(text).astimezone(timezone.utc)
+
+        self.assertEqual(normalize(actual), normalize(expected))
+
+    def build_validated_plan(self) -> tuple[object, Path, dict, dict]:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(
+            repo,
+            ".github/instructions/commit-message.instructions.md",
+            "\n".join(
+                [
+                    "## Format",
+                    "`<type>(<scope>): <subject>`",
+                    "## Types",
+                    "- `fix`",
+                    "- `docs`",
+                    "## Scopes",
+                    "scope is required",
+                ]
+            ),
+            "docs(repo): add commit rules",
+        )
+        commit_file(repo, "src/a.py", "one\n", "fix(core): seed", author_name="One", author_email="one@example.com", author_date="2026-03-27T00:00:00Z")
+        commit_file(repo, "src/b.py", "two\n", "fix(parser): follow-up", author_name="Two", author_email="two@example.com", author_date="2026-03-27T00:01:00Z")
+        rules = collect_commit_rules.build_rules(repo)
+        context = collect_recent_commits.build_plan(repo, 2, rules)
+        raw_plan = copy.deepcopy(context)
+        raw_plan["commits"][0]["new_message"] = "fix(core): rewrite seed"
+        raw_plan["commits"][1]["new_message"] = "fix(parser): rewrite follow-up\n\n- Preserve replay safety."
+        validated = validate_reword_plan_payload(
+            context,
+            rules,
+            raw_plan,
+            repo_state=branch_state(repo),
+            active_operation=detect_operation(repo),
+        )
+        self.assertTrue(validated["valid"])
+        return temp_dir, repo, context, validated
+
+    def run_apply(
+        self,
+        context: dict,
+        validated: dict,
+        *,
+        dry_run: bool,
+        temp_root: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, dict]:
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        tmp_path = Path(tmpdir.name)
+        context_path = tmp_path / "context.json"
+        plan_path = tmp_path / "validated.json"
+        result_path = tmp_path / "result.json"
+        write_json(context_path, context)
+        write_json(plan_path, validated)
+
+        stdout = io.StringIO()
+        argv = [
+            "apply_reword_plan.py",
+            "--context",
+            str(context_path),
+            "--plan",
+            str(plan_path),
+            "--result-output",
+            str(result_path),
+        ]
+        if dry_run:
+            argv.append("--dry-run")
+        if temp_root is not None:
+            argv.extend(["--temp-root", str(temp_root)])
+        with (
+            mock.patch.object(sys, "argv", argv),
+            mock.patch.dict(os.environ, env or {}, clear=False),
+            contextlib.redirect_stdout(stdout),
+        ):
+            exit_code = apply_reword_plan.main()
+        return exit_code, load_json(result_path)
+
+    def test_dry_run_leaves_head_unchanged(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+        head_before = run_git(repo, "rev-parse", "HEAD")
+
+        exit_code, result = self.run_apply(context, validated, dry_run=True)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(result["status"], "dry-run")
+        self.assertEqual(run_git(repo, "rev-parse", "HEAD"), head_before)
+        self.assertEqual(result["stop_reasons"], [])
+
+    def test_apply_rewrites_messages_and_preserves_author_metadata(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+
+        exit_code, result = self.run_apply(context, validated, dry_run=False)
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(result["apply_succeeded"])
+        subjects = run_git(repo, "log", "-n", "2", "--reverse", "--format=%s").splitlines()
+        self.assertEqual(subjects, ["fix(core): rewrite seed", "fix(parser): rewrite follow-up"])
+        authors = run_git(repo, "log", "-n", "2", "--reverse", "--format=%an|%ae|%aI").splitlines()
+        first_name, first_email, first_date = authors[0].split("|", 2)
+        second_name, second_email, second_date = authors[1].split("|", 2)
+        self.assertEqual(first_name, "One")
+        self.assertEqual(first_email, "one@example.com")
+        self.assert_utc_timestamp_equal(first_date, "2026-03-27T00:00:00+00:00")
+        self.assertEqual(second_name, "Two")
+        self.assertEqual(second_email, "two@example.com")
+        self.assert_utc_timestamp_equal(second_date, "2026-03-27T00:01:00+00:00")
+        self.assertEqual(result["counters"]["commits_rewritten"], 2)
+
+    def test_apply_refuses_root_rewrite_context(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        head_commit = commit_file(repo, "src/app.py", "one\n", "fix(app): seed")
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix"],
+                "scope_required": True,
+                "scope_suggestions": ["app"],
+                "subject_length_limit": 72,
+                "subject_rules": [],
+                "body_rules": [],
+                "references_rules": [],
+                "repo_defaults": [],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["app"],
+            "recent_subject_samples": ["fix(app): seed"],
+            "rules_reliability": "explicit",
+        }
+        context = collect_recent_commits.build_plan(repo, 1, rules)
+        validated = {
+            "valid": True,
+            "context_fingerprint": context["context_fingerprint"],
+            "message_set_fingerprint": "x" * 64,
+            "normalized_rewrite_actions": [
+                {
+                    "index": 1,
+                    "hash": head_commit,
+                    "new_message": "fix(app): rewrite seed",
+                }
+            ],
+            "warnings": [],
+            "counters": {},
+            "rewrite_scope": {
+                "branch": context["branch"],
+                "count": 1,
+                "head_commit": context["head_commit"],
+                "base_commit": context["base_commit"],
+            },
+            "rules_reliability": rules["rules_reliability"],
+            "fingerprint_match": True,
+            "stop_reasons": [],
+        }
+
+        exit_code, result = self.run_apply(context, validated, dry_run=False)
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("root_rewrite_unsupported", result["stop_reasons"])
+
+    def test_apply_detects_head_drift(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+        commit_file(repo, "src/c.py", "three\n", "fix(extra): drift")
+
+        exit_code, result = self.run_apply(context, validated, dry_run=False)
+
+        self.assertEqual(exit_code, 1)
+        self.assertTrue({"recent_hash_drift", "head_commit_drift"} & set(result["stop_reasons"]))
+
+    def test_apply_reports_replay_failure_and_cleanup_state(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+        original_git_result = apply_reword_plan.git_result
+
+        def failing_git_result(repo_path: Path, args: list[str], *, env: dict[str, str] | None = None):
+            if args[:2] == ["cherry-pick", "--no-commit"]:
+                return mock.Mock(returncode=1, stdout="", stderr="simulated cherry-pick failure")
+            return original_git_result(repo_path, args, env=env)
+
+        with mock.patch.object(apply_reword_plan, "git_result", side_effect=failing_git_result):
+            with mock.patch.object(
+                apply_reword_plan,
+                "cleanup_artifacts",
+                return_value=(False, ["C:/tmp/reword-leftover"]),
+            ):
+                head_before = run_git(repo, "rev-parse", "HEAD")
+                exit_code, result = self.run_apply(context, validated, dry_run=False)
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(result["stop_reasons"], ["replay_failed"])
+        self.assertFalse(result["cleanup_succeeded"])
+        self.assertEqual(result["leftover_paths"], ["C:/tmp/reword-leftover"])
+        self.assertEqual(run_git(repo, "rev-parse", "HEAD"), head_before)
+
+    def test_apply_uses_cli_temp_root_over_env(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+        cli_temp_root = repo.parent / "cli-temp-root"
+        env_temp_root = repo.parent / "env-temp-root"
+
+        exit_code, result = self.run_apply(
+            context,
+            validated,
+            dry_run=False,
+            temp_root=cli_temp_root,
+            env={apply_reword_plan.TEMP_ROOT_ENV_VAR: str(env_temp_root)},
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(result["temp_root_parent"], str(cli_temp_root.resolve()))
+        self.assertEqual(result["temp_root_source"], "cli")
+
+    def test_apply_uses_env_temp_root_without_cli_override(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+        env_temp_root = repo.parent / "env-temp-root"
+
+        exit_code, result = self.run_apply(
+            context,
+            validated,
+            dry_run=False,
+            env={apply_reword_plan.TEMP_ROOT_ENV_VAR: str(env_temp_root)},
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(result["temp_root_parent"], str(env_temp_root.resolve()))
+        self.assertEqual(result["temp_root_source"], "env")
+
+    def test_apply_reports_actionable_temp_root_permission_failure(self) -> None:
+        _temp_dir, repo, context, validated = self.build_validated_plan()
+        blocked_temp_root = repo.parent / "blocked-temp-root"
+        blocked_temp_root.write_text("not a directory\n", encoding="utf-8")
+        head_before = run_git(repo, "rev-parse", "HEAD")
+
+        exit_code, result = self.run_apply(
+            context,
+            validated,
+            dry_run=False,
+            temp_root=blocked_temp_root,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(result["stop_reasons"], ["replay_failed"])
+        self.assertEqual(result["temp_root_parent"], str(blocked_temp_root.resolve()))
+        self.assertEqual(result["temp_root_source"], "cli")
+        self.assertIn(str(blocked_temp_root.resolve()), result["error_message"])
+        self.assertIn("--temp-root", result["error_message"])
+        self.assertEqual(result["leftover_paths"], [])
+        self.assertFalse(result["cleanup_attempted"])
+        self.assertEqual(run_git(repo, "rev-parse", "HEAD"), head_before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_build_reword_packets_contract.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_build_reword_packets_contract.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from reword_test_support import commit_file, make_repo, write_json
+
+import build_reword_packets  # type: ignore  # noqa: E402
+from reword_plan_contract import (  # noqa: E402
+    COMMON_PATH_CONTRACT,
+    RAW_REREAD_ALLOWED_REASONS,
+    build_context_fingerprint,
+    compute_packet_metrics,
+    estimate_tokens_from_bytes,
+    json_bytes,
+)
+
+
+class BuildRewordPacketsContractTest(unittest.TestCase):
+    def run_script(self, rules: dict, plan: dict) -> tuple[int, Path, dict, dict]:
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        tmp_path = Path(tmpdir.name)
+        rules_path = tmp_path / "rules.json"
+        plan_path = tmp_path / "plan.json"
+        output_dir = tmp_path / "packets"
+        result_path = tmp_path / "build-result.json"
+        write_json(rules_path, rules)
+        write_json(plan_path, plan)
+
+        stdout = io.StringIO()
+        argv = [
+            "build_reword_packets.py",
+            "--rules",
+            str(rules_path),
+            "--plan",
+            str(plan_path),
+            "--output-dir",
+            str(output_dir),
+            "--result-output",
+            str(result_path),
+        ]
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(stdout):
+            exit_code = build_reword_packets.main()
+
+        orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        return exit_code, output_dir, orchestrator, result
+
+    def test_broad_review_mode_uses_flat_contract_and_packet_ids(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        head_commit = commit_file(repo, "README.md", "seed\n", "chore(repo): seed")
+        branch = build_reword_packets.branch_state(repo)["branch"] or "main"
+
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix", "chore", "docs"],
+                "scope_required": True,
+                "subject_length_limit": 72,
+                "body_rules": ["use bullets"],
+                "references_rules": [],
+                "scope_suggestions": ["infra"],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["infra", "docs"],
+            "recent_subject_samples": ["fix(parser): seed"],
+            "rules_reliability": "explicit",
+        }
+        commits = []
+        for index in range(1, 7):
+            commits.append(
+                {
+                    "index": index,
+                    "hash": f"{index}" * 40,
+                    "short_hash": f"{index}" * 12,
+                    "parent_hashes": ["0" * 40],
+                    "subject": f"fix(parser): normalize case {index}",
+                    "body": "",
+                    "full_message": f"fix(parser): normalize case {index}",
+                    "author_name": "Codex",
+                    "author_email": "codex@example.com",
+                    "author_date": "2026-03-27T00:00:00Z",
+                    "files": ["src/parser.py", "docs/notes.md"] if index == 1 else [f"src/module_{index}.py"],
+                    "shortstat": "1 file changed, 2 insertions(+), 1 deletion(-)",
+                    "new_message": "",
+                }
+            )
+        plan = {
+            "repo_root": str(repo),
+            "branch": branch,
+            "detached_head": False,
+            "count": len(commits),
+            "head_commit": head_commit,
+            "base_commit": head_commit,
+            "active_operation": None,
+            "commits": commits,
+        }
+
+        exit_code, output_dir, orchestrator, result = self.run_script(rules, plan)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(orchestrator["review_mode"], "broad-delegation")
+        self.assertFalse(orchestrator["decision_ready_packets"])
+        self.assertEqual(orchestrator["worker_return_contract"], "generic")
+        self.assertEqual(orchestrator["worker_output_shape"], "flat")
+        self.assertTrue(orchestrator["common_path_sufficient"])
+        self.assertEqual(orchestrator["raw_reread_reasons"], [])
+        self.assertEqual(orchestrator["common_path_contract"], COMMON_PATH_CONTRACT)
+        self.assertEqual(orchestrator["reread_reason_values"], RAW_REREAD_ALLOWED_REASONS)
+        self.assertEqual(
+            orchestrator["task_packet_names"],
+            ["rules_packet.json", "commit-01.json", "commit-02.json", "commit-03.json", "commit-04.json", "commit-05.json", "commit-06.json"],
+        )
+        self.assertEqual(
+            orchestrator["task_packet_ids"],
+            ["rules_packet", "commit-01", "commit-02", "commit-03", "commit-04", "commit-05", "commit-06"],
+        )
+        self.assertEqual(
+            orchestrator["packet_worker_map"],
+            {
+                "rules_packet": ["docs_verifier"],
+                "commit-01": ["evidence_summarizer"],
+                "commit-02": ["evidence_summarizer"],
+                "commit-03": ["evidence_summarizer"],
+                "commit-04": ["evidence_summarizer"],
+                "commit-05": ["evidence_summarizer"],
+                "commit-06": ["evidence_summarizer"],
+            },
+        )
+        self.assertEqual(
+            orchestrator["worker_output_fields"],
+            ["commit_indexes", "primary_intent", "suggested_type_scope", "body_needed", "evidence_files", "ambiguity", "confidence", "reread_control"],
+        )
+        self.assertEqual(orchestrator["context_fingerprint"], build_context_fingerprint(plan, rules))
+        self.assertEqual(orchestrator["rules_reliability"], "explicit")
+
+        global_packet = json.loads((output_dir / "global_packet.json").read_text(encoding="utf-8"))
+        self.assertFalse(global_packet["decision_ready_packets"])
+        self.assertEqual(global_packet["worker_return_contract"], "generic")
+        self.assertEqual(global_packet["worker_output_shape"], "flat")
+        self.assertTrue(global_packet["common_path_sufficient"])
+        self.assertEqual(global_packet["raw_reread_reasons"], [])
+        self.assertNotIn("candidate_field_bundles", global_packet)
+
+        commit_packet = json.loads((output_dir / "commit-01.json").read_text(encoding="utf-8"))
+        self.assertEqual(commit_packet["body_guidance"], {"body_recommended": True, "reason": "More than one file changed."})
+        self.assertEqual(commit_packet["scope_candidates"][0], "parser")
+        self.assertEqual(commit_packet["rules_reliability"], "explicit")
+
+        packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+        rules_packet = json.loads((output_dir / "rules_packet.json").read_text(encoding="utf-8"))
+        commit_packet_payloads = {
+            name: json.loads((output_dir / name).read_text(encoding="utf-8"))
+            for name in orchestrator["task_packet_names"]
+            if name.startswith("commit-")
+        }
+        expected_metrics = compute_packet_metrics(
+            {
+                "global_packet.json": global_packet,
+                "rules_packet.json": rules_packet,
+                **commit_packet_payloads,
+            },
+            local_only_sources={"rules": rules, "plan": plan},
+            shared_packets=COMMON_PATH_CONTRACT["shared_packets"],
+        )
+        self.assertEqual(packet_metrics, expected_metrics)
+        self.assertEqual(result["packet_metrics"], packet_metrics)
+        self.assertTrue(result["common_path_sufficient"])
+        self.assertEqual(result["raw_reread_reasons"], [])
+        self.assertEqual(
+            packet_metrics["estimated_local_only_tokens"],
+            estimate_tokens_from_bytes(json_bytes(rules) + json_bytes(plan)),
+        )
+        largest_commit_bytes = max(json_bytes(payload) for payload in commit_packet_payloads.values())
+        self.assertEqual(
+            packet_metrics["estimated_packet_tokens"],
+            estimate_tokens_from_bytes(json_bytes(rules_packet) + largest_commit_bytes),
+        )
+
+    def test_local_mode_surfaces_root_rewrite_blocker(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        head_commit = commit_file(repo, "src/app.py", "print('hi')\n", "fix(app): seed")
+        branch = build_reword_packets.branch_state(repo)["branch"] or "main"
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix"],
+                "scope_required": True,
+                "subject_length_limit": 72,
+                "body_rules": [],
+                "references_rules": [],
+                "scope_suggestions": ["app"],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["app"],
+            "recent_subject_samples": ["fix(app): seed"],
+        }
+        plan = {
+            "repo_root": str(repo),
+            "branch": branch,
+            "detached_head": False,
+            "count": 1,
+            "head_commit": head_commit,
+            "base_commit": None,
+            "active_operation": None,
+            "commits": [
+                {
+                    "index": 1,
+                    "hash": head_commit,
+                    "short_hash": head_commit[:12],
+                    "parent_hashes": [],
+                    "subject": "fix(app): seed",
+                    "body": "",
+                    "full_message": "fix(app): seed",
+                    "author_name": "Codex",
+                    "author_email": "codex@example.com",
+                    "author_date": "2026-03-27T00:00:00Z",
+                    "files": ["src/app.py"],
+                    "shortstat": "1 file changed, 1 insertion(+)",
+                    "new_message": "",
+                }
+            ],
+        }
+
+        exit_code, _output_dir, orchestrator, result = self.run_script(rules, plan)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(orchestrator["review_mode"], "local-only")
+        self.assertEqual(orchestrator["recommended_worker_count"], 0)
+        self.assertTrue(orchestrator["rewrite_blockers"]["root_rewrite_unsupported"])
+        self.assertTrue(result["common_path_sufficient"])
+
+    def test_missing_subject_and_files_emit_allowed_reread_reason(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        head_commit = commit_file(repo, "README.md", "seed\n", "chore(repo): seed")
+        branch = build_reword_packets.branch_state(repo)["branch"] or "main"
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix"],
+                "scope_required": True,
+                "subject_length_limit": 72,
+                "body_rules": [],
+                "references_rules": [],
+                "scope_suggestions": ["core"],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["core"],
+            "recent_subject_samples": [],
+        }
+        plan = {
+            "repo_root": str(repo),
+            "branch": branch,
+            "detached_head": False,
+            "count": 1,
+            "head_commit": head_commit,
+            "base_commit": head_commit,
+            "active_operation": None,
+            "commits": [
+                {
+                    "index": 1,
+                    "hash": head_commit,
+                    "short_hash": head_commit[:12],
+                    "parent_hashes": ["0" * 40],
+                    "subject": "",
+                    "body": "",
+                    "full_message": "",
+                    "author_name": "Codex",
+                    "author_email": "codex@example.com",
+                    "author_date": "2026-03-27T00:00:00Z",
+                    "files": [],
+                    "shortstat": "",
+                    "new_message": "",
+                }
+            ],
+        }
+
+        exit_code, _output_dir, orchestrator, result = self.run_script(rules, plan)
+
+        self.assertEqual(exit_code, 0)
+        self.assertFalse(orchestrator["common_path_sufficient"])
+        self.assertFalse(result["common_path_sufficient"])
+        self.assertGreaterEqual(result["raw_reread_count"], 1)
+        self.assertTrue(result["raw_reread_reasons"])
+        for reason in result["raw_reread_reasons"]:
+            self.assertIn(reason, RAW_REREAD_ALLOWED_REASONS)
+
+    def test_larger_commit_packet_drives_packet_path_estimate(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        head_commit = commit_file(repo, "README.md", "seed\n", "chore(repo): seed")
+        branch = build_reword_packets.branch_state(repo)["branch"] or "main"
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix", "docs"],
+                "scope_required": True,
+                "subject_length_limit": 72,
+                "body_rules": [],
+                "references_rules": [],
+                "scope_suggestions": ["core"],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["core"],
+            "recent_subject_samples": ["fix(core): seed"],
+        }
+        plan = {
+            "repo_root": str(repo),
+            "branch": branch,
+            "detached_head": False,
+            "count": 2,
+            "head_commit": head_commit,
+            "base_commit": head_commit,
+            "active_operation": None,
+            "commits": [
+                {
+                    "index": 1,
+                    "hash": "1" * 40,
+                    "short_hash": "1" * 12,
+                    "parent_hashes": ["0" * 40],
+                    "subject": "fix(core): small",
+                    "body": "",
+                    "full_message": "fix(core): small",
+                    "author_name": "Codex",
+                    "author_email": "codex@example.com",
+                    "author_date": "2026-03-27T00:00:00Z",
+                    "files": ["src/small.py"],
+                    "shortstat": "1 file changed, 1 insertion(+)",
+                    "new_message": "",
+                },
+                {
+                    "index": 2,
+                    "hash": "2" * 40,
+                    "short_hash": "2" * 12,
+                    "parent_hashes": ["1" * 40],
+                    "subject": "docs(core): much larger payload",
+                    "body": "body\n" * 20,
+                    "full_message": "docs(core): much larger payload\n\n" + ("body\n" * 20),
+                    "author_name": "Codex",
+                    "author_email": "codex@example.com",
+                    "author_date": "2026-03-27T00:00:00Z",
+                    "files": ["docs/guide.md", "docs/appendix.md", "docs/changelog.md"],
+                    "shortstat": "3 files changed, 30 insertions(+)",
+                    "new_message": "",
+                },
+            ],
+        }
+
+        exit_code, output_dir, _orchestrator, _result = self.run_script(rules, plan)
+
+        self.assertEqual(exit_code, 0)
+        packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+        rules_packet = json.loads((output_dir / "rules_packet.json").read_text(encoding="utf-8"))
+        commit_01 = json.loads((output_dir / "commit-01.json").read_text(encoding="utf-8"))
+        commit_02 = json.loads((output_dir / "commit-02.json").read_text(encoding="utf-8"))
+        self.assertGreater(json_bytes(commit_02), json_bytes(commit_01))
+        self.assertEqual(
+            packet_metrics["estimated_packet_tokens"],
+            estimate_tokens_from_bytes(json_bytes(rules_packet) + json_bytes(commit_02)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_collect_reword_contracts.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_collect_reword_contracts.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+
+from reword_test_support import commit_file, make_repo, run_git, write_rules_file
+
+import collect_commit_rules  # type: ignore  # noqa: E402
+import collect_recent_commits  # type: ignore  # noqa: E402
+
+
+class CollectRewordContractsTests(unittest.TestCase):
+    def test_collect_commit_rules_marks_explicit_reliability(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        write_rules_file(
+            repo,
+            "\n".join(
+                [
+                    "## Format",
+                    "`<type>(<scope>): <subject>`",
+                    "## Types",
+                    "- `fix`",
+                    "- `docs`",
+                    "## Scopes",
+                    "scope is required",
+                    "## Subject Rules",
+                    "72 characters or fewer",
+                ]
+            ),
+        )
+        commit_file(repo, "README.md", "seed\n", "fix(repo): seed")
+
+        payload = collect_commit_rules.build_rules(repo)
+
+        self.assertEqual(payload["rules_reliability"], "explicit")
+        self.assertEqual(payload["rules"]["format"], "<type>(<scope>): <subject>")
+        self.assertEqual(payload["rules"]["allowed_types"], ["fix", "docs"])
+
+    def test_collect_commit_rules_marks_fallback_without_explicit_guidance(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(repo, "README.md", "seed\n", "seed repo")
+
+        payload = collect_commit_rules.build_rules(repo)
+
+        self.assertEqual(payload["rules_reliability"], "fallback")
+        self.assertEqual(payload["rules"]["format"], "<type>(<scope>): <subject>")
+
+    def test_collect_recent_commits_attaches_context_fingerprint_for_root_commit_scope(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(repo, "src/app.py", "print('hi')\n", "fix(app): seed")
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix"],
+                "scope_required": True,
+                "scope_suggestions": ["app"],
+                "subject_length_limit": 72,
+                "subject_rules": [],
+                "body_rules": [],
+                "references_rules": [],
+                "repo_defaults": [],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["app"],
+            "recent_subject_samples": ["fix(app): seed"],
+            "rules_reliability": "explicit",
+        }
+
+        plan = collect_recent_commits.build_plan(repo, 1, rules)
+
+        self.assertIsNone(plan["base_commit"])
+        self.assertEqual(plan["rules_reliability"], "explicit")
+        self.assertTrue(plan["context_fingerprint"])
+
+    def test_collect_recent_commits_detects_detached_head(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        write_rules_file(repo, "## Format\n`<type>(<scope>): <subject>`")
+        first = commit_file(repo, "README.md", "seed\n", "fix(repo): seed")
+        commit_file(repo, "src/app.py", "print('hi')\n", "fix(app): add app")
+        run_git(repo, "checkout", first)
+        rules = collect_commit_rules.build_rules(repo)
+
+        plan = collect_recent_commits.build_plan(repo, 1, rules)
+
+        self.assertTrue(plan["detached_head"])
+        self.assertTrue(plan["context_fingerprint"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_recent_commits_driver.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_recent_commits_driver.py
@@ -66,6 +66,19 @@ class RewordRecentCommitsDriverTests(unittest.TestCase):
         self.assertFalse(branch_state(repo)["working_tree_dirty"])
         self.assertEqual(run_git(repo, "status", "--short"), "")
 
+    def test_local_only_mode_still_prepares_packet_artifacts(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+
+        exit_code, summary = self.run_driver("--repo", str(repo), "--count", "1", "--prepare-only")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "prepared")
+        self.assertEqual(summary["review_mode"], "local-only")
+        artifact_root = Path(summary["artifact_root"])
+        self.assertTrue((artifact_root / "packets" / "orchestrator.json").is_file())
+        self.assertTrue((artifact_root / "packets" / "global_packet.json").is_file())
+        self.assertTrue((artifact_root / "packets" / "rules_packet.json").is_file())
+
     def test_messages_file_dry_run_validates_and_finalizes_eval_log(self) -> None:
         _temp_dir, repo = self.seed_repo()
         _, prepare_summary = self.run_driver("--repo", str(repo), "--count", "2", "--prepare-only")
@@ -122,6 +135,28 @@ class RewordRecentCommitsDriverTests(unittest.TestCase):
         self.assertEqual(subjects, ["fix(core): rewrite seed", "fix(parser): rewrite follow-up"])
         eval_log = load_json(Path(summary["evaluation_log_path"]))
         self.assertTrue(eval_log["safety"]["apply_succeeded"])
+
+    def test_messages_file_inside_repo_outside_codex_tmp_is_rejected(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        _, prepare_summary = self.run_driver("--repo", str(repo), "--count", "2", "--prepare-only")
+        template_path = Path(prepare_summary["message_template_path"])
+        self.write_messages(template_path)
+        invalid_path = repo / "message-template.json"
+        invalid_path.write_text(template_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+        exit_code, summary = self.run_driver(
+            "--repo",
+            str(repo),
+            "--count",
+            "2",
+            "--messages-file",
+            str(invalid_path),
+            "--dry-run",
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "failed")
+        self.assertIn("messages-file paths inside the repo must live under .codex/tmp/", summary["error_message"])
 
 
 if __name__ == "__main__":

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_recent_commits_driver.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_recent_commits_driver.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from reword_test_support import commit_file, load_json, make_repo, run_git
+
+import reword_recent_commits  # type: ignore  # noqa: E402
+import reword_runtime_paths  # type: ignore  # noqa: E402
+from reword_plan_contract import branch_state  # noqa: E402
+
+
+class RewordRecentCommitsDriverTests(unittest.TestCase):
+    def seed_repo(self) -> tuple[object, Path]:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(
+            repo,
+            ".github/instructions/commit-message.instructions.md",
+            "\n".join(
+                [
+                    "## Format",
+                    "`<type>(<scope>): <subject>`",
+                    "## Types",
+                    "- `fix`",
+                    "- `docs`",
+                    "## Scopes",
+                    "scope is required",
+                ]
+            ),
+            "docs(repo): add commit rules",
+        )
+        commit_file(repo, "src/a.py", "one\n", "fix(core): seed")
+        commit_file(repo, "src/b.py", "two\n", "fix(parser): follow-up")
+        return temp_dir, repo
+
+    def run_driver(self, *args: str) -> tuple[int, dict]:
+        stdout = io.StringIO()
+        with mock.patch.object(sys, "argv", ["reword_recent_commits.py", *args]), contextlib.redirect_stdout(stdout):
+            exit_code = reword_recent_commits.main()
+        return exit_code, json.loads(stdout.getvalue())
+
+    def write_messages(self, template_path: Path) -> None:
+        template = load_json(template_path)
+        template["commits"][0]["new_message"] = "fix(core): rewrite seed"
+        template["commits"][1]["new_message"] = "fix(parser): rewrite follow-up"
+        template_path.write_text(json.dumps(template, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+    def test_prepare_only_uses_repo_codex_tmp_artifact_root_without_dirtying_repo(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+
+        exit_code, summary = self.run_driver("--repo", str(repo), "--count", "2", "--prepare-only")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "prepared")
+        artifact_root = Path(summary["artifact_root"])
+        template_path = Path(summary["message_template_path"])
+        artifact_parent = reword_runtime_paths.resolve_runtime_namespace_root(repo)
+        self.assertTrue(artifact_root.is_relative_to(artifact_parent))
+        self.assertTrue(template_path.is_file())
+        self.assertFalse(branch_state(repo)["working_tree_dirty"])
+        self.assertEqual(run_git(repo, "status", "--short"), "")
+
+    def test_messages_file_dry_run_validates_and_finalizes_eval_log(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        _, prepare_summary = self.run_driver("--repo", str(repo), "--count", "2", "--prepare-only")
+        template_path = Path(prepare_summary["message_template_path"])
+        self.write_messages(template_path)
+        head_before = run_git(repo, "rev-parse", "HEAD")
+
+        exit_code, summary = self.run_driver(
+            "--repo",
+            str(repo),
+            "--count",
+            "2",
+            "--messages-file",
+            str(template_path),
+            "--dry-run",
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "dry-run")
+        self.assertEqual(summary["next_action"], "apply")
+        validated = load_json(Path(summary["validated_path"]))
+        apply_result = load_json(Path(summary["apply_result_path"]))
+        eval_log = load_json(Path(summary["evaluation_log_path"]))
+        self.assertTrue(validated["valid"])
+        self.assertEqual(apply_result["status"], "dry-run")
+        self.assertFalse(eval_log["safety"]["apply_attempted"])
+        self.assertTrue(eval_log["safety"]["validation_passed"])
+        self.assertEqual(eval_log["quality"]["result_status"], "dry-run")
+        self.assertEqual(run_git(repo, "rev-parse", "HEAD"), head_before)
+
+    def test_messages_file_apply_updates_head(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+        _, prepare_summary = self.run_driver("--repo", str(repo), "--count", "2", "--prepare-only")
+        template_path = Path(prepare_summary["message_template_path"])
+        self.write_messages(template_path)
+        head_before = run_git(repo, "rev-parse", "HEAD")
+
+        exit_code, summary = self.run_driver(
+            "--repo",
+            str(repo),
+            "--count",
+            "2",
+            "--messages-file",
+            str(template_path),
+            "--apply",
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "ok")
+        self.assertEqual(summary["next_action"], "done")
+        self.assertNotEqual(summary["new_head"], head_before)
+        self.assertEqual(run_git(repo, "rev-parse", "HEAD"), summary["new_head"])
+        subjects = run_git(repo, "log", "-n", "2", "--reverse", "--format=%s").splitlines()
+        self.assertEqual(subjects, ["fix(core): rewrite seed", "fix(parser): rewrite follow-up"])
+        eval_log = load_json(Path(summary["evaluation_log_path"]))
+        self.assertTrue(eval_log["safety"]["apply_succeeded"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_workflow_smoke.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_workflow_smoke.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from reword_test_support import commit_file, load_json, make_repo, run_git
+
+import reword_recent_commits  # type: ignore  # noqa: E402
+
+
+class RewordWorkflowSmokeTests(unittest.TestCase):
+    def seed_repo(self) -> tuple[object, Path]:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(
+            repo,
+            ".github/instructions/commit-message.instructions.md",
+            "\n".join(
+                [
+                    "## Format",
+                    "`<type>(<scope>): <subject>`",
+                    "## Types",
+                    "- `fix`",
+                    "- `docs`",
+                    "## Scopes",
+                    "scope is required",
+                    "## Subject Rules",
+                    "72 characters or fewer",
+                ]
+            ),
+            "docs(repo): add commit rules",
+        )
+        commit_file(repo, "src/a.py", "one\n", "fix(core): seed")
+        commit_file(repo, "src/b.py", "two\n", "fix(parser): follow-up")
+        return temp_dir, repo
+
+    def run_driver(self, *args: str) -> tuple[int, dict]:
+        stdout = io.StringIO()
+        with mock.patch.object(sys, "argv", ["reword_recent_commits.py", *args]), contextlib.redirect_stdout(stdout):
+            exit_code = reword_recent_commits.main()
+        return exit_code, json.loads(stdout.getvalue())
+
+    def test_end_to_end_driver_prepare_apply_and_eval(self) -> None:
+        _temp_dir, repo = self.seed_repo()
+
+        exit_code, prepare_summary = self.run_driver("--repo", str(repo), "--count", "2", "--prepare-only")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(prepare_summary["status"], "prepared")
+        artifact_root = Path(prepare_summary["artifact_root"])
+        template_path = Path(prepare_summary["message_template_path"])
+        template = load_json(template_path)
+        template["commits"][0]["new_message"] = "fix(core): rewrite seed"
+        template["commits"][1]["new_message"] = "fix(parser): rewrite follow-up"
+        template_path.write_text(json.dumps(template, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+        exit_code, apply_summary = self.run_driver("--repo", str(repo), "--messages-file", str(template_path), "--apply")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(apply_summary["status"], "ok")
+        subjects = run_git(repo, "log", "-n", "2", "--reverse", "--format=%s").splitlines()
+        self.assertEqual(subjects, ["fix(core): rewrite seed", "fix(parser): rewrite follow-up"])
+        build_result = load_json(artifact_root / "build-result.json")
+        final_log = load_json(Path(apply_summary["evaluation_log_path"]))
+        apply_result = load_json(artifact_root / "apply-result.json")
+        self.assertTrue(final_log["safety"]["apply_succeeded"])
+        self.assertEqual(final_log["skill_specific"]["data"]["new_head"], apply_result["new_head"])
+        self.assertEqual(final_log["skill_specific"]["data"]["packet_count"], build_result["packet_metrics"]["packet_count"])
+        self.assertEqual(final_log["baseline"]["estimated_local_only_tokens"], build_result["packet_metrics"]["estimated_local_only_tokens"])
+        self.assertTrue(final_log["skill_specific"]["data"]["common_path_sufficient"])
+
+    def test_standalone_smoke_helper_prints_stable_summary_shape(self) -> None:
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "smoke_reword_recent_commits.py"
+        result = subprocess.run(
+            [sys.executable, "-B", str(script_path)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr or result.stdout)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            set(payload.keys()),
+            {"status", "packet_metrics", "common_path_sufficient", "evaluation_log_path"},
+        )
+        self.assertEqual(payload["status"], "ok")
+        self.assertIsInstance(payload["packet_metrics"], dict)
+        self.assertIsInstance(payload["common_path_sufficient"], bool)
+        self.assertTrue(Path(payload["evaluation_log_path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_validate_reword_plan.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_validate_reword_plan.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from reword_test_support import commit_file, make_repo
+
+import collect_commit_rules  # type: ignore  # noqa: E402
+import collect_recent_commits  # type: ignore  # noqa: E402
+import reword_runtime_paths  # type: ignore  # noqa: E402
+from reword_plan_contract import branch_state, detect_operation, validate_reword_plan_payload  # noqa: E402
+
+
+class ValidateRewordPlanTests(unittest.TestCase):
+    def make_context(self) -> tuple[object, object, dict, dict]:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(
+            repo,
+            ".github/instructions/commit-message.instructions.md",
+            "\n".join(
+                [
+                    "## Format",
+                    "`<type>(<scope>): <subject>`",
+                    "## Types",
+                    "- `fix`",
+                    "- `docs`",
+                    "## Scopes",
+                    "scope is required",
+                    "## Subject Rules",
+                    "72 characters or fewer",
+                ]
+            ),
+            "docs(repo): add commit rules",
+        )
+        commit_file(repo, "src/a.py", "one\n", "fix(core): seed")
+        commit_file(repo, "src/b.py", "two\n", "fix(parser): follow-up")
+        rules = collect_commit_rules.build_rules(repo)
+        plan = collect_recent_commits.build_plan(repo, 2, rules)
+        return temp_dir, repo, rules, plan
+
+    def test_validator_normalizes_order_and_warns_on_derived_rules(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(repo, "README.md", "seed\n", "docs(repo): seed")
+        commit_file(repo, "src/a.py", "one\n", "fix(core): seed")
+        commit_file(repo, "src/b.py", "two\n", "fix(parser): follow-up")
+        rules = collect_commit_rules.build_rules(repo)
+        plan = collect_recent_commits.build_plan(repo, 2, rules)
+        raw_plan = copy.deepcopy(plan)
+        raw_plan["commits"][0]["new_message"] = "fix(core): seed"
+        raw_plan["commits"][1]["new_message"] = "fix(parser): follow-up"
+        raw_plan["commits"].reverse()
+
+        payload = validate_reword_plan_payload(
+            plan,
+            rules,
+            raw_plan,
+            repo_state=branch_state(repo),
+            active_operation=detect_operation(repo),
+        )
+
+        self.assertTrue(payload["valid"])
+        self.assertEqual([item["index"] for item in payload["normalized_rewrite_actions"]], [1, 2])
+        self.assertIn("derived_rules_only", {item["code"] for item in payload["warnings"]})
+
+    def test_validator_rejects_dirty_worktree_and_stale_fingerprint(self) -> None:
+        _temp_dir, repo, rules, plan = self.make_context()
+        raw_plan = copy.deepcopy(plan)
+        raw_plan["commits"][0]["new_message"] = "fix(core): rewrite first"
+        raw_plan["commits"][1]["new_message"] = "fix(parser): rewrite second"
+        (repo / "src" / "scratch.py").write_text("dirty\n", encoding="utf-8")
+        plan["context_fingerprint"] = "stale"
+
+        payload = validate_reword_plan_payload(
+            plan,
+            rules,
+            raw_plan,
+            repo_state=branch_state(repo),
+            active_operation=detect_operation(repo),
+        )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("dirty_worktree", payload["stop_reasons"])
+        self.assertIn("stale_context_fingerprint", {item["code"] for item in payload["errors"]})
+
+    def test_validator_rejects_root_rewrite_unsupported(self) -> None:
+        temp_dir, repo = make_repo()
+        self.addCleanup(temp_dir.cleanup)
+        commit_file(repo, "src/app.py", "one\n", "fix(app): seed")
+        rules = {
+            "rules": {
+                "format": "<type>(<scope>): <subject>",
+                "allowed_types": ["fix"],
+                "scope_required": True,
+                "scope_suggestions": ["app"],
+                "subject_length_limit": 72,
+                "subject_rules": [],
+                "body_rules": [],
+                "references_rules": [],
+                "repo_defaults": [],
+            },
+            "rule_derivation": {
+                "format_source": "commit_message_instructions",
+                "allowed_types_source": "commit_message_instructions",
+                "scope_required_source": "commit_message_instructions",
+                "subject_length_limit_source": "commit_message_instructions",
+                "repo_defaults_source": "commit_message_instructions",
+            },
+            "recent_scope_vocabulary": ["app"],
+            "recent_subject_samples": ["fix(app): seed"],
+            "rules_reliability": "explicit",
+        }
+        plan = collect_recent_commits.build_plan(repo, 1, rules)
+        raw_plan = copy.deepcopy(plan)
+        raw_plan["commits"][0]["new_message"] = "fix(app): rewrite seed"
+
+        payload = validate_reword_plan_payload(
+            plan,
+            rules,
+            raw_plan,
+            repo_state=branch_state(repo),
+            active_operation=detect_operation(repo),
+        )
+
+        self.assertFalse(payload["valid"])
+        self.assertIn("root_rewrite_unsupported", payload["stop_reasons"])
+
+    def test_validator_rejects_missing_and_invalid_messages(self) -> None:
+        _temp_dir, repo, rules, plan = self.make_context()
+        raw_plan = {"commits": copy.deepcopy(plan["commits"])}
+        raw_plan["commits"][0]["new_message"] = ""
+        raw_plan["commits"][1]["new_message"] = "bad subject"
+
+        payload = validate_reword_plan_payload(
+            plan,
+            rules,
+            raw_plan,
+            repo_state=branch_state(repo),
+            active_operation=detect_operation(repo),
+        )
+
+        self.assertFalse(payload["valid"])
+        error_codes = {item["code"] for item in payload["errors"]}
+        self.assertIn("missing_new_message", error_codes)
+        self.assertIn("invalid_subject_format", error_codes)
+
+    def test_repo_codex_tmp_artifact_root_does_not_mark_worktree_dirty(self) -> None:
+        _temp_dir, repo, rules, plan = self.make_context()
+        raw_plan = copy.deepcopy(plan)
+        raw_plan["commits"][0]["new_message"] = "fix(core): rewrite first"
+        raw_plan["commits"][1]["new_message"] = "fix(parser): rewrite second"
+        artifact_path = (
+            reword_runtime_paths.resolve_runtime_namespace_root(repo)
+            / "test-run"
+            / "message-template.json"
+        )
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text("artifact\n", encoding="utf-8")
+
+        payload = validate_reword_plan_payload(
+            plan,
+            rules,
+            raw_plan,
+            repo_state=branch_state(repo),
+            active_operation=detect_operation(repo),
+        )
+
+        self.assertTrue(payload["valid"])
+        self.assertNotIn("dirty_worktree", payload["stop_reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_write_evaluation_log_reword.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_write_evaluation_log_reword.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import sys
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # type: ignore  # noqa: E402
+
+
+class WriteEvaluationLogRewordTests(unittest.TestCase):
+    def test_reword_skill_specific_data_and_phase_merges(self) -> None:
+        context = {
+            "repo_root": "C:/repo",
+            "repo_slug": "example/repo",
+            "branch": "feature/reword",
+            "count": 2,
+            "head_commit": "a" * 40,
+            "base_commit": "b" * 40,
+            "rules_reliability": "explicit",
+            "context_fingerprint": "f" * 64,
+            "commits": [{}, {}],
+        }
+        orchestrator = {
+            "review_mode": "targeted-delegation",
+            "commit_packet_count": 2,
+            "decision_ready_packets": False,
+            "worker_return_contract": "generic",
+            "worker_output_shape": "flat",
+            "packet_files": ["global_packet.json", "rules_packet.json", "commit-01.json", "commit-02.json", "orchestrator.json"],
+            "recommended_worker_count": 2,
+            "rules_reliability": "explicit",
+        }
+
+        log = eval_log.build_base_log(Path(__file__), context, orchestrator, None)
+        data = log["skill_specific"]["data"]
+        self.assertEqual(data["branch"], "feature/reword")
+        self.assertEqual(data["count"], 2)
+        self.assertEqual(data["rules_reliability"], "explicit")
+        self.assertIsNone(data["packet_count"])
+
+        build_result = {
+            "review_mode": "targeted-delegation",
+            "recommended_worker_count": 2,
+            "recommended_workers": [{"agent_type": "docs_verifier"}, {"agent_type": "evidence_summarizer"}],
+            "commit_packet_count": 2,
+            "active_packet_count": 3,
+            "applied_override_signals": ["aggregate_churn_threshold"],
+            "common_path_sufficient": True,
+            "raw_reread_count": 0,
+            "raw_reread_reasons": [],
+            "packet_metrics": {
+                "packet_count": 4,
+                "packet_size_bytes": 1400,
+                "largest_packet_bytes": 600,
+                "largest_two_packets_bytes": 950,
+                "estimated_local_only_tokens": 500,
+                "estimated_packet_tokens": 240,
+                "estimated_delegation_savings": 260,
+            },
+        }
+        eval_log.apply_phase_update(log, "build", build_result, 0.1)
+        self.assertEqual(log["orchestration"]["review_mode"], "targeted-delegation")
+        self.assertEqual(log["orchestration"]["worker_count"], 2)
+        self.assertEqual(log["orchestration"]["override_signals"], ["aggregate_churn_threshold"])
+        self.assertFalse(log["orchestration"]["raw_reread_required"])
+        self.assertEqual(log["input_size"]["active_areas"], 3)
+        self.assertEqual(log["input_size"]["candidate_batches"], 2)
+        self.assertEqual(log["skill_specific"]["data"]["packet_count"], 4)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_packet_tokens"], 240)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_delegation_savings"], 260)
+        self.assertTrue(log["skill_specific"]["data"]["common_path_sufficient"])
+        self.assertEqual(log["skill_specific"]["data"]["raw_reread_count"], 0)
+        self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 500)
+        self.assertEqual(log["baseline"]["estimated_token_savings"], 260)
+        self.assertEqual(log["baseline"]["estimated_delegation_savings"], 260)
+        self.assertEqual(log["measurement"]["efficiency_source"], "estimated")
+
+        validate_result = {
+            "valid": True,
+            "context_fingerprint": "f" * 64,
+            "rules_reliability": "explicit",
+            "counters": {"commits_validated": 2},
+            "stop_reasons": [],
+        }
+        eval_log.apply_phase_update(log, "validate", validate_result, 0.2)
+        self.assertTrue(log["safety"]["validation_run"])
+        self.assertTrue(log["safety"]["validation_passed"])
+        self.assertEqual(log["skill_specific"]["data"]["validation_commands"], ["validate_reword_plan.py"])
+
+        apply_result = {
+            "dry_run": False,
+            "apply_succeeded": True,
+            "fingerprint_match": True,
+            "new_head": "c" * 40,
+            "applied_commit_hashes": ["1" * 40, "2" * 40],
+            "force_push_needed": True,
+            "cleanup_succeeded": True,
+            "rules_reliability": "explicit",
+            "counters": {"commits_rewritten": 2},
+            "mutations": [{"kind": "rewrite_history"}],
+            "mutation_type": "rewrite_history",
+        }
+        eval_log.apply_phase_update(log, "apply", apply_result, 0.3)
+        self.assertTrue(log["safety"]["apply_attempted"])
+        self.assertTrue(log["safety"]["apply_succeeded"])
+        self.assertEqual(log["skill_specific"]["data"]["new_head"], "c" * 40)
+        self.assertEqual(log["skill_specific"]["data"]["applied_commit_hashes"], ["1" * 40, "2" * 40])
+        self.assertTrue(log["skill_specific"]["data"]["cleanup_succeeded"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/weekly-update/SKILL.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: weekly-update
+description: Top-level orchestration skill for reusable weekly updates. Synthesize recent PRs, rollouts, incidents, reviews, and blockers using packet-driven evidence collection and narrow read-only delegation, keep worker outputs proposal-grade, keep final classification and wording local, and update only a last-success marker after a reviewed plan clears apply gates.
+---
+
+# Weekly Update
+
+Use this skill as the top-level orchestration layer for packet-driven weekly updates.
+
+The retained fallback profile lives at `profiles/default/profile.json`.
+When this skill is vendored, prefer a project-local override at `.codex/project/profiles/weekly-update/profile.json`.
+Use `--profile` only when you need to override the default discovery order explicitly.
+Read `references/core-contract.md` for the reusable packet-workflow boundary.
+
+This is a packet-driven workflow:
+- keep evidence collection and packet building deterministic
+- keep final classification, section inclusion, final wording, and marker updates local
+- use `gpt-5.4-mini` workers only for narrow read-only packet analysis
+- treat worker classifications as proposals, not final decisions
+
+## Packet Contract
+
+- `orchestrator_profile=standard`
+- `decision_ready_packets=true`
+- `worker_return_contract=classification-oriented`
+- `worker_output_shape=hierarchical`
+- `packet_worker_map` is the routing authority for delegated packets
+- `worker_selection_guidance` is explanatory only and must not override explicit packet routing
+- workers read `global_packet.json` first, then exactly one focused packet or one narrow packet slice
+- workers return hierarchical proposal-grade output as `candidates[]` plus `footer`
+- token-efficiency counters live in `packet_metrics.json` and the evaluation log, not in runtime packets
+- read `references/architecture-note.md` for why this skill keeps hierarchy even though flat-contract skills remain the default elsewhere
+
+## Automation Prompt Shape
+
+When another automation or meta-skill invokes this skill, keep the prompt thin and contract-aware.
+
+Include:
+- `Use [$weekly-update](<skill-dir>/SKILL.md).`
+- the expected final section order
+- the requirement to state the exact reporting window
+- the instruction to report the concrete blocker and stop at the appropriate gate when collection, validation, or apply cannot proceed
+
+Do not restate:
+- packet internals
+- worker field lists
+- packet-to-worker routing details
+- apply-gate implementation details already locked in this skill
+
+Prefer a prompt shaped like:
+
+```text
+Use [$weekly-update](<skill-dir>/SKILL.md).
+
+Produce this workspace repo's weekly update.
+Return sections `PRs`, `Rollouts`, `Incidents`, `Reviews`, `Blockers / Risks`, and `Evidence reviewed`.
+State the exact reporting window.
+If the run cannot proceed, report the blocker clearly and stop at the appropriate gate.
+```
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/weekly-update/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/weekly-update/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/weekly-update/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Verify GitHub access first.
+- Run `gh auth status`.
+- If authentication fails, stop and tell the user to run `gh auth login`.
+- Do not substitute weaker local-only guesses when remote GitHub evidence is required for the reporting window.
+
+2. Collect structured context before broad reading.
+- Prefer `<python-bin> -B` for verification and smoke commands and reuse the resolved concrete interpreter path for every helper script.
+- Run `<python-bin> -B <skill-dir>/scripts/collect_weekly_update_context.py --repo-root <repo-root> --output <context-json> [--profile <profile-json>]`.
+- Run `<python-bin> -B <skill-dir>/scripts/lint_weekly_update.py --context <context-json> --output <lint-json>`.
+- Run `<python-bin> -B <skill-dir>/scripts/build_weekly_update_packets.py --context <context-json> --lint <lint-json> --output-dir <packet-dir> --result-output <build-result-json>`.
+- Read `<packet-dir>/orchestrator.json` first.
+- Keep `<packet-dir>/global_packet.json` in view before reading focused packets.
+- Treat `packet_metrics.json` and `<build-result-json>` as evaluation/regression artifacts, not runtime routing inputs.
+- State the exact reporting window in the final update.
+
+3. Follow the weekly-update candidate model.
+- Final sections are `PRs`, `Rollouts`, `Incidents`, `Reviews`, `Blockers / Risks`, and `Evidence reviewed`.
+- Workers return candidate proposals. `proposed_classification` is worker proposal only; the main agent may override it during final adjudication.
+- `summary` is the candidate-level fact summary.
+- `classification_rationale` explains why that proposal was made.
+- `source_refs` is the canonical citation list across packets and worker output.
+- `artifact_only` candidates are reference-only evidence and do not surface as standalone section items.
+- Worker outputs remain proposal-grade only; they never decide final classification or final weekly wording.
+
+4. Respect review mode and keep delegation narrow.
+- `local-only`: use no workers. Reserve for quiet windows with a small candidate set and no meaningful rollout or incident activity.
+- `targeted-delegation`: default mode. Use 1-2 `gpt-5.4-mini` workers on one focused packet each.
+- `broad-delegation`: use 3-4 `gpt-5.4-mini` workers only when releases, incidents, reviews, and nested PR lineage all expand the evidence surface.
+- Read `references/delegation-playbook.md` when `review_mode` is not `local-only`.
+- Use `packet_worker_map` as the only concrete routing source for delegated packets.
+- Treat `worker_selection_guidance` and worker families as explanatory metadata only.
+- Do not ask workers to rediscover the whole repo, reread long raw diffs, or draft the final weekly update.
+- Workers are read-only packet analysts, not final adjudicators.
+
+5. Respect authority and weekly output rules.
+- Authority order:
+  - published GitHub releases and linked release issues
+  - merged PR diffs and git history
+  - directly related review, issue, and workflow-run evidence
+  - structured workflow packets
+  - local last-success state as baseline only
+- `Incidents` is narrow. Include only actual events that materially affected operations, validation, release, or schedule during the reporting window.
+- Put release gates, pending investigations, reusable evidence artifacts, and unresolved risks in `Blockers / Risks` instead.
+- In `Reviews`, include resolved findings once. Unresolved gate-impact findings may also appear in `Blockers / Risks`.
+- Exclude generic notices, bot noise, and empty self-reviews.
+
+6. Apply only after local synthesis.
+- Build and locally review `weekly-update-plan.json`.
+- Prefer `<python-bin> -B <skill-dir>/scripts/validate_weekly_update_plan.py --context <context-json> --plan <weekly-update-plan.json> --output <validation-json>` before apply when the plan was synthesized or edited locally.
+- Run `<python-bin> -B <skill-dir>/scripts/apply_weekly_update.py --context <context-json> --plan <weekly-update-plan.json> [--dry-run]`.
+- `apply_weekly_update.py` reads only the synthesized plan fields `overall_confidence`, `stop_reasons`, and `allow_marker_update`.
+- Do not let the apply step read worker footers directly.
+- Stop before marker updates when unresolved `raw_reread_reason` candidates remain or the final plan confidence is `low`.
+
+## Required Packets
+
+- `orchestrator.json`
+- `global_packet.json`
+- `mapping_packet.json`
+- `changes_packet.json`
+- `incidents_packet.json`
+- `risks_packet.json`
+
+## Eval-Side Build Artifacts
+
+- `packet_metrics.json`
+- build result JSON from `--result-output`
+
+## Scripts
+
+- `<skill-dir>/scripts/collect_weekly_update_context.py`
+  - Collect the reporting window, repo metadata, releases, PRs, issues, review evidence, workflow runs, and candidate inventory.
+- `<skill-dir>/scripts/lint_weekly_update.py`
+  - Check deterministic boundary conditions such as missing evidence, stale context, and packet-shape blockers.
+- `<skill-dir>/scripts/build_weekly_update_packets.py`
+  - Build the orchestrator, global packet, the four focused packets, `packet_metrics.json`, and an optional build result JSON for evaluation-log phase merge.
+- `<skill-dir>/scripts/validate_weekly_update_plan.py`
+  - Validate `weekly-update-plan.json` against the collected context before apply, including marker-update gating, section shape, and artifact-only exclusion rules.
+- `<skill-dir>/scripts/write_evaluation_log.py`
+  - Record the shared evaluation log for efficiency, quality, and safety tracking.
+- `<skill-dir>/scripts/apply_weekly_update.py`
+  - Update only the last-success marker after the local plan passes the apply gate.
+- `<skill-dir>/scripts/smoke_weekly_update.py`
+  - Run an opt-in end-to-end smoke of collect → lint → build → eval init/build → validate → eval validate → apply `--dry-run` → eval apply, verify runtime packets stay lean, and confirm `--dry-run` apply does not write a marker.
+- `<skill-dir>/scripts/refresh_weekly_update_live_fixture.py`
+  - Maintainer-only helper that refreshes the live sample fixture and paired plan fixtures from current repo and GitHub evidence. Keep it out of the default test path and prefer `--dry-run` before overwriting fixture files.
+
+## Evaluation
+
+- Use `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>` after packet generation.
+- Use `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py phase --log <eval-log-json> --phase build --result <build-result-json>` after packet build.
+- Use phase updates for deterministic validate and apply results when those outputs exist.
+- Keep token-efficiency counters in `packet_metrics.json` and the evaluation log only; do not treat them as runtime routing metadata.
+- Finalize the evaluation log after the run with worker usage, packet usage, confidence, marker-update status, and any stop reasons.
+- Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
+- Read `references/evaluation-log-contract.md` for the shared envelope and `references/weekly-update-evaluation-contract.md` for workflow-specific fields.
+
+## Output
+
+- Tell the user which packets and evidence categories drove the result.
+- Tell the user whether the run stayed local or used mini workers.
+- Tell the user whether the run stopped at planning or advanced to apply.
+- When blocked, name the blocker precisely: invalid `gh` auth, stale context, low-confidence plan, or unresolved raw reread exceptions.

--- a/builders/packet-workflow/retained-skills/weekly-update/agents/openai.yaml
+++ b/builders/packet-workflow/retained-skills/weekly-update/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Weekly Update"
+  short_description: "Top-level packet-driven weekly update orchestrator with profile-aware repo conventions"
+  default_prompt: >-
+    Use $weekly-update to collect context, build packets, optionally delegate
+    narrow read-only packet analysis, keep final adjudication and wording
+    local, state the exact reporting window, and apply only after local plan
+    validation.

--- a/builders/packet-workflow/retained-skills/weekly-update/builder-spec.json
+++ b/builders/packet-workflow/retained-skills/weekly-update/builder-spec.json
@@ -1,0 +1,253 @@
+{
+  "skill_name": "weekly-update",
+  "description": "Synthesize a concise, evidence-based weekly update from repository and directly related GitHub evidence by collecting a reporting window, building decision-ready packets, optionally delegating narrow read-only packet analysis, keeping final classification and wording local, and updating only a last-success marker after a reviewed plan clears apply gates. Use when Codex must prepare a guarded weekly status update without encoding repo-specific conventions in foundry core.",
+  "domain_slug": "weekly_update",
+  "workflow_family": "repo-audit",
+  "archetype": "plan-validate-apply",
+  "primary_goal": "produce a concise, evidence-based weekly update from repository and directly related GitHub evidence",
+  "trigger_phrases": [
+    "weekly update",
+    "summarize this week's PRs",
+    "synthesize this week's rollouts incidents and reviews",
+    "build a weekly status update"
+  ],
+  "task_packet_names": [
+    "mapping_packet",
+    "changes_packet",
+    "incidents_packet",
+    "risks_packet"
+  ],
+  "orchestrator_profile": "standard",
+  "needs_lint": true,
+  "needs_validate": true,
+  "needs_apply": true,
+  "decision_ready_packets": true,
+  "worker_return_contract": "classification-oriented",
+  "worker_output_shape": "hierarchical",
+  "authority_order": [
+    "published GitHub releases and linked release issues",
+    "merged PR diffs and git history",
+    "directly related review, issue, and workflow-run evidence",
+    "structured workflow packets",
+    "local last-success state as baseline only"
+  ],
+  "stop_conditions": [
+    "low confidence",
+    "stale snapshot or stale structured context",
+    "GitHub evidence is required but gh auth is invalid",
+    "ambiguous incident versus blocker classification",
+    "missing reporting window baseline when reuse is required"
+  ],
+  "review_mode_overrides": [
+    "reporting window includes more than 8 merged PRs or more than 15 relevant issues",
+    "release, incident, and review surfaces are all active in the same window",
+    "nested branch lineage or workflow-run failures materially expand the evidence graph"
+  ],
+  "preferred_worker_families": {
+    "context_findings": [
+      "repo_mapper",
+      "docs_verifier"
+    ],
+    "candidate_producers": [
+      "evidence_summarizer",
+      "large_diff_auditor",
+      "log_triager"
+    ],
+    "verifiers": [
+      "docs_verifier"
+    ]
+  },
+  "candidate_field_bundles": [
+    {
+      "name": "identity",
+      "description": "Stable candidate identity and source information.",
+      "required": true,
+      "fields": [
+        "candidate_id",
+        "source_type",
+        "source_id",
+        "title"
+      ]
+    },
+    {
+      "name": "proposal",
+      "description": "Proposal-grade summary and classification rationale for local adjudication.",
+      "required": true,
+      "fields": [
+        "summary",
+        "proposed_classification",
+        "classification_rationale"
+      ]
+    },
+    {
+      "name": "evidence",
+      "description": "Decision-ready supporting evidence, references, and excerpt bundle.",
+      "required": true,
+      "fields": [
+        "materiality_evidence",
+        "concrete_failure_evidence",
+        "source_refs",
+        "excerpt_bundle"
+      ]
+    },
+    {
+      "name": "adjudication",
+      "description": "Ambiguity, confidence, reread control, and packet membership for local xHigh adjudication.",
+      "required": true,
+      "fields": [
+        "open_ambiguity",
+        "confidence",
+        "raw_reread_reason",
+        "packet_membership"
+      ]
+    },
+    {
+      "name": "follow_up",
+      "description": "Candidate-local risk, next step, and checks.",
+      "required": true,
+      "fields": [
+        "risk",
+        "recommended_next_step",
+        "tests_or_checks"
+      ]
+    }
+  ],
+  "worker_footer_fields": [
+    "packet_ids",
+    "candidate_ids",
+    "primary_outcome",
+    "overall_confidence",
+    "coverage_gaps",
+    "overall_risk"
+  ],
+  "reread_reason_values": [
+    "conflicting_signals",
+    "missing_failure_evidence",
+    "missing_materiality_evidence",
+    "schema_mismatch",
+    "insufficient_excerpt_quality"
+  ],
+  "packet_worker_map": {
+    "mapping_packet": [
+      "repo_mapper"
+    ],
+    "changes_packet": [
+      "large_diff_auditor"
+    ],
+    "incidents_packet": [
+      "log_triager"
+    ],
+    "risks_packet": [
+      "evidence_summarizer"
+    ]
+  },
+  "domain_overlay": {
+    "proposal_enum_values": [
+      "actual_incident",
+      "blocker_or_risk",
+      "artifact_only",
+      "ignore"
+    ],
+    "reference_only_candidate_values": [
+      "artifact_only"
+    ],
+    "output_inclusion_rules": {
+      "standalone": [
+        "actual_incident",
+        "blocker_or_risk"
+      ],
+      "reference_only": [
+        "artifact_only"
+      ],
+      "excluded": [
+        "ignore"
+      ]
+    }
+  },
+  "repo_profile": {
+    "name": "default",
+    "summary": "Default reusable profile scaffold for weekly-update workflows. Replace review docs, path hints, and repo conventions in project-local profiles when vendored.",
+    "repo_match": {
+      "root_markers": [
+        ".git",
+        "README.md"
+      ],
+      "remote_patterns": []
+    },
+    "bindings": {
+      "primary_readme_path": "README.md",
+      "settings_source_path": null,
+      "publish_config_path": null
+    },
+    "packet_defaults": {
+      "review_docs": {
+        "mapping_packet": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ],
+        "changes_packet": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ],
+        "incidents_packet": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ],
+        "risks_packet": [
+          "README.md",
+          "CONTRIBUTING.md"
+        ]
+      },
+      "source_path_globs": {
+        "mapping_packet": [
+          "**/*"
+        ],
+        "changes_packet": [
+          "**/*"
+        ],
+        "incidents_packet": [
+          "**/*"
+        ],
+        "risks_packet": [
+          "**/*"
+        ]
+      }
+    },
+    "lint_rules": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "extra": {
+      "weekly_update": {
+        "state": {
+          "namespace": "weekly-update"
+        },
+        "review_markers": {
+          "acknowledged": [
+            "phase=ack"
+          ],
+          "resolved": [
+            "phase=complete"
+          ]
+        },
+        "release_issue": {
+          "title_regex": "^\\[Release\\]\\s*(?P<tag>v[0-9A-Za-z._-]+)$"
+        },
+        "priority_markers": {
+          "regex": "\\[(?:P[0-3]|medium|high|low)\\]"
+        }
+      }
+    },
+    "notes": [
+      "Keep repo-specific weekly-update conventions in project-local profile data when vendored.",
+      "Do not encode validator or apply behavior in this profile."
+    ]
+  },
+  "builder_versioning": {
+    "builder_family": "packet-workflow",
+    "builder_semver": "0.1.0",
+    "compatibility_epoch": 1,
+    "builder_spec_schema_version": 1,
+    "repo_profile_schema_version": 1
+  }
+}

--- a/builders/packet-workflow/retained-skills/weekly-update/migration-worksheet.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/migration-worksheet.md
@@ -1,0 +1,69 @@
+# Migration Worksheet: weekly-update
+
+## Workflow Snapshot
+- `workflow_family`: `repo-audit`
+- Current runtime shape: `standard`, `classification-oriented`, `hierarchical`, lint/validate/apply split
+- Primary packets: `global_packet`, `mapping_packet`, `changes_packet`, `incidents_packet`, `risks_packet`
+- Current authoritative files:
+  - references: `weekly-update-contract.md`, `weekly-update-evaluation-contract.md`, `architecture-note.md`
+  - scripts: `collect_weekly_update_context.py`, `build_weekly_update_packets.py`, `validate_weekly_update_plan.py`, `apply_weekly_update.py`
+  - tests: collect/build/validate/apply/smoke coverage exists
+
+## Repo-Specific Inputs Seen In Legacy Skill
+- state-marker namespace and marker path conventions
+- release-issue title matching
+- review-thread marker tokens
+- priority marker extraction
+- optional review-doc lists and source-path hints
+
+## Migration Classification
+- `core`
+  - validator/apply separation
+  - review-mode semantics
+  - worker-family semantics and packet-routing authority rules
+  - decision-ready hierarchical packet semantics
+- `profiles/default/profile.json`
+  - repo markers and README binding
+  - review-doc paths and source-path globs
+  - repo-specific weekly-update conventions under `extra.weekly_update`
+- Skill-local
+  - weekly-update section order and candidate schema
+  - classification values and `artifact_only` handling
+  - raw-reread gating and marker-update gates
+  - incident versus blocker adjudication rules
+
+## Legacy Inventory Mapping
+- references kept as domain-local: `weekly-update-contract.md`, `weekly-update-evaluation-contract.md`, `architecture-note.md`, `delegation-playbook.md`
+- new retained interface additions: `builder-spec.json`, `references/core-contract.md`, `profiles/default/profile.json`
+- scripts updated for profile metadata wiring: `collect_weekly_update_context.py`, `smoke_weekly_update.py`, `refresh_weekly_update_live_fixture.py`, `weekly_update_lib.py`
+
+## Retained vs Consumer-Local Decision
+- Data-only profile differences that should stay declarative:
+  - state namespace
+  - review marker tokens
+  - release title regex
+  - priority marker regex
+  - packet review-doc lists and path globs
+- Behavior that remains skill-local:
+  - candidate classification semantics
+  - final section ordering
+  - marker-update validation and apply rules
+  - raw-reread exception handling
+- Decision: `retained`
+
+## Core Escalation Check
+- Shared gap already handled in foundry:
+  - profile-aware retained skills need active-profile metadata in collected context and packets
+  - builder validation must reject invalid hierarchical retained-shape combinations
+- Weekly-update-specific logic that should not move into core:
+  - incident versus blocker heuristics
+  - review-finding filtering rules
+  - marker-update gating for weekly status runs
+- Decision:
+  - keep builder/core changes generic
+  - keep weekly-update adjudication and apply semantics skill-local
+
+## Builder Compatibility History
+- `unversioned -> packet-workflow 0.1.0`
+  - change reason: introduced explicit builder-version compatibility metadata and upgrade rules for packet-workflow retained skills.
+  - manual migration scope: added `builder_versioning` to `builder-spec.json`, added `metadata.versioning` to `profiles/default/profile.json`, and wired collector-side `builder_compatibility` reporting.

--- a/builders/packet-workflow/retained-skills/weekly-update/profiles/default/profile.json
+++ b/builders/packet-workflow/retained-skills/weekly-update/profiles/default/profile.json
@@ -1,0 +1,88 @@
+{
+  "bindings": {
+    "primary_readme_path": "README.md",
+    "publish_config_path": null,
+    "settings_source_path": null
+  },
+  "extra": {
+    "weekly_update": {
+      "priority_markers": {
+        "regex": "\\[(?:P[0-3]|medium|high|low)\\]"
+      },
+      "release_issue": {
+        "title_regex": "^\\[Release\\]\\s*(?P<tag>v[0-9A-Za-z._-]+)$"
+      },
+      "review_markers": {
+        "acknowledged": [
+          "phase=ack"
+        ],
+        "resolved": [
+          "phase=complete"
+        ]
+      },
+      "state": {
+        "namespace": "weekly-update"
+      }
+    }
+  },
+  "lint_rules": {
+    "missing_review_docs_are_errors": false,
+    "require_readme_settings_table": false
+  },
+  "name": "default",
+  "notes": [
+    "Keep repo-specific weekly-update conventions in project-local profile data when vendored.",
+    "Do not encode validator or apply behavior in this profile."
+  ],
+  "packet_defaults": {
+    "review_docs": {
+      "changes_packet": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "incidents_packet": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "mapping_packet": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ],
+      "risks_packet": [
+        "README.md",
+        "CONTRIBUTING.md"
+      ]
+    },
+    "source_path_globs": {
+      "changes_packet": [
+        "**/*"
+      ],
+      "incidents_packet": [
+        "**/*"
+      ],
+      "mapping_packet": [
+        "**/*"
+      ],
+      "risks_packet": [
+        "**/*"
+      ]
+    }
+  },
+  "profile_path": "profiles/default/profile.json",
+  "repo_match": {
+    "remote_patterns": [],
+    "root_markers": [
+      ".git",
+      "README.md"
+    ]
+  },
+  "summary": "Default reusable profile scaffold for weekly-update workflows. Replace review docs, path hints, and repo conventions in project-local profiles when vendored.",
+  "metadata": {
+    "versioning": {
+      "builder_family": "packet-workflow",
+      "builder_semver": "0.1.0",
+      "compatibility_epoch": 1,
+      "repo_profile_schema_version": 1
+    }
+  }
+}

--- a/builders/packet-workflow/retained-skills/weekly-update/references/architecture-note.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/architecture-note.md
@@ -1,0 +1,65 @@
+# Weekly Update Architecture Note
+
+`weekly-update` keeps a hierarchical worker contract on purpose.
+
+Flat-contract skills are the default in this environment because they are usually easier to validate, easier to keep lean, and easier for the main agent to trust. That remains true here as well. This skill is an exception, not the template.
+
+## Why Hierarchy Is Necessary Here
+
+`weekly-update` is not a narrow mutation workflow and not a single-decision audit. It has to:
+
+- review many heterogeneous evidence items from one reporting window
+- keep proposal-only candidate classifications separate from final local adjudication
+- move candidates across final sections during local synthesis
+- recompute run-level confidence locally instead of inheriting worker confidence
+- control raw reread exceptions at candidate granularity, not only at batch granularity
+
+That combination requires two distinct layers:
+
+- `candidates[]`
+  - candidate-level facts, proposed classification, evidence, ambiguity, and reread control
+- `footer`
+  - worker-level batch summary, overall confidence, coverage gaps, and batch risk
+
+If these are flattened into one contract here, one of two bad outcomes follows:
+
+- candidate-level evidence gets duplicated into every worker summary and packets bloat
+- worker-level summary absorbs candidate distinctions and the main agent has to reopen raw evidence more often
+
+The current hierarchy avoids both. It preserves candidate-local evidence while still giving the main agent one packet-level summary to compare across workers.
+
+## Why Flat Contract Is Still The Default
+
+Use a flat contract when the workflow is primarily:
+
+- one object in, one decision out
+- one plan in, one validated mutation out
+- one focused packet in, one local judgment out
+
+That shape usually has:
+
+- less duplicated structure
+- fewer ways for runtime and evaluation metadata to blur together
+- simpler validator/apply boundaries
+- easier common-path sufficiency
+
+Most PR writeup, release-copy, docs-sync, and commit-mutation skills fit that model better than `weekly-update`.
+
+## When Hierarchy Is Warranted
+
+Keep hierarchy only when all of these are true:
+
+- the worker must return multiple proposal-grade candidates from one packet
+- the final local pass may materially reclassify or suppress those candidates
+- batch-level confidence and coverage gaps matter separately from candidate-level evidence
+- raw reread exceptions must remain candidate-scoped
+
+If any of those stop being true, flatten the contract instead of preserving hierarchy out of habit.
+
+## Non-Goals
+
+This note does not justify broader runtime packets, extra local summary packets, or token-efficiency counters in runtime metadata.
+
+- `weekly-update` stays on `orchestrator_profile=standard`
+- token/size metrics stay in `packet_metrics.json` and evaluation logs
+- hierarchy explains worker output shape only; it does not justify packet sprawl

--- a/builders/packet-workflow/retained-skills/weekly-update/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/core-contract.md
@@ -174,6 +174,7 @@ Domain overlay:
 
 - Keep runtime routing, authority, stop conditions, review mode, domain overlay, and adjudication support in `orchestrator.json` and `global_packet.json`.
 - Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `.codex/tmp/`, not at repo root or in tracked source directories.
 - Keep repo-specific file layout and weekly-update conventions in the repo profile instead of hardcoding them into this core contract.
 - Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
 

--- a/builders/packet-workflow/retained-skills/weekly-update/references/core-contract.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/core-contract.md
@@ -1,0 +1,183 @@
+# Weekly Update Core Contract
+
+This file captures the reusable packet-workflow core for the retained `weekly-update` scaffold.
+Keep repo-specific paths, review-doc lists, and weekly-update conventions in `profiles/default/profile.json`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, worker-routing behavior, or validator/apply semantics in them.
+Consumer repos should prefer `.codex/project/profiles/weekly-update/profile.json` over editing the retained default directly.
+
+## Core Metadata
+
+- `workflow_family`: `repo-audit`
+- `archetype`: `plan-validate-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `true`
+- `worker_return_contract`: `classification-oriented`
+- `worker_output_shape`: `hierarchical`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+- `mapping_packet.json`
+- `changes_packet.json`
+- `incidents_packet.json`
+- `risks_packet.json`
+
+Review mode overrides inherited by default:
+- reporting window includes more than 8 merged PRs or more than 15 relevant issues
+- release, incident, and review surfaces are all active in the same window
+- nested branch lineage or workflow-run failures materially expand the evidence graph
+
+Authority order:
+- published GitHub releases and linked release issues
+- merged PR diffs and git history
+- directly related review, issue, and workflow-run evidence
+- structured workflow packets
+- local last-success state as baseline only
+
+Stop conditions:
+- low confidence
+- stale snapshot or stale structured context
+- GitHub evidence is required but gh auth is invalid
+- ambiguous incident versus blocker classification
+- missing reporting window baseline when reuse is required
+
+## Classification-Oriented Worker Contract
+
+- This scaffold uses the `classification-oriented` worker return contract.
+- XHigh reread policy: Do not reopen raw evidence by default after packet generation. Only reopen raw evidence when reread control points to an allowed reason such as conflicting signals, missing failure evidence, missing materiality evidence, schema mismatch, or insufficient excerpt quality.
+- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.
+- Hierarchical workers return top-level `candidates[]` plus `footer`.
+
+Candidate field bundles:
+- `identity`
+  - `candidate_id`
+  - `source_type`
+  - `source_id`
+  - `title`
+- `proposal`
+  - `summary`
+  - `proposed_classification`
+  - `classification_rationale`
+- `evidence`
+  - `materiality_evidence`
+  - `concrete_failure_evidence`
+  - `source_refs`
+  - `excerpt_bundle`
+- `adjudication`
+  - `open_ambiguity`
+  - `confidence`
+  - `raw_reread_reason`
+  - `packet_membership`
+- `follow_up`
+  - `risk`
+  - `recommended_next_step`
+  - `tests_or_checks`
+
+Worker footer fields:
+- `packet_ids`
+- `candidate_ids`
+- `primary_outcome`
+- `overall_confidence`
+- `coverage_gaps`
+- `overall_risk`
+
+Domain overlay:
+- proposal enum values:
+  - `actual_incident`
+  - `blocker_or_risk`
+  - `artifact_only`
+  - `ignore`
+- reference-only candidate values:
+  - `artifact_only`
+- output inclusion rules:
+  - `standalone`
+    - `actual_incident`
+    - `blocker_or_risk`
+  - `reference_only`
+    - `artifact_only`
+  - `excluded`
+    - `ignore`
+
+## Worker Families
+
+- Preferred worker families for this scaffold:
+- `context_findings`
+  - `repo_mapper`
+  - `docs_verifier`
+- `candidate_producers`
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `verifiers`
+  - `docs_verifier`
+
+- Surfaced optional worker pool for docs stays deduped even when a worker belongs to multiple families:
+- `docs_verifier`
+
+- Packet routing hook:
+- `packet_worker_map` is the routing authority when configured.
+- `mapping_packet`
+  - `repo_mapper`
+- `changes_packet`
+  - `large_diff_auditor`
+- `incidents_packet`
+  - `log_triager`
+- `risks_packet`
+  - `evidence_summarizer`
+
+- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.
+
+## Repo Profile Boundary
+
+- Default generated profile: `profiles/default/profile.json`
+- Preferred project-local override path: `.codex/project/profiles/weekly-update/profile.json`
+- Summary: Default reusable profile scaffold for weekly-update workflows. Replace review docs, path hints, and repo conventions in project-local profiles when vendored.
+- Default bindings:
+- `primary_readme_path`: `README.md`
+- `settings_source_path`: `null`
+- `publish_config_path`: `null`
+- Default packet defaults:
+- review docs:
+  - `mapping_packet`
+    - `README.md`
+    - `CONTRIBUTING.md`
+  - `changes_packet`
+    - `README.md`
+    - `CONTRIBUTING.md`
+  - `incidents_packet`
+    - `README.md`
+    - `CONTRIBUTING.md`
+  - `risks_packet`
+    - `README.md`
+    - `CONTRIBUTING.md`
+- source path globs:
+  - `mapping_packet`
+    - `**/*`
+  - `changes_packet`
+    - `**/*`
+  - `incidents_packet`
+    - `**/*`
+  - `risks_packet`
+    - `**/*`
+- Default lint rules:
+- `require_readme_settings_table`: false
+- `missing_review_docs_are_errors`: false
+- Default repo-specific conventions stay in `repo_profile.extra.weekly_update`:
+  - state namespace
+  - review marker tokens
+  - release issue title regex
+  - priority marker regex
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, review mode, domain overlay, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and weekly-update conventions in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes
+
+- Active profile metadata should appear in collected context plus `orchestrator.json`, `global_packet.json`, and build-result artifacts.
+- Consumer repos should prefer the project-local `weekly-update` profile path above over editing the foundry-retained default.

--- a/builders/packet-workflow/retained-skills/weekly-update/references/delegation-playbook.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/delegation-playbook.md
@@ -1,0 +1,194 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`
+  - no workers
+- `targeted-delegation`
+  - default mode
+  - 1-2 workers
+- `broad-delegation`
+  - 3-4 workers
+- Optional QA worker
+  - only when worker findings conflict or a raw reread exception remains unresolved
+
+## Worker Families
+
+- `context_findings`
+  - `repo_mapper`
+  - `docs_verifier`
+- `candidate_producers`
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `verifiers`
+  - `docs_verifier`
+
+Surfaced optional-worker list after subtracting explicitly routed workers:
+- `targeted-delegation`
+  - `docs_verifier`
+  - `evidence_summarizer`
+  - `log_triager`
+- `broad-delegation`
+  - `docs_verifier`
+- `local-only`
+  - no delegation; optional workers are informational only and should not be spawned
+
+Rules:
+- `packet_worker_map` is the routing authority
+- `worker_selection_guidance` is explanatory only
+- do not infer routing from packet names alone when explicit routing metadata exists
+
+## Shared Packet Discipline
+
+Every worker reads `global_packet.json` first.
+
+Then give the worker only:
+- one focused packet or one narrow slice from a focused packet
+- any explicitly referenced file slice only when the packet cannot carry the required evidence
+
+Do not ask workers to:
+- rediscover the whole repo state from scratch
+- reread long raw diffs or workflow logs without an explicit exception reason
+- draft the final user-facing weekly update
+
+## Explicit Packet Routing
+
+Use this `packet_worker_map`:
+- `mapping_packet -> repo_mapper`
+- `changes_packet -> large_diff_auditor`
+- `incidents_packet -> log_triager`
+- `risks_packet -> evidence_summarizer`
+
+Use these `worker_selection_guidance` notes only as supporting context:
+- `repo_mapper`
+  - reporting-window grounding, release linkage, PR lineage, candidate inventory, and packet membership
+- `docs_verifier`
+  - tracked docs or runbooks needed to resolve conflicting packet evidence
+- `large_diff_auditor`
+  - shipped change bullets, behavior or config changes, and review-driven follow-ups
+- `log_triager`
+  - failure signals, workflow impact, and incident-versus-risk evidence
+- `evidence_summarizer`
+  - narrative-heavy issue, release, review, or workflow discussion compressed into adjudication-ready excerpts and rationales
+
+## Candidate Proposal Rules
+
+Workers return proposal-grade candidates only.
+
+- `proposed_classification` is worker proposal only; the main agent may override it
+- `summary` is the candidate-level fact summary
+- `classification_rationale` explains why that proposal was made
+- `source_refs` is the canonical citation list
+- `artifact_only` candidates remain reference-only evidence
+
+If a worker cannot support a proposal cleanly from the packet, it should lower confidence or set `raw_reread_reason` rather than broadening scope on its own.
+
+## Worker Output Contract
+
+Each worker response has:
+- `candidates[]`
+- `footer`
+
+### `candidates[]`
+
+Each candidate entry should include:
+- `candidate_id`
+- `summary`
+- `proposed_classification`
+- `classification_rationale`
+- `materiality_evidence`
+- `concrete_failure_evidence`
+- `open_ambiguity`
+- `confidence`
+- `source_refs`
+- `excerpt_bundle`
+- `raw_reread_reason`
+- `packet_membership`
+- `risk`
+- `recommended_next_step`
+- `tests_or_checks`
+
+`confidence` meanings:
+- `high`
+  - direct failure and materiality evidence with no meaningful conflict
+- `medium`
+  - core evidence exists but some ambiguity remains
+- `low`
+  - raw reread is likely required before final adjudication
+
+### Worker Footer Fields
+
+Return `footer` with these fields exactly:
+- `packet_ids`
+- `candidate_ids`
+- `primary_outcome`
+- `overall_confidence`
+- `coverage_gaps`
+- `overall_risk`
+
+Field meanings:
+- `packet_ids`
+  - the packets or packet slices the worker actually used
+- `candidate_ids`
+  - follow `candidates[]` stable discovery order exactly
+- `primary_outcome`
+  - worker-level batch summary only
+- `overall_confidence`
+  - worker-level confidence for the full batch
+- `coverage_gaps`
+  - unread or insufficiently verified scope
+- `overall_risk`
+  - remaining batch-level operational or adjudication risk
+
+Candidate-level `risk` is specific to one candidate. Worker-level `overall_risk` summarizes the batch.
+
+## Excerpt And Reread Rules
+
+Each candidate uses named excerpt slots:
+- `failure_excerpt`
+- `materiality_excerpt`
+- `ambiguity_excerpt`
+
+Selection rules:
+- choose one excerpt that most directly shows failure or broken behavior
+- choose one excerpt that most directly shows weekly materiality
+- choose one excerpt that most directly shows ambiguity or unresolved scope
+
+If the packet cannot support a usable excerpt bundle, set `raw_reread_reason` to one of:
+- `conflicting_signals`
+- `missing_failure_evidence`
+- `missing_materiality_evidence`
+- `schema_mismatch`
+- `insufficient_excerpt_quality`
+
+`raw_reread_reason != null` means the main agent may approve a narrow raw reread for that candidate only.
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $weekly-update to analyze packet-driven workflow inputs.
+
+Read only:
+- <global-packet>
+- <focused-packet-or-focused-slice>
+
+Read `global_packet.json` first.
+Treat `packet_worker_map` as routing authority.
+Treat proposed_classification as worker proposal only.
+Use source_refs as the canonical citation list.
+Return:
+- candidates[]
+- footer.packet_ids
+- footer.candidate_ids
+- footer.primary_outcome
+- footer.overall_confidence
+- footer.coverage_gaps
+- footer.overall_risk
+```
+
+Keep each worker narrow. Keep the final section wording, final classification, and marker-update decision local.

--- a/builders/packet-workflow/retained-skills/weekly-update/references/evaluation-log-contract.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/evaluation-log-contract.md
@@ -1,0 +1,57 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope in `weekly-update`.
+
+## Purpose
+
+Track three outcomes consistently:
+- efficiency
+- quality
+- safety
+
+Default log path:
+
+`~/.codex/tmp/evaluation_logs/weekly-update/<run-id>.json`
+
+The default path must stay outside the repo. An explicit override path is allowed.
+
+## Common Envelope
+
+Use this top-level shape:
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep truly common fields in the shared envelope only.
+- Put workflow-specific counters or mutation details in `skill_specific.data`.
+- Default `baseline.method` to `none`.
+- Leave savings fields null when no baseline exists.
+- Label estimated or unavailable data explicitly in `measurement`.
+- Renormalize scoring weights when a signal is missing.
+
+## Helper Workflow
+
+Use `scripts/write_evaluation_log.py` in three modes:
+- `init`
+  - `--context <json> --orchestrator <json> [--lint <json>] [--output <json>]`
+- `phase`
+  - `--log <json> --phase build|lint|validate|apply --result <json> [--duration-seconds <float>]`
+- `finalize`
+  - `--log <json> --final <json>`

--- a/builders/packet-workflow/retained-skills/weekly-update/references/weekly-update-contract.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/weekly-update-contract.md
@@ -1,0 +1,411 @@
+# Weekly Update Contract
+
+This file defines the packet, candidate, worker, and apply contract for the `weekly-update` skill.
+
+## Builder Metadata
+
+- `workflow_family`: `repo-audit`
+- `archetype`: `plan-validate-apply`
+- `orchestrator_profile`: `standard`
+- `decision_ready_packets`: `true`
+- `worker_return_contract`: `classification-oriented`
+- `worker_output_shape`: `hierarchical`
+- trigger phrases:
+  - weekly update
+  - summarize this week's PRs
+  - synthesize this week's rollouts incidents and reviews
+  - build a weekly status update
+
+## Final Output Shape
+
+The final update must:
+- state the exact reporting window
+- use these sections in order:
+  - `PRs`
+  - `Rollouts`
+  - `Incidents`
+  - `Reviews`
+  - `Blockers / Risks`
+  - `Evidence reviewed`
+- include only verified items from the reporting window
+- say so briefly when a section has no verified evidence
+
+## Required Runtime Packet Outputs
+
+- `orchestrator.json`
+- `global_packet.json`
+- `mapping_packet.json`
+- `changes_packet.json`
+- `incidents_packet.json`
+- `risks_packet.json`
+
+## Eval-Side Build Outputs
+
+- `packet_metrics.json`
+- build result JSON emitted via `build_weekly_update_packets.py --result-output`
+
+Token-efficiency counters belong only in these evaluation-side artifacts, not in `orchestrator.json`.
+
+## Repo Profile Boundary
+
+- default retained profile: `profiles/default/profile.json`
+- preferred project-local override: `.codex/project/profiles/weekly-update/profile.json`
+- explicit `--profile <profile-json>` remains available for manual override, smoke, and fixture-refresh entrypoints
+- keep repo-specific conventions in `repo_profile.extra.weekly_update`
+- collected context, `orchestrator.json`, `global_packet.json`, and build-result artifacts should surface active profile metadata
+
+## Authority Order
+
+Use evidence in this order:
+- published GitHub releases and linked release issues
+- merged PR diffs and git history
+- directly related review, issue, and workflow-run evidence
+- structured workflow packets
+- local last-success state as baseline only
+
+The last-success marker is never a facts source for the weekly narrative. It is only a baseline source for the reporting window.
+
+## Review Mode Guidance
+
+- `local-only`
+  - use no workers
+  - reserve for quiet windows with a small candidate set and no meaningful rollout or incident activity
+- `targeted-delegation`
+  - default mode
+  - use 1-2 workers on narrow focused packets
+- `broad-delegation`
+  - use 3-4 workers when releases, incidents, reviews, and nested PR lineage materially expand the evidence graph
+
+## Worker Routing Metadata
+
+Preferred worker families:
+- `context_findings`
+  - `repo_mapper`
+  - `docs_verifier`
+- `candidate_producers`
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `verifiers`
+  - `docs_verifier`
+
+Concrete routing uses `packet_worker_map`:
+- `mapping_packet -> repo_mapper`
+- `changes_packet -> large_diff_auditor`
+- `incidents_packet -> log_triager`
+- `risks_packet -> evidence_summarizer`
+
+Rules:
+- `packet_worker_map` is the routing authority
+- `worker_selection_guidance` is explanatory only
+- routed worker budgets still follow `local-only`, `targeted-delegation`, and `broad-delegation`
+
+## Candidate Proposal Model
+
+Workers and collectors produce proposal-grade candidates. The main agent performs the final adjudication.
+
+- `proposed_classification` is worker proposal only; the main agent may override it.
+- `final_classification` is local synthesis state, not a worker-output field.
+- `summary` is the candidate-level fact summary.
+- `classification_rationale` explains why the candidate was proposed for that classification.
+- `artifact_only` candidates are reference-only evidence. They do not appear as standalone final section items, but may support another candidate or appear in `Evidence reviewed`.
+
+### Candidate Schema
+
+Every candidate record uses this schema:
+- `candidate_id`
+- `source_type`
+- `source_id`
+- `title`
+- `summary`
+- `proposed_classification`
+- `classification_rationale`
+- `materiality_evidence`
+- `concrete_failure_evidence`
+- `open_ambiguity`
+- `confidence`
+- `source_refs`
+- `excerpt_bundle`
+- `raw_reread_reason`
+- `packet_membership`
+- `risk`
+- `recommended_next_step`
+- `tests_or_checks`
+
+### Classification Values
+
+`proposed_classification` allows only:
+- `actual_incident`
+- `blocker_or_risk`
+- `artifact_only`
+- `ignore`
+
+### Confidence Rules
+
+`confidence` is a candidate-level enum:
+- `high`
+  - failure and materiality evidence are both direct
+  - no meaningful conflicting signal remains
+- `medium`
+  - core evidence exists
+  - some ambiguity remains, but the proposal is still usable
+- `low`
+  - a proposal is possible
+  - raw reread is likely required before final adjudication
+
+### Canonical Citations
+
+`source_refs` is the canonical citation list across packets and worker output.
+
+Each entry must include:
+- `kind`
+- `ref`
+
+It may also include:
+- `url`
+
+Example refs:
+- `issue/#110`
+- `pr/#97`
+- `release/v0.2.3`
+- `run/23635553980`
+- `review/pr107-comment2992368622`
+- `file/.github/scripts/perf_telemetry_automation.py`
+
+Do not use a separate `evidence_files_or_links` field.
+
+### Excerpt Bundle
+
+`excerpt_bundle` uses named slots:
+- `failure_excerpt`
+- `materiality_excerpt`
+- `ambiguity_excerpt`
+
+Each slot is nullable. When present it contains:
+- `text`
+- `source_ref`
+- `source_type`
+- `why_selected`
+
+Selection rules:
+- `failure_excerpt`
+  - choose the excerpt that most directly shows failure, regression, invalid output, or broken behavior
+- `materiality_excerpt`
+  - choose the excerpt that most directly shows weekly relevance such as creation, resolution, significant update, or linked PR/workflow impact during the reporting window
+- `ambiguity_excerpt`
+  - choose the excerpt that most directly shows unresolved scope, incomplete evidence, or remaining ambiguity
+
+Do not place full issue bodies, long PR diffs, or workflow-log transcripts inside the excerpt bundle.
+
+### Raw Reread Control
+
+`raw_reread_reason` is a nullable enum:
+- `null`
+- `conflicting_signals`
+- `missing_failure_evidence`
+- `missing_materiality_evidence`
+- `schema_mismatch`
+- `insufficient_excerpt_quality`
+
+Treat `raw_reread_reason != null` as an exception path. The main agent should reread raw evidence only for those candidates when local adjudication requires it.
+
+### Packet Membership
+
+`packet_membership` is the canonical list of packet names that contain the candidate.
+
+Use it to:
+- track intended duplication across packets
+- verify packet completeness
+- explain why a review-related candidate may appear in both `Reviews` and `Blockers / Risks`
+
+## Packet Semantics
+
+### `orchestrator.json`
+
+Keep runtime routing and local-adjudication metadata here:
+- `orchestrator_profile`
+- `review_mode`
+- `decision_ready_packets`
+- `worker_return_contract`
+- `worker_output_shape`
+- `packet_worker_map`
+- `preferred_worker_families`
+- `recommended_workers`
+- `optional_workers`
+- `shared_packet`
+- `selected_packets`
+- `common_path_contract`
+- `local_responsibilities`
+- `review_mode_overrides`
+
+Do not place token/size counters or build-only packet inventory metadata in `orchestrator.json`.
+
+### `global_packet.json`
+
+Keep shared workflow facts here:
+- reporting window
+- primary goal
+- authority order
+- stop conditions
+- review mode
+- worker budget
+- section rules
+- source-gap summary
+- `decision_ready_packets`
+- `worker_return_contract`
+- `worker_output_shape`
+- `candidate_field_bundles`
+- `worker_footer_fields`
+- `reread_reason_values`
+- `domain_overlay`
+- `preferred_worker_families`
+- `packet_worker_map`
+- `worker_selection_guidance`
+
+### `common_path_contract`
+
+Lock the normal local-adjudication path to:
+- `global_packet.json`
+- `mapping_packet.json`
+- one focused packet needed for the current decision
+
+Raw reread stays exception-only and must remain candidate-scoped through `raw_reread_reason`.
+
+### `mapping_packet.json`
+
+Keep the evidence map here:
+- reporting window
+- default branch
+- release-to-issue linkage
+- top-level versus nested PR lineage
+- candidate inventory index
+- each candidate's `packet_membership`
+- candidates whose `raw_reread_reason != null`
+
+### `changes_packet.json`
+
+Keep top-level shipped change candidates here:
+- top-level merged PR candidates only
+- `shipped_change_bullets`
+- `review_followups`
+- linked issue and review candidate references
+
+`review_followups` must stay separate from `shipped_change_bullets`.
+
+### `incidents_packet.json`
+
+Keep incident-focused candidates here:
+- candidates proposed as `actual_incident`
+- incident-adjacent candidates that still require adjudication
+- workflow failures only when they materially affected release, validation, or schedule
+
+### `risks_packet.json`
+
+Keep blocker and risk material here:
+- candidates proposed as `blocker_or_risk`
+- `artifact_only` reference candidates
+- unresolved review findings
+- release-gate gaps
+- pending follow-ups
+
+## Reviews And Blockers Rules
+
+- `Incidents` is narrow.
+  - include only actual events that materially affected operations, validation, release, or schedule during the reporting window
+- pending investigations, gate tracking, reusable evidence artifacts, and forecasted risks belong in `Blockers / Risks`, not `Incidents`
+- resolved review findings appear in `Reviews` only
+- unresolved review findings with release or merge-gate impact may appear in both `Reviews` and `Blockers / Risks`
+- generic notices, bot noise, and empty self-reviews are always excluded
+
+## Worker Output Contract
+
+Each worker response has two layers:
+- top-level `candidates[]`
+- top-level `footer`
+
+### Candidate-Level Fields
+
+Each entry in `candidates[]` contains candidate-level data. The worker-level summary does not replace or absorb these fields.
+
+Required candidate fields:
+- `candidate_id`
+- `summary`
+- `proposed_classification`
+- `classification_rationale`
+- `materiality_evidence`
+- `concrete_failure_evidence`
+- `open_ambiguity`
+- `confidence`
+- `source_refs`
+- `excerpt_bundle`
+- `raw_reread_reason`
+- `packet_membership`
+- `risk`
+- `recommended_next_step`
+- `tests_or_checks`
+
+### Worker Footer Fields
+
+Every worker response also includes `footer` with:
+- `packet_ids`
+- `candidate_ids`
+- `primary_outcome`
+- `overall_confidence`
+- `coverage_gaps`
+- `overall_risk`
+
+Definitions:
+- `footer.primary_outcome`
+  - worker-level batch summary only
+- `footer.overall_confidence`
+  - worker-level confidence for the whole batch
+  - summarize candidate confidences and unresolved ambiguity as `high`, `medium`, or `low`
+- `footer.candidate_ids`
+  - follow `candidates[]` stable discovery order exactly
+- `footer.coverage_gaps`
+  - scope the worker could not read or could not verify sufficiently
+- `footer.overall_risk`
+  - remaining batch-level operational or adjudication risk
+
+Candidate-level `risk` is limited to that candidate. It is not a substitute for worker-level `footer.overall_risk`.
+
+## Plan And Apply Contract
+
+Use `weekly-update-plan.json` as the local synthesis artifact.
+
+It should include at least:
+- `context_id`
+- `context_fingerprint`
+- `reporting_window`
+- `selected_packets`
+- `overall_confidence`
+- `stop_reasons`
+- `allow_marker_update`
+- `sections`
+
+`scripts/apply_weekly_update.py` must read only the synthesized plan fields:
+- `overall_confidence`
+- `stop_reasons`
+- `allow_marker_update`
+
+`scripts/validate_weekly_update_plan.py` validates the full plan schema before apply, including:
+- required plan fields
+- section-key coverage and ordering
+- `artifact_only` direct-section exclusion
+- unresolved reread and low-confidence marker-update blocks
+
+The apply step must not read worker footers directly.
+
+Marker updates are blocked when:
+- unresolved `raw_reread_reason` exceptions remain after adjudication
+- `overall_confidence` is `low`
+- `allow_marker_update` is `false`
+
+## Notes
+
+- Flat contracts remain the default in this environment. Read `references/architecture-note.md` for why `weekly-update` keeps a hierarchical contract as an explicit exception.
+- Use only repository evidence and directly related GitHub evidence available during the run.
+- When evidence is missing or conflicting, keep the claim out of the final weekly update.
+- Keep packet contents adjudication-ready so the main agent does not need broad raw rereads in the normal path.
+- `scripts/refresh_weekly_update_live_fixture.py` is maintainer-only. It may refresh fixture snapshots from live evidence, but it must stay out of the default unit-test path because it depends on networked GitHub state.
+- Automation or meta-skill prompts should stay thin: invoke `$weekly-update`, specify the final section order and reporting-window requirement, and let this skill own packet internals, worker routing, and apply-gate details.

--- a/builders/packet-workflow/retained-skills/weekly-update/references/weekly-update-evaluation-contract.md
+++ b/builders/packet-workflow/retained-skills/weekly-update/references/weekly-update-evaluation-contract.md
@@ -1,0 +1,83 @@
+# Weekly Update Evaluation Contract
+
+Use the shared envelope in `references/evaluation-log-contract.md` and keep workflow-specific metrics under `skill_specific.data`.
+
+## Recommended Domain Fields
+
+Record only workflow-specific counters and boundary signals that do not fit cleanly in the shared envelope.
+
+Recommended fields:
+- `reporting_window`
+- `review_mode`
+- `selected_packets`
+- `worker_count`
+- `worker_mix`
+- `worker_packet_usage`
+- `worker_footer_confidences`
+- `candidate_counts_by_proposed_classification`
+- `candidate_counts_by_final_section`
+- `raw_reread_reason_counts`
+- `raw_reread_count`
+- `proposal_override_count`
+- `coverage_gap_count`
+- `packet_count`
+- `estimated_packet_tokens`
+- `estimated_delegation_savings`
+- `common_path_sufficient`
+- `stop_reasons`
+- `plan_overall_confidence`
+- `allow_marker_update`
+- `marker_update_attempted`
+- `marker_update_written`
+
+## Candidate And Plan Metrics
+
+Track proposal-stage and final-plan metrics separately.
+
+- `candidate_counts_by_proposed_classification`
+  - count worker or collector proposals before final adjudication
+- `candidate_counts_by_final_section`
+  - count only final section placements after local adjudication
+- `proposal_override_count`
+  - count candidates whose final local classification or section placement differs materially from the worker proposal
+- `raw_reread_reason_counts`
+  - count exception-path candidates by reread reason
+
+## Confidence Semantics
+
+- `worker_footer_confidences`
+  - record worker-level `overall_confidence` values for each worker response when workers were used
+- `plan_overall_confidence`
+  - record the final run-level confidence from `weekly-update-plan.json`
+  - this is the confidence the apply step uses
+
+Do not treat worker-footer confidence as the final apply gate by itself.
+
+## Marker Update Semantics
+
+Record marker-update outcomes explicitly:
+- `allow_marker_update`
+  - final gate from `weekly-update-plan.json`
+- `marker_update_attempted`
+  - whether the apply step attempted a state write
+- `marker_update_written`
+  - whether the last-success marker was actually updated
+
+If marker update is skipped, capture the reason in `stop_reasons` or a short workflow-specific note.
+
+## Build-Phase Metrics
+
+`build_weekly_update_packets.py --result-output` is the source for build-phase evaluation merge.
+
+- merge `packet_metrics.json` and the build result during `write_evaluation_log.py phase --phase build`
+- keep token-efficiency counters out of runtime packets
+- treat `common_path_sufficient` and `raw_reread_count` as packet-quality regression signals, not as runtime routing inputs
+
+## Expected Behavior
+
+- Keep full candidate bodies out of the evaluation log unless a debugging path explicitly requires them.
+- Prefer counts, booleans, enums, and short reason lists over free-form summaries.
+- Keep `coverage_gap_count` focused on unread or insufficiently verified scope, not on ordinary low-priority follow-ups.
+- Keep the evaluation contract aligned with the worker proposal model, packet membership tracking, and the plan-driven apply gate.
+- `scripts/apply_weekly_update.py` should read only `weekly-update-plan.json` fields `overall_confidence`, `stop_reasons`, and `allow_marker_update`, not worker footers.
+- Keep `estimated_packet_tokens` and `estimated_delegation_savings` as evaluation/regression signals only.

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/apply_weekly_update.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/apply_weekly_update.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Dry-run or apply a planned action file for weekly-update."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from weekly_update_lib import apply_plan, load_json, write_json
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--plan", required=True, help="Planned action JSON.")
+    parser.add_argument("--dry-run", action="store_true", help="Report the apply plan without mutating.")
+    parser.add_argument("--state-file", help="Optional state marker path override.")
+    parser.add_argument("--result-output", help="Optional machine-readable apply result JSON.")
+    return parser.parse_args()
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    plan = load_json(Path(args.plan).resolve())
+    summary = apply_plan(
+        context=context,
+        plan=plan,
+        state_file=args.state_file,
+        dry_run=args.dry_run,
+    )
+    if args.result_output:
+        write_json(Path(args.result_output).resolve(), summary)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/build_weekly_update_packets.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/build_weekly_update_packets.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Build focused packets for weekly-update from collected context."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from weekly_update_lib import build_packet_artifacts, load_json, write_json
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--lint", help="Optional lint findings JSON.")
+    parser.add_argument("--output-dir", required=True, help="Packet output directory.")
+    parser.add_argument("--result-output", help="Optional machine-readable build result JSON.")
+    return parser.parse_args()
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    lint = load_json(Path(args.lint)) if args.lint else {}
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = build_packet_artifacts(context, lint)
+    packets = artifacts["packets"]
+    for file_name, payload in packets.items():
+        write_json(output_dir / file_name, payload)
+    write_json(output_dir / "packet_metrics.json", artifacts["packet_metrics"])
+    if args.result_output:
+        write_json(Path(args.result_output).resolve(), artifacts["build_result"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/collect_weekly_update_context.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/collect_weekly_update_context.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Collect structured workflow context for weekly-update."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from weekly_update_lib import (
+    collect_context,
+    default_repo_profile_path,
+    emit_builder_compatibility_warning,
+    write_json,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True, help="Repository root to inspect.")
+    parser.add_argument("--output", required=True, help="Output JSON path.")
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    parser.add_argument("--state-file", help="Optional state marker path override.")
+    parser.add_argument("--window-days", type=int, default=7, help="Window size when no state marker is reused.")
+    parser.add_argument("--now-utc", help="Optional ISO8601 UTC timestamp override for deterministic runs.")
+    return parser.parse_args()
+
+def main() -> int:
+    args = parse_args()
+    payload = collect_context(
+        repo_root=args.repo_root,
+        profile=args.profile,
+        state_file=args.state_file,
+        window_days=args.window_days,
+        now_utc=args.now_utc,
+    )
+    emit_builder_compatibility_warning(payload.get("builder_compatibility") or {})
+    write_json(Path(args.output).resolve(), payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/lint_weekly_update.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/lint_weekly_update.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Run deterministic lint checks for weekly-update."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from weekly_update_lib import lint_context, load_json, write_json
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--output", required=True, help="Output lint JSON.")
+    return parser.parse_args()
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    findings = lint_context(context)
+    write_json(Path(args.output).resolve(), findings)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/refresh_weekly_update_live_fixture.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/refresh_weekly_update_live_fixture.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Maintainer-only helper to refresh weekly-update test fixtures from live repo evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from weekly_update_lib import (
+    empty_plan_sections,
+    default_repo_profile_path,
+    extract_release_tag,
+    fetch_pr_detail,
+    fetch_review_comments,
+    get_repo_metadata,
+    isoformat_utc,
+    label_names,
+    link_releases_to_issues,
+    list_issues,
+    list_merged_pr_summaries,
+    list_releases,
+    list_workflow_runs,
+    load_repo_profile,
+    load_state_marker,
+    parse_iso8601,
+    resolve_repo_root,
+    resolve_profile_path,
+    select_reporting_window,
+    short_markdown_summary,
+    title_prefix,
+    utc_now,
+    verify_gh_auth,
+    weekly_update_runtime_settings,
+    window_contains,
+    write_json,
+    build_pr_lineage,
+    build_issue_linkage_set,
+    classify_issue,
+)
+
+
+def default_fixture_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "tests" / "fixtures"
+
+
+def parse_args() -> argparse.Namespace:
+    fixture_dir = default_fixture_dir()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True, help="Repository root to inspect.")
+    parser.add_argument("--sample-output", default=str(fixture_dir / "weekly_update_sample.json"), help="Output path for the refreshed live sample fixture.")
+    parser.add_argument("--plan-dir", default=str(fixture_dir), help="Directory for paired plan fixtures.")
+    parser.add_argument("--skip-plan-fixtures", action="store_true", help="Refresh only the live sample fixture.")
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+    parser.add_argument("--state-file", help="Optional state marker path override.")
+    parser.add_argument("--window-days", type=int, default=7, help="Window size to use when no state marker is reused.")
+    parser.add_argument("--now-utc", help="Optional deterministic ISO8601 UTC timestamp override.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the refresh summary without writing fixture files.")
+    return parser.parse_args()
+
+
+def trim_fixture_text(text: str | None, *, limit: int = 4000) -> str:
+    normalized = str(text or "").strip()
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 15].rstrip() + "\n[truncated]"
+
+
+def fixture_state_marker(state_marker: dict[str, Any] | None, reporting_window: dict[str, Any]) -> dict[str, Any] | None:
+    if reporting_window.get("source") != "state_marker":
+        return None
+    marker = dict(state_marker or {})
+    window_end = str(marker.get("window_end_utc") or marker.get("completed_at_utc") or reporting_window.get("start_utc") or "").strip()
+    return {"window_end_utc": window_end} if window_end else None
+
+
+def normalize_release_fixture(release: dict[str, Any], release_issue_linkage: dict[str, list[int]]) -> dict[str, Any]:
+    issue_numbers = release_issue_linkage.get(str(release.get("tag_name") or ""), [])
+    payload = {
+        "tag_name": str(release.get("tag_name") or ""),
+        "published_at": str(release.get("published_at") or ""),
+    }
+    if issue_numbers:
+        payload["release_issue_number"] = int(issue_numbers[0])
+    return payload
+
+
+def normalize_pr_fixture(pr: dict[str, Any], pr_lineage: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    payload = {
+        "number": int(pr["number"]),
+        "title": str(pr.get("title") or ""),
+        "base_ref_name": str(pr.get("base_ref_name") or pr.get("baseRefName") or ""),
+        "merged_at": str(pr.get("merged_at") or pr.get("mergedAt") or ""),
+        "linked_issue_numbers": list(pr.get("linked_issue_numbers") or []),
+        "shipped_change_bullets": list(pr.get("shipped_change_bullets") or []),
+        "review_followups": list(pr.get("risk_bullets") or []),
+    }
+    root = (pr_lineage.get(str(pr["number"])) or {}).get("root_top_level_pr")
+    if root is not None:
+        payload["absorbed_into"] = int(root)
+    return payload
+
+
+def normalize_issue_fixture(issue: dict[str, Any], linked_from_pr_numbers: list[int]) -> dict[str, Any]:
+    payload = {
+        "number": int(issue["number"]),
+        "title": str(issue.get("title") or ""),
+        "body": trim_fixture_text(issue.get("body")),
+        "labels": label_names(issue),
+        "state": str(issue.get("state") or "").upper(),
+        "created_at": str(issue.get("createdAt") or ""),
+        "updated_at": str(issue.get("updatedAt") or ""),
+    }
+    if linked_from_pr_numbers:
+        payload["linked_from_pr_numbers"] = linked_from_pr_numbers
+    return payload
+
+
+def serialize_review_comment(comment: dict[str, Any]) -> dict[str, Any]:
+    payload = {
+        "id": int(comment["id"]),
+        "body": trim_fixture_text(comment.get("body"), limit=1200),
+        "author": str((comment.get("user") or {}).get("login") or comment.get("author") or ""),
+        "created_at": str(comment.get("created_at") or ""),
+        "in_reply_to_id": comment.get("in_reply_to_id"),
+        "path": comment.get("path"),
+    }
+    return payload
+
+
+def build_review_threads(pr_number: int, comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    roots = [comment for comment in comments if comment.get("in_reply_to_id") is None]
+    replies_by_root: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for comment in comments:
+        if comment.get("in_reply_to_id") is not None:
+            replies_by_root[int(comment["in_reply_to_id"])].append(comment)
+    threads: list[dict[str, Any]] = []
+    for root in sorted(roots, key=lambda item: (str(item.get("created_at") or ""), int(item.get("id") or 0))):
+        thread_comments = [serialize_review_comment(root)]
+        thread_comments.extend(
+            serialize_review_comment(reply)
+            for reply in sorted(replies_by_root.get(int(root["id"]), []), key=lambda item: (str(item.get("created_at") or ""), int(item.get("id") or 0)))
+        )
+        threads.append({"pr_number": pr_number, "comments": thread_comments})
+    return threads
+
+
+def normalize_workflow_run_fixture(run: dict[str, Any]) -> dict[str, Any]:
+    run_id = int(run.get("databaseId") or 0)
+    return {
+        "databaseId": run_id,
+        "workflowName": str(run.get("workflowName") or ""),
+        "conclusion": str(run.get("conclusion") or ""),
+        "status": str(run.get("status") or ""),
+        "event": str(run.get("event") or ""),
+        "headBranch": str(run.get("headBranch") or ""),
+        "headSha": str(run.get("headSha") or ""),
+        "createdAt": str(run.get("createdAt") or ""),
+        "updatedAt": str(run.get("updatedAt") or ""),
+        "url": f"https://example.invalid/run/{run_id}",
+    }
+
+
+def build_plan_fixtures(*, context_id: str, context_fingerprint: str, reporting_window: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    base = {
+        "context_id": context_id,
+        "context_fingerprint": context_fingerprint,
+        "reporting_window": reporting_window,
+        "selected_packets": ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"],
+        "sections": empty_plan_sections(),
+    }
+    return {
+        "weekly_update_plan_ready.json": {
+            **base,
+            "overall_confidence": "medium",
+            "stop_reasons": [],
+            "allow_marker_update": True,
+        },
+        "weekly_update_plan_low.json": {
+            **base,
+            "overall_confidence": "low",
+            "stop_reasons": [],
+            "allow_marker_update": False,
+        },
+        "weekly_update_plan_reread.json": {
+            **base,
+            "overall_confidence": "medium",
+            "stop_reasons": ["raw reread exception unresolved"],
+            "allow_marker_update": False,
+            "unresolved_raw_reread_candidate_ids": ["fixture-reread-candidate"],
+        },
+    }
+
+
+def collect_live_fixture_payload(
+    *,
+    repo_root: Path,
+    profile: str | None,
+    state_file: str | None,
+    window_days: int,
+    now_utc: str | None,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]], dict[str, Any]]:
+    profile_path = resolve_profile_path(profile, repo_root=repo_root)
+    repo_profile = load_repo_profile(profile_path)
+    runtime_settings = weekly_update_runtime_settings(repo_profile)
+    verify_gh_auth(repo_root)
+    repo_meta = get_repo_metadata(repo_root)
+    marker, marker_warnings = load_state_marker(Path(state_file).resolve()) if state_file else (None, [])
+    current_now = parse_iso8601(now_utc) or utc_now()
+    reporting_window = select_reporting_window(now_utc=current_now, window_days=window_days, state_marker=marker)
+    window_start = parse_iso8601(reporting_window["start_utc"])
+    window_end = parse_iso8601(reporting_window["end_utc"])
+    assert window_start is not None and window_end is not None
+
+    releases, release_warnings = list_releases(repo_root, repo_meta["repo_slug"], window_start=window_start, window_end=window_end)
+    issues, issue_warnings = list_issues(repo_root, repo_meta["repo_slug"])
+    pr_summaries, pr_summary_warnings = list_merged_pr_summaries(repo_root, repo_meta["repo_slug"], window_start=window_start, window_end=window_end)
+    merged_prs: list[dict[str, Any]] = []
+    pr_warnings: list[str] = []
+    for summary in pr_summaries:
+        detail, detail_warnings = fetch_pr_detail(repo_root, repo_meta["repo_slug"], int(summary["number"]))
+        merged_prs.append(detail)
+        pr_warnings.extend(detail_warnings)
+    top_level_prs, nested_prs, pr_lineage = build_pr_lineage(merged_prs, repo_meta["default_branch"])
+    release_issue_linkage = link_releases_to_issues(
+        releases,
+        issues,
+        release_title_re=runtime_settings["release_title_re"],
+    )
+    linked_issue_numbers = build_issue_linkage_set(top_level_prs)
+    active_release_tags = {release["tag_name"] for release in releases}
+
+    classified_issues = [
+        item
+        for item in (
+            classify_issue(
+                issue,
+                window_start=window_start,
+                window_end=window_end,
+                linked_issue_numbers=linked_issue_numbers,
+                active_release_tags=active_release_tags,
+                release_title_re=runtime_settings["release_title_re"],
+            )
+            for issue in issues
+        )
+        if item["classification"] != "ignore"
+    ]
+    top_level_links: dict[int, list[int]] = defaultdict(list)
+    for pr in top_level_prs:
+        for issue_number in pr.get("linked_issue_numbers") or []:
+            top_level_links[int(issue_number)].append(int(pr["number"]))
+
+    selected_issue_numbers = {
+        int(item["number"])
+        for item in classified_issues
+        if title_prefix(str(item.get("title") or "")) != "release"
+        and not extract_release_tag(
+            str(item.get("title") or ""),
+            release_title_re=runtime_settings["release_title_re"],
+        )
+    }
+    selected_issues = [issue for issue in issues if int(issue["number"]) in selected_issue_numbers]
+
+    review_threads: list[dict[str, Any]] = []
+    review_warnings: list[str] = []
+    for pr in top_level_prs:
+        comments, warnings = fetch_review_comments(repo_root, repo_meta["repo_slug"], int(pr["number"]))
+        review_warnings.extend(warnings)
+        review_threads.extend(build_review_threads(int(pr["number"]), comments))
+
+    workflow_runs, workflow_warnings = list_workflow_runs(repo_root, repo_meta["repo_slug"], window_start=window_start, window_end=window_end)
+
+    sample_payload = {
+        "now_utc": isoformat_utc(current_now),
+        "window_days": window_days,
+        "profile_name": repo_profile.get("name"),
+        "state_marker": fixture_state_marker(marker, reporting_window),
+        "default_branch": repo_meta["default_branch"],
+        "releases": [normalize_release_fixture(release, release_issue_linkage) for release in releases],
+        "prs": [normalize_pr_fixture(pr, pr_lineage) for pr in [*nested_prs, *top_level_prs]],
+        "issues": [normalize_issue_fixture(issue, sorted(top_level_links.get(int(issue["number"]), []))) for issue in selected_issues],
+        "review_threads": review_threads,
+        "workflow_runs": [normalize_workflow_run_fixture(run) for run in workflow_runs],
+    }
+    sample_payload["prs"].sort(key=lambda item: str(item.get("merged_at") or ""))
+    sample_payload["issues"].sort(key=lambda item: int(item.get("number") or 0))
+    sample_payload["review_threads"].sort(key=lambda item: (int(item.get("pr_number") or 0), int((item.get("comments") or [{}])[0].get("id") or 0)))
+    sample_payload["workflow_runs"].sort(key=lambda item: str(item.get("createdAt") or ""))
+
+    context_id = f"weekly-update:{current_now.strftime('%Y%m%dT%H%M%SZ')}"
+    context_fingerprint = f"fixture-refresh:{current_now.strftime('%Y%m%dT%H%M%SZ')}"
+    plan_payloads = build_plan_fixtures(context_id=context_id, context_fingerprint=context_fingerprint, reporting_window=reporting_window)
+    summary = {
+        "repo_root": str(repo_root),
+        "repo_slug": repo_meta["repo_slug"],
+        "reporting_window": reporting_window,
+        "counts": {
+            "releases": len(sample_payload["releases"]),
+            "prs": len(sample_payload["prs"]),
+            "issues": len(sample_payload["issues"]),
+            "review_threads": len(sample_payload["review_threads"]),
+            "workflow_runs": len(sample_payload["workflow_runs"]),
+        },
+        "warnings": marker_warnings + release_warnings + issue_warnings + pr_summary_warnings + pr_warnings + review_warnings + workflow_warnings,
+    }
+    return sample_payload, plan_payloads, summary
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = resolve_repo_root(args.repo_root)
+    sample_output = Path(args.sample_output).resolve()
+    plan_dir = Path(args.plan_dir).resolve()
+    sample_payload, plan_payloads, summary = collect_live_fixture_payload(
+        repo_root=repo_root,
+        profile=args.profile,
+        state_file=args.state_file,
+        window_days=args.window_days,
+        now_utc=args.now_utc,
+    )
+    if not args.dry_run:
+        write_json(sample_output, sample_payload)
+        if not args.skip_plan_fixtures:
+            plan_dir.mkdir(parents=True, exist_ok=True)
+            for file_name, payload in plan_payloads.items():
+                write_json(plan_dir / file_name, payload)
+    result = {
+        "ok": True,
+        "dry_run": args.dry_run,
+        "sample_output": str(sample_output),
+        "plan_dir": None if args.skip_plan_fixtures else str(plan_dir),
+        "counts": summary["counts"],
+        "warnings": summary["warnings"],
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/smoke_weekly_update.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/smoke_weekly_update.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Run an opt-in end-to-end smoke test for the weekly-update CLI wrappers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from weekly_update_lib import OUTPUT_SECTIONS
+
+
+EXPECTED_PACKET_FILES = (
+    "orchestrator.json",
+    "global_packet.json",
+    "mapping_packet.json",
+    "changes_packet.json",
+    "incidents_packet.json",
+    "risks_packet.json",
+)
+EXPECTED_EVAL_FILES = ("packet_metrics.json",)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", help="Repository root to inspect. Defaults to the current working directory.")
+    parser.add_argument("--profile", help="Path to the active repo profile JSON.")
+    parser.add_argument("--window-days", type=int, default=7, help="Window size passed through to collect.")
+    parser.add_argument("--now-utc", help="Optional deterministic ISO8601 UTC timestamp override for collect.")
+    return parser.parse_args()
+
+
+def script_path(name: str) -> Path:
+    return Path(__file__).resolve().with_name(name)
+
+
+def repo_root_path(value: str | None) -> Path | None:
+    if value:
+        candidate = Path(value).resolve()
+        return candidate if (candidate / ".git").exists() else None
+    for candidate in [Path.cwd().resolve(), *Path.cwd().resolve().parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def smoke_summary(status: str, reason: str | None, repo_root: Path | None, next_action: str, **extra: Any) -> dict[str, Any]:
+    payload = {
+        "status": status,
+        "reason": reason,
+        "repo_root": str(repo_root) if repo_root else None,
+        "next_action": next_action,
+    }
+    payload.update(extra)
+    return payload
+
+
+def run_script(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    command = [sys.executable, "-B", *args]
+    try:
+        return subprocess.run(command, cwd=str(cwd) if cwd else None, env=env, text=True, capture_output=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        stdout = (exc.stdout or "").strip()
+        details = "\n".join(part for part in (stderr, stdout) if part)
+        detail_suffix = f"\n{details}" if details else ""
+        raise RuntimeError(f"Command failed: {' '.join(command)}{detail_suffix}") from exc
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def build_minimal_plan(context: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "context_id": context.get("context_id"),
+        "context_fingerprint": context.get("context_fingerprint"),
+        "reporting_window": context.get("reporting_window"),
+        "selected_packets": ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"],
+        "overall_confidence": "high",
+        "stop_reasons": [],
+        "allow_marker_update": False,
+        "sections": {section: [] for section in OUTPUT_SECTIONS},
+    }
+
+
+def missing_packet_files(packet_dir: Path) -> list[str]:
+    return [name for name in EXPECTED_PACKET_FILES if not (packet_dir / name).is_file()]
+
+
+def missing_eval_files(packet_dir: Path) -> list[str]:
+    return [name for name in EXPECTED_EVAL_FILES if not (packet_dir / name).is_file()]
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = repo_root_path(args.repo_root)
+    if repo_root is None:
+        print(
+            json.dumps(
+                smoke_summary(
+                    "blocked",
+                    "git_repo_required",
+                    None if args.repo_root is None else Path(args.repo_root).resolve(),
+                    "run_from_repo_or_pass_repo_root",
+                ),
+                indent=2,
+                ensure_ascii=True,
+            )
+        )
+        return 0
+
+    smoke_result: dict[str, Any]
+
+    temp_root = Path.cwd() / ".codex" / "tmp" / "packet-workflow" / "weekly-update"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="smoke-") as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        context_path = temp_dir / "context.json"
+        lint_path = temp_dir / "lint.json"
+        packet_dir = temp_dir / "packets"
+        build_result_path = temp_dir / "build-result.json"
+        plan_path = temp_dir / "weekly-update-plan.json"
+        plan_validation_path = temp_dir / "weekly-update-plan-validation.json"
+        apply_result_path = temp_dir / "apply-result.json"
+        eval_log_path = temp_dir / "eval-log.json"
+
+        run_script(
+            [
+                str(script_path("collect_weekly_update_context.py")),
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(context_path),
+                *(["--profile", args.profile] if args.profile else []),
+                "--window-days",
+                str(args.window_days),
+                *(
+                    ["--now-utc", args.now_utc]
+                    if args.now_utc
+                    else []
+                ),
+            ]
+        )
+        context = read_json(context_path)
+        if not context:
+            raise RuntimeError("collect_weekly_update_context.py produced an empty context payload")
+
+        run_script(
+            [
+                str(script_path("lint_weekly_update.py")),
+                "--context",
+                str(context_path),
+                "--output",
+                str(lint_path),
+            ]
+        )
+        run_script(
+            [
+                str(script_path("build_weekly_update_packets.py")),
+                "--context",
+                str(context_path),
+                "--lint",
+                str(lint_path),
+                "--output-dir",
+                str(packet_dir),
+                "--result-output",
+                str(build_result_path),
+            ]
+        )
+        build_result = read_json(build_result_path)
+        packet_metrics = read_json(packet_dir / "packet_metrics.json")
+
+        packet_files = sorted(path.name for path in packet_dir.iterdir() if path.is_file())
+        missing_packets = missing_packet_files(packet_dir)
+        if missing_packets:
+            raise RuntimeError(f"Missing packet files: {', '.join(missing_packets)}")
+        missing_eval = missing_eval_files(packet_dir)
+        if missing_eval:
+            raise RuntimeError(f"Missing evaluation-side packet files: {', '.join(missing_eval)}")
+        expected_file_count = len(EXPECTED_PACKET_FILES) + len(EXPECTED_EVAL_FILES)
+        if len(packet_files) != expected_file_count:
+            raise RuntimeError(f"Expected {expected_file_count} packet-side files, found {len(packet_files)}")
+        if not (packet_dir / "orchestrator.json").is_file():
+            raise RuntimeError("orchestrator.json was not written")
+        if not (packet_dir / "global_packet.json").is_file():
+            raise RuntimeError("global_packet.json was not written")
+        orchestrator = read_json(packet_dir / "orchestrator.json")
+        if "estimated_packet_tokens" in orchestrator or "packet_size_bytes" in orchestrator:
+            raise RuntimeError("orchestrator.json unexpectedly contains token-efficiency counters")
+        if packet_metrics.get("estimated_packet_tokens", 0) >= packet_metrics.get("estimated_local_only_tokens", 0):
+            raise RuntimeError("packet_metrics.json did not report token-efficiency savings")
+        if build_result.get("common_path_sufficient") is not True:
+            raise RuntimeError("weekly-update smoke run required raw rereads in the common path")
+        if int(build_result.get("raw_reread_count") or 0) != 0:
+            raise RuntimeError("weekly-update smoke run reported raw rereads")
+
+        plan = build_minimal_plan(context)
+        plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        run_script(
+            [
+                str(script_path("write_evaluation_log.py")),
+                "init",
+                "--context",
+                str(context_path),
+                "--orchestrator",
+                str(packet_dir / "orchestrator.json"),
+                "--lint",
+                str(lint_path),
+                "--output",
+                str(eval_log_path),
+            ]
+        )
+        run_script(
+            [
+                str(script_path("write_evaluation_log.py")),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "build",
+                "--result",
+                str(build_result_path),
+            ]
+        )
+        run_script(
+            [
+                str(script_path("validate_weekly_update_plan.py")),
+                "--context",
+                str(context_path),
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(plan_validation_path),
+            ]
+        )
+        plan_validation = read_json(plan_validation_path)
+        if plan_validation.get("valid") is not True:
+            raise RuntimeError("validate_weekly_update_plan.py did not accept the smoke plan")
+        run_script(
+            [
+                str(script_path("write_evaluation_log.py")),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "validate",
+                "--result",
+                str(plan_validation_path),
+            ]
+        )
+        run_script(
+            [
+                str(script_path("apply_weekly_update.py")),
+                "--context",
+                str(context_path),
+                "--plan",
+                str(plan_path),
+                "--dry-run",
+                "--result-output",
+                str(apply_result_path),
+            ]
+        )
+        apply_result = read_json(apply_result_path)
+        if apply_result.get("apply_succeeded") is not True:
+            raise RuntimeError("apply_weekly_update.py did not report success")
+        if apply_result.get("marker_update_written") is not False:
+            raise RuntimeError("apply_weekly_update.py unexpectedly wrote the marker")
+        if apply_result.get("primary_artifact") is not None:
+            raise RuntimeError("apply_weekly_update.py reported an unexpected primary artifact")
+        run_script(
+            [
+                str(script_path("write_evaluation_log.py")),
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "apply",
+                "--result",
+                str(apply_result_path),
+            ]
+        )
+        eval_log = read_json(eval_log_path)
+        if eval_log.get("skill", {}).get("name") != "weekly-update":
+            raise RuntimeError("write_evaluation_log.py did not initialize a weekly-update log")
+        if eval_log.get("skill_specific", {}).get("data", {}).get("estimated_packet_tokens") != packet_metrics.get("estimated_packet_tokens"):
+            raise RuntimeError("Build metrics did not merge into the evaluation log")
+
+        smoke_result = smoke_summary(
+            "ok",
+            None,
+            repo_root,
+            "review_smoke_results",
+            context_id=context.get("context_id"),
+            packet_count=packet_metrics.get("packet_count"),
+            packet_files=packet_files,
+            plan_valid=bool(plan_validation.get("valid")),
+            apply_succeeded=bool(apply_result.get("apply_succeeded")),
+            marker_update_written=bool(apply_result.get("marker_update_written")),
+            estimated_local_only_tokens=packet_metrics.get("estimated_local_only_tokens"),
+            estimated_packet_tokens=packet_metrics.get("estimated_packet_tokens"),
+            estimated_delegation_savings=packet_metrics.get("estimated_delegation_savings"),
+            common_path_sufficient=build_result.get("common_path_sufficient"),
+            raw_reread_count=build_result.get("raw_reread_count"),
+        )
+
+    print(json.dumps(smoke_result, indent=2, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/validate_weekly_update_plan.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/validate_weekly_update_plan.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Validate a synthesized weekly-update plan against the collected context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from weekly_update_lib import load_json, validate_weekly_update_plan, write_json
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--plan", required=True, help="Synthesized weekly update plan JSON.")
+    parser.add_argument("--output", help="Optional machine-readable validation result JSON.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    plan = load_json(Path(args.plan).resolve())
+    result = validate_weekly_update_plan(context, plan)
+    if args.output:
+        write_json(Path(args.output).resolve(), result)
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("valid") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/weekly_update_lib.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/weekly_update_lib.py
@@ -1,0 +1,1820 @@
+﻿#!/usr/bin/env python3
+"""Shared helpers for the weekly-update skill."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlencode
+
+
+def resolve_builder_scripts_dir() -> Path:
+    script_path = Path(__file__).resolve()
+    searched: list[Path] = []
+    seen: set[Path] = set()
+    for base in script_path.parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "scripts",
+            base
+            / ".codex"
+            / "vendor"
+            / "packetflow_foundry"
+            / "builders"
+            / "packet-workflow"
+            / "scripts",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            searched.append(resolved)
+            if resolved.is_dir():
+                return resolved
+    search_list = ", ".join(path.as_posix() for path in searched)
+    raise SystemExit(
+        "[ERROR] Missing packet-workflow builder scripts. "
+        f"Searched: {search_list}"
+    )
+
+
+BUILDER_SCRIPTS_DIR = resolve_builder_scripts_dir()
+if str(BUILDER_SCRIPTS_DIR) not in sys.path:
+    sys.path.append(str(BUILDER_SCRIPTS_DIR))
+
+from packet_workflow_versioning import (  # type: ignore  # noqa: E402
+    classify_builder_compatibility,
+    extract_profile_versioning,
+    extract_skill_builder_versioning,
+    format_runtime_warning,
+    load_builder_versioning,
+    load_json_document,
+)
+
+SKILL_NAME = "weekly-update"
+SKILL_VERSION = "0.1.0"
+WORKFLOW_FAMILY = "repo-audit"
+ARCHETYPE = "plan-validate-apply"
+ORCHESTRATOR_PROFILE = "standard"
+PRIMARY_GOAL = "Produce a concise, evidence-based weekly update from repository and directly related GitHub evidence."
+OUTPUT_SECTIONS = ["PRs", "Rollouts", "Incidents", "Reviews", "Blockers / Risks", "Evidence reviewed"]
+PACKET_NAMES = ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"]
+PACKET_FILES = ["global_packet.json", *(f"{name}.json" for name in PACKET_NAMES)]
+RUNTIME_PACKET_FILES = ["orchestrator.json", *PACKET_FILES]
+DEFAULT_PAGE_SIZE = 100
+MAX_GH_PAGES = 20
+DECISION_READY_PACKETS = True
+WORKER_RETURN_CONTRACT = "classification-oriented"
+WORKER_OUTPUT_SHAPE = "hierarchical"
+AUTHORITY_ORDER = [
+    "published GitHub releases and linked release issues",
+    "merged PR diffs and git history",
+    "directly related review, issue, and workflow-run evidence",
+    "structured workflow packets",
+    "local last-success state as baseline only",
+]
+STOP_CONDITIONS = [
+    "low confidence",
+    "stale snapshot or stale structured context",
+    "GitHub evidence is required but gh auth is invalid",
+    "ambiguous incident versus blocker classification",
+    "missing reporting window baseline when reuse is required",
+]
+REVIEW_MODE_OVERRIDES = [
+    "reporting window includes more than 8 merged PRs or more than 15 relevant issues",
+    "release, incident, and review surfaces are all active in the same window",
+    "nested branch lineage or workflow-run failures materially expand the evidence graph",
+]
+ACTUAL_INCIDENT = "actual_incident"
+BLOCKER_OR_RISK = "blocker_or_risk"
+ARTIFACT_ONLY = "artifact_only"
+IGNORE = "ignore"
+PROPOSED_CLASSIFICATIONS = [ACTUAL_INCIDENT, BLOCKER_OR_RISK, ARTIFACT_ONLY, IGNORE]
+CONFIDENCE_VALUES = ["high", "medium", "low"]
+RAW_REREAD_REASONS = [
+    "conflicting_signals",
+    "missing_failure_evidence",
+    "missing_materiality_evidence",
+    "schema_mismatch",
+    "insufficient_excerpt_quality",
+]
+COMMON_PATH_CONTRACT = {
+    "local_adjudication_basis": [
+        "global_packet.json",
+        "mapping_packet.json",
+        "one focused packet needed for the current decision",
+    ],
+    "raw_reread_exception_reasons": RAW_REREAD_REASONS,
+    "regression_rule": "Canonical common path should not require broad raw rereads.",
+}
+PACKET_METRIC_FIELDS = [
+    "packet_count",
+    "packet_size_bytes",
+    "largest_packet_bytes",
+    "largest_two_packets_bytes",
+    "estimated_local_only_tokens",
+    "estimated_packet_tokens",
+    "estimated_delegation_savings",
+]
+CANDIDATE_REQUIRED_FIELDS = [
+    "candidate_id",
+    "source_type",
+    "source_id",
+    "title",
+    "summary",
+    "proposed_classification",
+    "classification_rationale",
+    "materiality_evidence",
+    "concrete_failure_evidence",
+    "open_ambiguity",
+    "confidence",
+    "source_refs",
+    "excerpt_bundle",
+    "raw_reread_reason",
+    "packet_membership",
+    "risk",
+    "recommended_next_step",
+    "tests_or_checks",
+]
+WORKER_FOOTER_FIELDS = [
+    "packet_ids",
+    "candidate_ids",
+    "primary_outcome",
+    "overall_confidence",
+    "coverage_gaps",
+    "overall_risk",
+]
+PLAN_REQUIRED_FIELDS = [
+    "context_id",
+    "context_fingerprint",
+    "overall_confidence",
+    "stop_reasons",
+    "allow_marker_update",
+    "sections",
+]
+PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["repo_mapper", "docs_verifier"],
+    "candidate_producers": ["evidence_summarizer", "large_diff_auditor", "log_triager"],
+    "verifiers": ["docs_verifier"],
+}
+PACKET_WORKER_MAP = {
+    "mapping_packet": ["repo_mapper"],
+    "changes_packet": ["large_diff_auditor"],
+    "incidents_packet": ["log_triager"],
+    "risks_packet": ["evidence_summarizer"],
+}
+WORKER_SELECTION_GUIDANCE = {
+    "repo_mapper": "Use for reporting-window grounding, release linkage, PR lineage, candidate inventory, and packet membership checks.",
+    "docs_verifier": "Use only when tracked docs or runbooks are needed to resolve conflicting packet evidence.",
+    "evidence_summarizer": "Use for the most narrative-heavy packet or slice when issues, release notes, or review discussion need adjudication-ready compression.",
+    "large_diff_auditor": "Use for shipped-change, behavior-change, config-change, and review-followup extraction from the changes packet.",
+    "log_triager": "Use for incident, workflow-failure, and blocker-versus-incident evidence in the incidents or risks packet.",
+}
+WORKER_FAMILY_ORDER = ["context_findings", "candidate_producers", "verifiers"]
+DEFAULT_STATE_NAMESPACE = SKILL_NAME
+DEFAULT_REVIEW_ACK_MARKERS = ["phase=ack"]
+DEFAULT_REVIEW_COMPLETE_MARKERS = ["phase=complete"]
+DEFAULT_RELEASE_TITLE_REGEX = r"^\[Release\]\s*(?P<tag>v[0-9A-Za-z._-]+)"
+DEFAULT_PRIORITY_MARKERS_REGEX = r"\[(?:P[0-3]|medium|high|low)\]"
+CANDIDATE_FIELD_BUNDLES = [
+    {
+        "name": "identity",
+        "description": "Stable candidate identity and source information.",
+        "required": True,
+        "fields": ["candidate_id", "source_type", "source_id", "title"],
+    },
+    {
+        "name": "proposal",
+        "description": "Proposal-grade summary and classification rationale for local adjudication.",
+        "required": True,
+        "fields": ["summary", "proposed_classification", "classification_rationale"],
+    },
+    {
+        "name": "evidence",
+        "description": "Decision-ready supporting evidence, references, and excerpt bundle.",
+        "required": True,
+        "fields": ["materiality_evidence", "concrete_failure_evidence", "source_refs", "excerpt_bundle"],
+    },
+    {
+        "name": "adjudication",
+        "description": "Ambiguity, confidence, reread control, and packet membership for local xHigh adjudication.",
+        "required": True,
+        "fields": ["open_ambiguity", "confidence", "raw_reread_reason", "packet_membership"],
+    },
+    {
+        "name": "follow_up",
+        "description": "Candidate-local risk, next step, and checks.",
+        "required": True,
+        "fields": ["risk", "recommended_next_step", "tests_or_checks"],
+    },
+]
+DOMAIN_OVERLAY = {
+    "proposal_enum_values": PROPOSED_CLASSIFICATIONS,
+    "reference_only_candidate_values": [ARTIFACT_ONLY],
+    "output_inclusion_rules": {
+        "standalone": [ACTUAL_INCIDENT, BLOCKER_OR_RISK],
+        "reference_only": [ARTIFACT_ONLY],
+        "excluded": [IGNORE],
+    },
+}
+FAILED_WORKFLOW_CONCLUSIONS = {"action_required", "failure", "startup_failure", "timed_out"}
+NEUTRAL_WORKFLOW_CONCLUSIONS = {"", "cancelled", "neutral", "skipped", "success"}
+TITLE_PREFIX_RE = re.compile(r"^\[(?P<prefix>[^\]]+)\]\s*")
+DEFAULT_RELEASE_TITLE_RE = re.compile(DEFAULT_RELEASE_TITLE_REGEX)
+HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+BULLET_RE = re.compile(r"^\s*-\s+(?P<value>.+?)\s*$", re.MULTILINE)
+ISSUE_REF_RE = re.compile(r"(?<![A-Za-z0-9])#(?P<number>\d+)\b")
+DEFAULT_REVIEW_ACK_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE) for pattern in DEFAULT_REVIEW_ACK_MARKERS
+]
+DEFAULT_REVIEW_COMPLETE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE) for pattern in DEFAULT_REVIEW_COMPLETE_MARKERS
+]
+DEFAULT_PRIORITY_MARKER_RE = re.compile(DEFAULT_PRIORITY_MARKERS_REGEX, re.IGNORECASE)
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]+\)")
+MARKDOWN_CODE_RE = re.compile(r"`([^`]+)`")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+WHITESPACE_RE = re.compile(r"\s+")
+CONCRETE_FAILURE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"\banomaly\b",
+        r"\bblocked\b",
+        r"\bbroken\b",
+        r"\bcrash(?:ed|es)?\b",
+        r"\berror\b",
+        r"\bfail(?:ed|s|ure)?\b",
+        r"\bincorrect\b",
+        r"\bregression\b",
+        r"\brepro(?:duced|ducible|duce)?\b",
+        r"\bstall(?:ed|ing)?\b",
+        r"\bstuck\b",
+        r"\bwrong\b",
+    ]
+]
+STRONG_EVIDENCE_FAILURE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [r"\bactive distress\b", r"\berror\b", r"\bfail(?:ed|s|ure)?\b", r"\bregression\b"]
+]
+PLANNING_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [r"\bnext steps\b", r"\bpending\b", r"\bwaiting for\b", r"\bcomparison summary\b"]
+]
+GENERIC_REVIEW_NOISE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [r"^summary by codex", r"^automated review", r"^useful\?\s+react with"]
+]
+GATE_IMPACT_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [r"\bblock(?:er|ing)?\b", r"\bbefore merge\b", r"\bbreak(?:s|ing)?\b", r"\bfail(?:ed|s|ure)?\b", r"\brelease gate\b", r"\bregression\b", r"\bwrong\b"]
+]
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_iso8601(value: str | None) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=parsed.tzinfo or timezone.utc).astimezone(timezone.utc)
+
+
+def isoformat_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def run_command(args: list[str], cwd: Path, *, check: bool = True) -> str:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"{args[0]} not found") from exc
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"{args[0]} failed"
+        raise RuntimeError(detail)
+    return result.stdout
+
+
+def run_git(repo_root: Path, args: list[str], *, check: bool = True) -> str:
+    return run_command(["git", *args], repo_root, check=check)
+
+
+def run_gh_json(repo_root: Path, args: list[str]) -> Any:
+    text = run_command(["gh", *args], repo_root).strip()
+    return json.loads(text) if text else {}
+
+
+def build_api_path(endpoint: str, params: dict[str, Any] | None = None) -> str:
+    query = urlencode({key: value for key, value in (params or {}).items() if value is not None}, doseq=True)
+    return f"{endpoint}?{query}" if query else endpoint
+
+
+def truncation_gap(label: str, *, max_pages: int = MAX_GH_PAGES) -> str:
+    return f"{label} may be truncated after {max_pages} pages."
+
+
+def page_stop_on_last_timestamp(page_items: list[dict[str, Any]], *, key: str, window_start: datetime) -> bool:
+    if not page_items:
+        return True
+    last_value = str(page_items[-1].get(key) or "")
+    last_timestamp = parse_iso8601(last_value)
+    return bool(last_timestamp and last_timestamp < window_start)
+
+
+def paginate_gh_api(
+    repo_root: Path,
+    endpoint: str,
+    *,
+    params: dict[str, Any] | None = None,
+    collection_key: str | None = None,
+    max_pages: int = MAX_GH_PAGES,
+    stop_when: Any | None = None,
+    label: str | None = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    items: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    base_params = {"per_page": DEFAULT_PAGE_SIZE}
+    base_params.update(params or {})
+    truncated = False
+    for page in range(1, max_pages + 1):
+        payload = run_gh_json(repo_root, ["api", build_api_path(endpoint, {**base_params, "page": page})])
+        page_items = payload.get(collection_key) if collection_key and isinstance(payload, dict) else payload
+        if not isinstance(page_items, list) or not page_items:
+            break
+        items.extend(page_items)
+        if stop_when and stop_when(page_items):
+            break
+        if len(page_items) < int(base_params["per_page"]):
+            break
+        if page == max_pages:
+            truncated = True
+    if truncated:
+        warnings.append(truncation_gap(label or endpoint, max_pages=max_pages))
+    return items, warnings
+
+
+def resolve_repo_root(repo_root: str) -> Path:
+    requested = Path(repo_root).resolve()
+    if not requested.exists():
+        raise SystemExit(f"[ERROR] Missing repo root: {requested}")
+    return Path(run_git(requested, ["rev-parse", "--show-toplevel"]).strip()).resolve()
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / "default" / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.is_file():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None = None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.exists():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise SystemExit(f"[ERROR] Missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict[str, Any]:
+    payload = load_json(path)
+    if not isinstance(payload, dict):
+        raise SystemExit("[ERROR] Repo profile must be a JSON object.")
+    return payload
+
+
+def build_builder_compatibility(repo_profile: dict[str, Any]) -> dict[str, Any]:
+    return classify_builder_compatibility(
+        current_builder=load_builder_versioning(),
+        skill_versioning=extract_skill_builder_versioning(
+            load_json_document(skill_root() / "builder-spec.json")
+        ),
+        profile_versioning=extract_profile_versioning(repo_profile),
+    )
+
+
+def compute_repo_hash(repo_root: Path) -> str:
+    return hashlib.sha256(str(repo_root).lower().encode("utf-8")).hexdigest()[:16]
+
+
+def default_state_file(repo_hash: str, *, namespace: str = DEFAULT_STATE_NAMESPACE) -> Path:
+    home = Path(os.environ.get("USERPROFILE") or Path.home())
+    safe_namespace = str(namespace or DEFAULT_STATE_NAMESPACE).strip() or DEFAULT_STATE_NAMESPACE
+    return home / ".codex" / "state" / safe_namespace / f"{repo_hash}.json"
+
+
+def weekly_update_profile_data(repo_profile: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(repo_profile, dict):
+        return {}
+    extra = repo_profile.get("extra")
+    if not isinstance(extra, dict):
+        return {}
+    payload = extra.get("weekly_update")
+    return dict(payload) if isinstance(payload, dict) else {}
+
+
+def string_list_or_default(value: Any, default: list[str]) -> list[str]:
+    if not isinstance(value, list):
+        return list(default)
+    normalized = [str(item).strip() for item in value if str(item).strip()]
+    return normalized or list(default)
+
+
+def weekly_update_runtime_settings(repo_profile: dict[str, Any] | None) -> dict[str, Any]:
+    payload = weekly_update_profile_data(repo_profile)
+    review_markers = payload.get("review_markers")
+    review_markers = review_markers if isinstance(review_markers, dict) else {}
+    release_issue = payload.get("release_issue")
+    release_issue = release_issue if isinstance(release_issue, dict) else {}
+    priority_markers = payload.get("priority_markers")
+    priority_markers = priority_markers if isinstance(priority_markers, dict) else {}
+    state = payload.get("state")
+    state = state if isinstance(state, dict) else {}
+    release_title_regex = str(
+        release_issue.get("title_regex") or DEFAULT_RELEASE_TITLE_REGEX
+    ).strip() or DEFAULT_RELEASE_TITLE_REGEX
+    priority_markers_regex = str(
+        priority_markers.get("regex") or DEFAULT_PRIORITY_MARKERS_REGEX
+    ).strip() or DEFAULT_PRIORITY_MARKERS_REGEX
+    ack_markers = string_list_or_default(
+        review_markers.get("acknowledged"), DEFAULT_REVIEW_ACK_MARKERS
+    )
+    resolved_markers = string_list_or_default(
+        review_markers.get("resolved"), DEFAULT_REVIEW_COMPLETE_MARKERS
+    )
+    state_namespace = str(
+        state.get("namespace") or DEFAULT_STATE_NAMESPACE
+    ).strip() or DEFAULT_STATE_NAMESPACE
+    return {
+        "state_namespace": state_namespace,
+        "release_title_regex": release_title_regex,
+        "release_title_re": re.compile(release_title_regex),
+        "review_ack_markers": ack_markers,
+        "review_ack_patterns": [
+            re.compile(pattern, re.IGNORECASE) for pattern in ack_markers
+        ],
+        "review_complete_markers": resolved_markers,
+        "review_complete_patterns": [
+            re.compile(pattern, re.IGNORECASE) for pattern in resolved_markers
+        ],
+        "priority_markers_regex": priority_markers_regex,
+        "priority_marker_re": re.compile(priority_markers_regex, re.IGNORECASE),
+    }
+
+
+def load_state_marker(state_file: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    if not state_file.exists():
+        return None, []
+    try:
+        payload = load_json(state_file)
+    except Exception as exc:  # noqa: BLE001
+        return None, [f"State marker is unreadable: {exc}"]
+    if not payload.get("window_end_utc") and not payload.get("completed_at_utc"):
+        return None, ["State marker is missing `window_end_utc` and `completed_at_utc`."]
+    return payload, []
+
+
+def select_reporting_window(*, now_utc: datetime, window_days: int, state_marker: dict[str, Any] | None) -> dict[str, Any]:
+    marker_end = parse_iso8601(str((state_marker or {}).get("window_end_utc") or (state_marker or {}).get("completed_at_utc") or ""))
+    if marker_end is not None and marker_end < now_utc:
+        start_utc = marker_end
+        source = "state_marker"
+        marker_reused = True
+    else:
+        start_utc = now_utc - timedelta(days=window_days)
+        source = "last_7_days" if window_days == 7 else "explicit_window_days"
+        marker_reused = False
+    return {
+        "start_utc": isoformat_utc(start_utc),
+        "end_utc": isoformat_utc(now_utc),
+        "source": source,
+        "window_days": window_days,
+        "marker_reused": marker_reused,
+        "span_hours": round((now_utc - start_utc).total_seconds() / 3600, 2),
+    }
+
+
+def sha256_json(payload: dict[str, Any]) -> str:
+    normalized = json.dumps(payload, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def json_bytes(payload: Any) -> int:
+    return len(json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+
+
+def estimate_tokens_from_bytes(byte_count: int) -> int:
+    if byte_count <= 0:
+        return 0
+    return max(1, int(round(byte_count / 4.0)))
+
+
+def normalize_text(text: str) -> str:
+    cleaned = MARKDOWN_IMAGE_RE.sub(" ", text or "")
+    cleaned = MARKDOWN_LINK_RE.sub(r"\1", cleaned)
+    cleaned = MARKDOWN_CODE_RE.sub(r"\1", cleaned)
+    cleaned = HTML_TAG_RE.sub(" ", cleaned)
+    return WHITESPACE_RE.sub(" ", cleaned).strip()
+
+
+def first_meaningful_line(text: str) -> str:
+    for raw_line in (text or "").splitlines():
+        line = normalize_text(raw_line).strip(" -*")
+        if line and not line.lower().startswith("useful? react with"):
+            return line
+    return ""
+
+
+def short_markdown_summary(text: str, *, fallback: str, limit: int = 220) -> str:
+    candidate = first_meaningful_line(text) or normalize_text(text) or fallback
+    return candidate if len(candidate) <= limit else candidate[: limit - 3].rstrip() + "..."
+
+
+def normalized_timestamp(value: Any) -> str:
+    parsed = parse_iso8601(str(value or ""))
+    return isoformat_utc(parsed) if parsed is not None else str(value or "")
+
+
+def stable_unique(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        value = str(item or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def empty_plan_sections() -> dict[str, list[Any]]:
+    return {section: [] for section in OUTPUT_SECTIONS}
+
+
+def extract_markdown_sections(markdown: str) -> dict[str, str]:
+    matches = list(HEADING_RE.finditer(markdown or ""))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(markdown)
+        sections[match.group(1).strip().lower()] = markdown[start:end].strip()
+    return sections
+
+
+def extract_section_bullets(markdown: str, headings: Iterable[str]) -> list[str]:
+    sections = extract_markdown_sections(markdown)
+    bullets: list[str] = []
+    for heading in headings:
+        section = sections.get(heading.strip().lower(), "")
+        bullets.extend(normalize_text(match.group("value")) for match in BULLET_RE.finditer(section))
+    return [bullet for bullet in bullets if bullet]
+
+
+def extract_issue_numbers_from_text(text: str) -> list[int]:
+    return sorted({int(match.group("number")) for match in ISSUE_REF_RE.finditer(text or "")})
+
+
+def classify_changed_paths(paths: Iterable[str]) -> dict[str, list[str]]:
+    groups = {"runtime": [], "automation": [], "docs": [], "tests": [], "config": [], "other": []}
+    for raw_path in paths:
+        path = str(raw_path).replace("\\", "/").strip()
+        lower = path.lower()
+        if not path:
+            continue
+        if "/tests/" in lower or lower.endswith(("_test.py", ".tests.cs", ".spec.ts")):
+            groups["tests"].append(path)
+        elif lower.startswith(".github/scripts/") or lower.startswith(".github/workflows/"):
+            groups["automation"].append(path)
+        elif lower.endswith(".md"):
+            groups["docs"].append(path)
+        elif lower.endswith((".json", ".toml", ".xml", ".yml", ".yaml", ".csproj", ".props", ".targets")):
+            groups["config"].append(path)
+        elif lower.endswith((".cs", ".py", ".js", ".ts", ".tsx", ".jsx", ".go", ".rs", ".java")):
+            groups["runtime"].append(path)
+        else:
+            groups["other"].append(path)
+    return groups
+
+
+def title_prefix(title: str) -> str:
+    match = TITLE_PREFIX_RE.match(title.strip())
+    return match.group("prefix").strip().lower() if match else ""
+
+
+def extract_release_tag(
+    title: str, *, release_title_re: re.Pattern[str] | None = None
+) -> str | None:
+    match = (release_title_re or DEFAULT_RELEASE_TITLE_RE).match(title.strip())
+    return match.group("tag") if match else None
+
+
+def label_names(issue: dict[str, Any]) -> list[str]:
+    labels = issue.get("labels") or []
+    values: list[str] = []
+    for label in labels:
+        raw = label if isinstance(label, str) else label.get("name")
+        value = str(raw or "").strip().lower()
+        if value:
+            values.append(value)
+    return sorted(set(values))
+
+
+def window_contains(raw_timestamp: str | None, window_start: datetime, window_end: datetime) -> bool:
+    parsed = parse_iso8601(raw_timestamp)
+    return bool(parsed and window_start <= parsed <= window_end)
+
+
+def compute_materiality_reasons(
+    item: dict[str, Any],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    created_key: str = "createdAt",
+    updated_key: str = "updatedAt",
+    merged_key: str | None = None,
+    linked_from_pr: bool = False,
+    matched_release: bool = False,
+) -> list[str]:
+    reasons: list[str] = []
+    if window_contains(str(item.get(created_key) or ""), window_start, window_end):
+        reasons.append("created_in_window")
+    if window_contains(str(item.get(updated_key) or ""), window_start, window_end):
+        reasons.append("updated_in_window")
+    if merged_key and window_contains(str(item.get(merged_key) or ""), window_start, window_end):
+        reasons.append("merged_in_window")
+    if linked_from_pr:
+        reasons.append("linked_from_top_level_pr")
+    if matched_release:
+        reasons.append("matched_active_release")
+    return reasons
+
+
+def has_any_pattern(text: str, patterns: Iterable[re.Pattern[str]]) -> bool:
+    normalized = normalize_text(text).lower()
+    return any(pattern.search(normalized) for pattern in patterns)
+
+
+def canonical_ref(kind: str, ref: str, url: str | None = None) -> dict[str, str]:
+    payload = {"kind": kind, "ref": ref}
+    if url:
+        payload["url"] = url
+    return payload
+
+
+def make_excerpt(text: str | None, *, source_ref: str, source_type: str, why_selected: str) -> dict[str, str] | None:
+    normalized = normalize_text(text or "")
+    if not normalized:
+        return None
+    return {"text": normalized, "source_ref": source_ref, "source_type": source_type, "why_selected": why_selected}
+
+
+def excerpt_bundle(*, failure_text: str | None, materiality_text: str | None, ambiguity_text: str | None, source_ref: str, source_type: str) -> dict[str, Any]:
+    return {
+        "failure_excerpt": make_excerpt(failure_text, source_ref=source_ref, source_type=source_type, why_selected="Most direct failure or regression excerpt."),
+        "materiality_excerpt": make_excerpt(materiality_text, source_ref=source_ref, source_type=source_type, why_selected="Most direct weekly materiality excerpt."),
+        "ambiguity_excerpt": make_excerpt(ambiguity_text, source_ref=source_ref, source_type=source_type, why_selected="Most direct remaining ambiguity excerpt."),
+    }
+
+
+def confidence_from_signals(*, materiality_present: bool, failure_present: bool, raw_reread_reason: str | None, open_ambiguity: str) -> str:
+    if raw_reread_reason:
+        return "low"
+    if materiality_present and (failure_present or not open_ambiguity.strip()):
+        return "high"
+    if materiality_present:
+        return "medium"
+    return "low"
+
+
+def metadata_excerpt(created_at: str | None, updated_at: str | None, merged_at: str | None = None) -> str:
+    parts: list[str] = []
+    if merged_at:
+        parts.append(f"Merged at {merged_at}.")
+    if created_at:
+        parts.append(f"Created at {created_at}.")
+    if updated_at and updated_at != created_at:
+        parts.append(f"Updated at {updated_at}.")
+    return " ".join(parts)
+
+
+def verify_gh_auth(repo_root: Path) -> None:
+    try:
+        run_command(["gh", "auth", "status"], repo_root)
+    except RuntimeError as exc:
+        raise SystemExit(f"[ERROR] GitHub evidence is required but gh auth is invalid: {exc}") from exc
+
+
+def get_repo_metadata(repo_root: Path) -> dict[str, str]:
+    payload = run_gh_json(repo_root, ["repo", "view", "--json", "nameWithOwner,defaultBranchRef,url"])
+    repo_slug = str(payload.get("nameWithOwner") or "").strip()
+    default_branch = str((payload.get("defaultBranchRef") or {}).get("name") or "").strip()
+    repo_url = str(payload.get("url") or "").strip()
+    if not repo_slug or not default_branch:
+        raise SystemExit("[ERROR] Unable to resolve repository slug or default branch from gh.")
+    return {"repo_slug": repo_slug, "default_branch": default_branch, "repo_url": repo_url}
+
+
+def get_branch_state(repo_root: Path) -> dict[str, str]:
+    return {
+        "current_branch": run_git(repo_root, ["rev-parse", "--abbrev-ref", "HEAD"]).strip(),
+        "head_sha": run_git(repo_root, ["rev-parse", "HEAD"]).strip(),
+    }
+
+
+def list_releases(repo_root: Path, repo_slug: str, *, window_start: datetime, window_end: datetime) -> tuple[list[dict[str, Any]], list[str]]:
+    payload, warnings = paginate_gh_api(
+        repo_root,
+        f"repos/{repo_slug}/releases",
+        stop_when=lambda page_items: page_stop_on_last_timestamp(page_items, key="published_at", window_start=window_start),
+        label="releases",
+    )
+    releases: list[dict[str, Any]] = []
+    for item in payload if isinstance(payload, list) else []:
+        if item.get("draft") or not item.get("published_at"):
+            continue
+        published_at = parse_iso8601(str(item.get("published_at") or ""))
+        if published_at and window_start <= published_at <= window_end:
+            releases.append({
+                "tag_name": str(item.get("tag_name") or ""),
+                "name": str(item.get("name") or ""),
+                "url": str(item.get("html_url") or ""),
+                "published_at": isoformat_utc(published_at),
+                "body": str(item.get("body") or ""),
+            })
+    return sorted(releases, key=lambda item: item["published_at"]), warnings
+
+
+def list_issues(repo_root: Path, repo_slug: str) -> tuple[list[dict[str, Any]], list[str]]:
+    payload, warnings = paginate_gh_api(
+        repo_root,
+        f"repos/{repo_slug}/issues",
+        params={"state": "all", "sort": "updated", "direction": "desc"},
+        label="issues",
+    )
+    issues: list[dict[str, Any]] = []
+    for item in payload if isinstance(payload, list) else []:
+        if item.get("pull_request"):
+            continue
+        issues.append({
+            "number": int(item.get("number") or 0),
+            "title": str(item.get("title") or ""),
+            "url": str(item.get("html_url") or item.get("url") or ""),
+            "state": str(item.get("state") or "").upper(),
+            "labels": item.get("labels") or [],
+            "createdAt": normalized_timestamp(item.get("created_at")),
+            "updatedAt": normalized_timestamp(item.get("updated_at")),
+            "body": str(item.get("body") or ""),
+        })
+    return issues, warnings
+
+
+def list_merged_pr_summaries(repo_root: Path, repo_slug: str, *, window_start: datetime, window_end: datetime) -> tuple[list[dict[str, Any]], list[str]]:
+    payload, warnings = paginate_gh_api(
+        repo_root,
+        f"repos/{repo_slug}/pulls",
+        params={"state": "closed", "sort": "updated", "direction": "desc"},
+        stop_when=lambda page_items: page_stop_on_last_timestamp(page_items, key="updated_at", window_start=window_start),
+        label="merged PR summaries",
+    )
+    prs: list[dict[str, Any]] = []
+    for item in payload if isinstance(payload, list) else []:
+        merged_at = parse_iso8601(str(item.get("merged_at") or ""))
+        if merged_at and window_start <= merged_at <= window_end:
+            prs.append({
+                "number": int(item.get("number") or 0),
+                "title": str(item.get("title") or ""),
+                "url": str(item.get("html_url") or item.get("url") or ""),
+                "mergedAt": isoformat_utc(merged_at),
+                "baseRefName": str((item.get("base") or {}).get("ref") or ""),
+                "headRefName": str((item.get("head") or {}).get("ref") or ""),
+            })
+    return sorted(prs, key=lambda item: str(item.get("mergedAt") or "")), warnings
+
+
+def fetch_pr_detail(repo_root: Path, repo_slug: str, pr_number: int) -> tuple[dict[str, Any], list[str]]:
+    pr = run_gh_json(repo_root, ["api", f"repos/{repo_slug}/pulls/{pr_number}"])
+    files, warnings = paginate_gh_api(
+        repo_root,
+        f"repos/{repo_slug}/pulls/{pr_number}/files",
+        label=f"PR #{pr_number} files",
+    )
+    body = str(pr.get("body") or "")
+    paths = [str(file_item.get("filename") or "") for file_item in (files if isinstance(files, list) else [])]
+    return {
+        "number": int(pr.get("number") or pr_number),
+        "title": str(pr.get("title") or ""),
+        "url": str(pr.get("html_url") or ""),
+        "body": body,
+        "base_ref_name": str((pr.get("base") or {}).get("ref") or ""),
+        "head_ref_name": str((pr.get("head") or {}).get("ref") or ""),
+        "merged_at": normalized_timestamp(pr.get("merged_at")),
+        "merge_commit_sha": str(pr.get("merge_commit_sha") or ""),
+        "head_sha": str((pr.get("head") or {}).get("sha") or ""),
+        "linked_issue_numbers": extract_issue_numbers_from_text(body),
+        "files": [{"path": path} for path in paths if path],
+        "changed_file_groups": classify_changed_paths(paths),
+        "shipped_change_bullets": extract_section_bullets(body, ["What changed", "Change summary"]) or [short_markdown_summary(body, fallback=str(pr.get("title") or ""))],
+        "risk_bullets": extract_section_bullets(body, ["Risk / Rollback", "Risk", "Risks"]),
+        "validation_bullets": extract_section_bullets(body, ["Validation", "Testing"]),
+    }, warnings
+
+
+def fetch_review_comments(repo_root: Path, repo_slug: str, pr_number: int) -> tuple[list[dict[str, Any]], list[str]]:
+    payload, warnings = paginate_gh_api(
+        repo_root,
+        f"repos/{repo_slug}/pulls/{pr_number}/comments",
+        label=f"PR #{pr_number} review comments",
+    )
+    comments: list[dict[str, Any]] = []
+    for item in payload if isinstance(payload, list) else []:
+        comments.append({
+            "id": int(item.get("id") or 0),
+            "body": str(item.get("body") or ""),
+            "created_at": normalized_timestamp(item.get("created_at")),
+            "updated_at": normalized_timestamp(item.get("updated_at")),
+            "in_reply_to_id": item.get("in_reply_to_id"),
+            "path": item.get("path"),
+            "html_url": str(item.get("html_url") or item.get("url") or ""),
+            "user": item.get("user") or {},
+        })
+    return comments, warnings
+
+
+def list_workflow_runs(repo_root: Path, repo_slug: str, *, window_start: datetime, window_end: datetime) -> tuple[list[dict[str, Any]], list[str]]:
+    payload, warnings = paginate_gh_api(
+        repo_root,
+        f"repos/{repo_slug}/actions/runs",
+        collection_key="workflow_runs",
+        label="workflow runs",
+    )
+    runs: list[dict[str, Any]] = []
+    for item in payload if isinstance(payload, list) else []:
+        created_at = normalized_timestamp(item.get("created_at"))
+        updated_at = normalized_timestamp(item.get("updated_at"))
+        if window_contains(created_at, window_start, window_end) or window_contains(updated_at, window_start, window_end):
+            runs.append({
+                "databaseId": int(item.get("id") or item.get("database_id") or 0),
+                "workflowName": str(item.get("name") or item.get("display_title") or ""),
+                "status": str(item.get("status") or ""),
+                "conclusion": str(item.get("conclusion") or ""),
+                "event": str(item.get("event") or ""),
+                "headBranch": str(item.get("head_branch") or ""),
+                "headSha": str(item.get("head_sha") or ""),
+                "createdAt": created_at,
+                "updatedAt": updated_at,
+                "url": str(item.get("html_url") or item.get("url") or ""),
+            })
+    return runs, warnings
+
+
+def split_top_level_prs(merged_prs: list[dict[str, Any]], default_branch: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    top_level, nested = [], []
+    for pr in merged_prs:
+        (top_level if str(pr.get("base_ref_name") or pr.get("baseRefName") or "") == default_branch else nested).append(pr)
+    return top_level, nested
+
+
+def build_pr_lineage(merged_prs: list[dict[str, Any]], default_branch: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    ordered = sorted(merged_prs, key=lambda item: str(item.get("merged_at") or item.get("mergedAt") or ""))
+    top_level, nested = split_top_level_prs(ordered, default_branch)
+    parent_by_child: dict[int, int] = {}
+    by_number = {int(pr["number"]): pr for pr in ordered}
+    for pr in nested:
+        base_ref = str(pr.get("base_ref_name") or pr.get("baseRefName") or "")
+        merged_at = str(pr.get("merged_at") or pr.get("mergedAt") or "")
+        parent = next((candidate for candidate in ordered if int(candidate["number"]) != int(pr["number"]) and str(candidate.get("head_ref_name") or candidate.get("headRefName") or "") == base_ref and str(candidate.get("merged_at") or candidate.get("mergedAt") or "") > merged_at), None)
+        if parent is not None:
+            parent_by_child[int(pr["number"])] = int(parent["number"])
+    lineage: dict[str, dict[str, Any]] = {}
+    absorbed: dict[int, list[int]] = {}
+    for pr in nested:
+        number = int(pr["number"])
+        chain: list[int] = []
+        current = number
+        while current in parent_by_child and parent_by_child[current] not in chain:
+            current = parent_by_child[current]
+            chain.append(current)
+        root = current if str(by_number.get(current, {}).get("base_ref_name") or by_number.get(current, {}).get("baseRefName") or "") == default_branch else None
+        lineage[str(number)] = {"candidate_pr": number, "absorbed_by": parent_by_child.get(number), "root_top_level_pr": root, "chain": chain}
+        if root is not None:
+            absorbed.setdefault(root, []).append(number)
+    top_level = [{**pr, "absorbed_nested_pr_numbers": sorted(absorbed.get(int(pr["number"]), []))} for pr in top_level]
+    return top_level, nested, lineage
+
+
+def build_issue_linkage_set(prs: Iterable[dict[str, Any]]) -> set[int]:
+    linked: set[int] = set()
+    for pr in prs:
+        linked.update(int(number) for number in pr.get("linked_issue_numbers") or [])
+    return linked
+
+
+def link_releases_to_issues(
+    releases: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+    *,
+    release_title_re: re.Pattern[str] | None = None,
+) -> dict[str, list[int]]:
+    lookup: dict[str, list[int]] = {}
+    for issue in issues:
+        tag = extract_release_tag(
+            str(issue.get("title") or ""), release_title_re=release_title_re
+        )
+        if tag:
+            lookup.setdefault(tag, []).append(int(issue["number"]))
+    return {release["tag_name"]: sorted(lookup.get(release["tag_name"], [])) for release in releases}
+
+
+def classify_issue(
+    issue: dict[str, Any],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    linked_issue_numbers: set[int],
+    active_release_tags: set[str],
+    release_title_re: re.Pattern[str] | None = None,
+) -> dict[str, Any]:
+    number = int(issue.get("number"))
+    title = str(issue.get("title") or "").strip()
+    body = str(issue.get("body") or "")
+    labels = label_names(issue)
+    prefix = title_prefix(title)
+    matched_release_tag = extract_release_tag(title, release_title_re=release_title_re)
+    materiality_reasons = compute_materiality_reasons(issue, window_start=window_start, window_end=window_end, linked_from_pr=number in linked_issue_numbers, matched_release=matched_release_tag in active_release_tags if matched_release_tag else False)
+    weekly_material = bool(materiality_reasons)
+    concrete_failure = has_any_pattern(f"{title}\n{body}", CONCRETE_FAILURE_PATTERNS)
+    normalized_issue_text = normalize_text(f"{title}\n{body}").lower()
+    if any(token in normalized_issue_text for token in ("no reproduced signal yet", "no failure signal", "not reproduced yet")):
+        concrete_failure = False
+    strong_failure = has_any_pattern(f"{title}\n{body}", STRONG_EVIDENCE_FAILURE_PATTERNS)
+    if any(token in normalized_issue_text for token in ("does not add a new failure signal", "artifact collection only", "reusable but does not add")):
+        strong_failure = False
+    classification = IGNORE
+    rule = "outside_reporting_window"
+    is_release_issue = prefix == "release" or "release" in labels
+    is_bug = prefix == "bug" or "bug" in labels
+    is_investigation = prefix in {"investigation", "software investigation"} or "investigation" in labels
+    is_evidence = prefix in {"software evidence", "raw log"}
+    is_perf = prefix == "performance telemetry" or "performance" in labels
+    is_compatibility = "compatibility" in labels
+    if is_release_issue:
+        classification = BLOCKER_OR_RISK if issue.get("state") == "OPEN" and (weekly_material or matched_release_tag in active_release_tags) else ARTIFACT_ONLY if weekly_material and matched_release_tag in active_release_tags else IGNORE
+        rule = "open_release_issue" if classification == BLOCKER_OR_RISK else "linked_release_issue" if classification == ARTIFACT_ONLY else rule
+    elif is_bug and weekly_material:
+        classification, rule = ACTUAL_INCIDENT, "bug_issue"
+    elif is_investigation:
+        if weekly_material and (concrete_failure or is_compatibility):
+            classification, rule = ACTUAL_INCIDENT, "investigation_with_concrete_failure"
+        elif weekly_material or issue.get("state") == "OPEN":
+            classification, rule = BLOCKER_OR_RISK, "investigation_tracker"
+    elif is_evidence:
+        classification, rule = (ACTUAL_INCIDENT, "evidence_with_failure_signal") if weekly_material and strong_failure else (ARTIFACT_ONLY, "evidence_artifact") if weekly_material else (IGNORE, rule)
+    elif is_perf:
+        classification, rule = (ACTUAL_INCIDENT, "performance_regression") if weekly_material and strong_failure else (ARTIFACT_ONLY, "performance_artifact") if weekly_material else (IGNORE, rule)
+    elif is_compatibility and weekly_material:
+        classification, rule = (ACTUAL_INCIDENT, "compatibility_with_failure_signal") if concrete_failure else (BLOCKER_OR_RISK, "compatibility_tracker")
+    elif weekly_material and any(label in labels for label in ("needs-decision", "needs-repro")):
+        classification, rule = BLOCKER_OR_RISK, "tracking_label"
+    summary = short_markdown_summary(body, fallback=title)
+    rationale_bits = [f"Rule `{rule}` matched."] if classification != IGNORE else []
+    if weekly_material:
+        rationale_bits.append("The issue changed during the reporting window or linked directly to shipped work.")
+    if concrete_failure:
+        rationale_bits.append("The title or body includes concrete failure or repro language.")
+    return {
+        "number": number,
+        "title": title,
+        "url": issue.get("url"),
+        "classification": classification,
+        "classification_rationale": " ".join(rationale_bits),
+        "summary": summary,
+        "materiality_reasons": materiality_reasons,
+        "weekly_material": weekly_material,
+        "concrete_failure": concrete_failure,
+        "matched_release_tag": matched_release_tag,
+        "labels": labels,
+        "rule": rule,
+        "state": str(issue.get("state") or "").upper(),
+    }
+
+
+def is_generic_review_noise(body: str) -> bool:
+    normalized = normalize_text(body)
+    return not normalized or any(pattern.search(normalized.lower()) for pattern in GENERIC_REVIEW_NOISE_PATTERNS)
+
+
+def extract_review_findings(
+    pr_number: int,
+    pr_url: str,
+    review_comments: list[dict[str, Any]],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    review_ack_patterns: list[re.Pattern[str]] | None = None,
+    review_complete_patterns: list[re.Pattern[str]] | None = None,
+    priority_marker_re: re.Pattern[str] | None = None,
+) -> list[dict[str, Any]]:
+    ack_patterns = review_ack_patterns or DEFAULT_REVIEW_ACK_PATTERNS
+    complete_patterns = review_complete_patterns or DEFAULT_REVIEW_COMPLETE_PATTERNS
+    gate_priority_pattern = priority_marker_re or DEFAULT_PRIORITY_MARKER_RE
+    replies_by_root: dict[int, list[dict[str, Any]]] = {}
+    for comment in review_comments:
+        if comment.get("in_reply_to_id") is not None:
+            replies_by_root.setdefault(int(comment["in_reply_to_id"]), []).append(comment)
+    findings: list[dict[str, Any]] = []
+    for comment in review_comments:
+        if comment.get("in_reply_to_id") is not None:
+            continue
+        body = str(comment.get("body") or "").strip()
+        author = str((comment.get("user") or {}).get("login") or comment.get("author") or "").lower()
+        if author.endswith("[bot]") or normalize_text(body).lower() in {"looks good to me.", "lgtm"} or is_generic_review_noise(body):
+            continue
+        materiality_reasons = []
+        created_at = str(comment.get("created_at") or "")
+        updated_at = str(comment.get("updated_at") or "")
+        if window_contains(created_at, window_start, window_end):
+            materiality_reasons.append("review_comment_in_window")
+        if window_contains(updated_at, window_start, window_end) and updated_at != created_at:
+            materiality_reasons.append("review_reply_in_window")
+        if not materiality_reasons:
+            continue
+        replies = replies_by_root.get(int(comment["id"]), [])
+        status = (
+            "resolved"
+            if any(
+                pattern.search(str(reply.get("body") or ""))
+                for reply in replies
+                for pattern in complete_patterns
+            )
+            else "acknowledged"
+            if any(
+                pattern.search(str(reply.get("body") or ""))
+                for reply in replies
+                for pattern in ack_patterns
+            )
+            else "unresolved"
+        )
+        summary = short_markdown_summary(body, fallback=f"Review finding on PR #{pr_number}")
+        findings.append({
+            "id": f"review-pr{pr_number}-comment{comment['id']}",
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "comment_id": int(comment["id"]),
+            "html_url": comment.get("html_url"),
+            "summary": summary,
+            "raw_body": body,
+            "status": status,
+            "gate_impact": bool(gate_priority_pattern.search(body) or has_any_pattern(f"{body}\n{summary}", GATE_IMPACT_PATTERNS)),
+            "materiality_reasons": materiality_reasons,
+            "created_at": created_at,
+            "updated_at": updated_at,
+            "path": comment.get("path"),
+        })
+    return findings
+
+
+def classify_workflow_run(run: dict[str, Any], *, window_start: datetime, window_end: datetime) -> dict[str, Any] | None:
+    conclusion = str(run.get("conclusion") or "").lower()
+    if conclusion in NEUTRAL_WORKFLOW_CONCLUSIONS or conclusion not in FAILED_WORKFLOW_CONCLUSIONS:
+        return None
+    materiality_reasons = compute_materiality_reasons(run, window_start=window_start, window_end=window_end, created_key="createdAt", updated_key="updatedAt")
+    if not materiality_reasons:
+        return None
+    return {"database_id": int(run["databaseId"]), "workflow_name": str(run.get("workflowName") or ""), "summary": f"{run.get('workflowName')} concluded with {conclusion}.", "url": run.get("url"), "created_at": run.get("createdAt"), "updated_at": run.get("updatedAt"), "materiality_reasons": materiality_reasons}
+
+
+def candidate_base(**kwargs: Any) -> dict[str, Any]:
+    candidate = dict(kwargs)
+    for field in CANDIDATE_REQUIRED_FIELDS:
+        candidate.setdefault(field, [] if field in {"materiality_evidence", "concrete_failure_evidence", "source_refs", "packet_membership", "tests_or_checks"} else "" if field in {"summary", "classification_rationale", "open_ambiguity", "risk", "recommended_next_step"} else None)
+    return candidate
+
+
+def build_context_fingerprint(context: dict[str, Any]) -> str:
+    payload = {
+        "repo_slug": context.get("repo_slug"),
+        "default_branch": context.get("default_branch"),
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_weekly_update": weekly_update_profile_data(
+            context.get("repo_profile")
+        ),
+        "reporting_window": context.get("reporting_window"),
+        "release_tags": [release.get("tag_name") for release in context.get("releases", [])],
+        "top_level_pr_numbers": [pr.get("number") for pr in context.get("top_level_prs", [])],
+        "nested_pr_numbers": [pr.get("number") for pr in context.get("nested_prs", [])],
+        "candidate_ids": [candidate.get("candidate_id") for candidate in context.get("candidate_inventory", [])],
+    }
+    return sha256_json(payload)
+
+
+
+
+
+def build_candidate_inventory(context: dict[str, Any], releases: list[dict[str, Any]], top_level_prs: list[dict[str, Any]], issues: list[dict[str, Any]], classified_issues: list[dict[str, Any]], review_findings: list[dict[str, Any]], workflow_failures: list[dict[str, Any]], release_issue_linkage: dict[str, list[int]]) -> list[dict[str, Any]]:
+    issue_lookup = {int(issue["number"]): issue for issue in issues}
+    review_by_pr: dict[int, list[dict[str, Any]]] = {}
+    inventory: list[dict[str, Any]] = []
+    for finding in review_findings:
+        review_by_pr.setdefault(int(finding["pr_number"]), []).append(finding)
+    for release in releases:
+        tag = release["tag_name"]
+        inventory.append(candidate_base(
+            candidate_id=f"release-{tag}", source_type="release", source_id=tag, title=release.get("name") or tag,
+            summary=f"Published release {tag}.", proposed_classification=IGNORE, classification_rationale="Release candidates feed the Rollouts section directly.",
+            materiality_evidence=[f"published_at={release['published_at']}"], concrete_failure_evidence=[], open_ambiguity="", confidence="high",
+            source_refs=[canonical_ref("release", f"release/{tag}", release.get("url"))],
+            excerpt_bundle=excerpt_bundle(failure_text=None, materiality_text=f"Release {tag} was published at {release['published_at']}.", ambiguity_text=None, source_ref=f"release/{tag}", source_type="release"),
+            raw_reread_reason=None, packet_membership=["mapping_packet"], risk="", recommended_next_step="", tests_or_checks=[], section_hint="Rollouts", linked_issue_numbers=release_issue_linkage.get(tag, []),
+        ))
+    for pr in top_level_prs:
+        risk_text = " ".join(pr.get("risk_bullets") or [])
+        review_ids = [finding["id"] for finding in review_by_pr.get(int(pr["number"]), [])]
+        inventory.append(candidate_base(
+            candidate_id=f"pr-{pr['number']}", source_type="pr", source_id=f"#{pr['number']}", title=pr["title"],
+            summary=short_markdown_summary(pr["body"], fallback=pr["title"]), proposed_classification=IGNORE, classification_rationale="Top-level merged PRs feed the PRs section directly.",
+            materiality_evidence=[f"merged_at={pr['merged_at']}", f"base_ref={pr['base_ref_name']}"], concrete_failure_evidence=[], open_ambiguity=risk_text, confidence="high",
+            source_refs=[canonical_ref("pr", f"pr/#{pr['number']}", pr.get("url"))],
+            excerpt_bundle=excerpt_bundle(failure_text=None, materiality_text=f"PR #{pr['number']} merged to {pr['base_ref_name']} at {pr['merged_at']}.", ambiguity_text=risk_text, source_ref=f"pr/#{pr['number']}", source_type="pr"),
+            raw_reread_reason=None, packet_membership=["mapping_packet", "changes_packet"], risk=risk_text, recommended_next_step=(pr.get("risk_bullets") or [""])[0], tests_or_checks=list(pr.get("validation_bullets") or []),
+            section_hint="PRs", shipped_change_bullets=list(pr.get("shipped_change_bullets") or []), review_followups=[], review_candidate_items=review_ids, changed_path_groups=pr.get("changed_file_groups") or {}, absorbed_nested_pr_numbers=list(pr.get("absorbed_nested_pr_numbers") or []),
+        ))
+    for classified in classified_issues:
+        issue = issue_lookup[int(classified["number"])]
+        failure_text = short_markdown_summary(issue.get("body") or "", fallback=classified["title"]) if classified["concrete_failure"] else None
+        ambiguity_text = "Tracker remains open and still affects release or scheduling decisions." if classified["classification"] == BLOCKER_OR_RISK and classified["state"] == "OPEN" else ""
+        raw_reread_reason = "missing_failure_evidence" if classified["classification"] == ACTUAL_INCIDENT and not failure_text else None
+        section_hint = "Incidents" if classified["classification"] == ACTUAL_INCIDENT else "Blockers / Risks" if classified["classification"] == BLOCKER_OR_RISK else "Evidence reviewed" if classified["classification"] == ARTIFACT_ONLY else "Ignore"
+        packet_membership = ["mapping_packet"] + (["incidents_packet"] if classified["classification"] == ACTUAL_INCIDENT else ["risks_packet"] if classified["classification"] in {BLOCKER_OR_RISK, ARTIFACT_ONLY} else [])
+        inventory.append(candidate_base(
+            candidate_id=f"issue-{classified['number']}", source_type="issue", source_id=f"#{classified['number']}", title=classified["title"], summary=classified["summary"],
+            proposed_classification=classified["classification"], classification_rationale=classified["classification_rationale"], materiality_evidence=list(classified["materiality_reasons"]),
+            concrete_failure_evidence=[failure_text] if failure_text else [], open_ambiguity=ambiguity_text,
+            confidence=confidence_from_signals(materiality_present=classified["weekly_material"], failure_present=classified["concrete_failure"], raw_reread_reason=raw_reread_reason, open_ambiguity=ambiguity_text),
+            source_refs=[canonical_ref("issue", f"issue/#{classified['number']}", classified.get("url"))],
+            excerpt_bundle=excerpt_bundle(failure_text=failure_text, materiality_text=metadata_excerpt(issue.get("createdAt"), issue.get("updatedAt")), ambiguity_text=ambiguity_text, source_ref=f"issue/#{classified['number']}", source_type="issue"),
+            raw_reread_reason=raw_reread_reason, packet_membership=packet_membership,
+            risk="Open blocker or release-risk tracker remains active." if classified["classification"] == BLOCKER_OR_RISK else "Incident evidence affected validation or delivery during the week." if classified["classification"] == ACTUAL_INCIDENT else "",
+            recommended_next_step="Resolve or explicitly downgrade the tracker before the next weekly report." if classified["classification"] == BLOCKER_OR_RISK and classified["state"] == "OPEN" else "",
+            tests_or_checks=[], section_hint=section_hint, classification_rule=classified["rule"],
+        ))
+    for finding in review_findings:
+        proposed = BLOCKER_OR_RISK if finding["status"] != "resolved" and finding["gate_impact"] else IGNORE
+        packets = ["mapping_packet", "changes_packet"] + (["risks_packet"] if proposed == BLOCKER_OR_RISK else [])
+        inventory.append(candidate_base(
+            candidate_id=finding["id"], source_type="review_finding", source_id=str(finding["comment_id"]), title=f"PR #{finding['pr_number']} review finding", summary=finding["summary"],
+            proposed_classification=proposed, classification_rationale="Unresolved review finding still carries merge or release-gate risk." if proposed == BLOCKER_OR_RISK else "Review finding is included for Reviews synthesis only.",
+            materiality_evidence=list(finding["materiality_reasons"]), concrete_failure_evidence=[finding["summary"]] if finding["gate_impact"] else [],
+            open_ambiguity="" if finding["status"] == "resolved" else "Review thread is not fully closed.", confidence="high" if finding["gate_impact"] and finding["status"] == "resolved" else "medium",
+            source_refs=[canonical_ref("review", f"review/pr{finding['pr_number']}-comment{finding['comment_id']}", finding.get("html_url")), canonical_ref("pr", f"pr/#{finding['pr_number']}", finding.get("pr_url"))],
+            excerpt_bundle=excerpt_bundle(failure_text=finding["summary"] if finding["gate_impact"] else None, materiality_text=metadata_excerpt(finding.get("created_at"), finding.get("updated_at")), ambiguity_text="" if finding["status"] == "resolved" else "Review thread is not fully closed.", source_ref=f"review/pr{finding['pr_number']}-comment{finding['comment_id']}", source_type="review_finding"),
+            raw_reread_reason=None, packet_membership=packets, risk="Unresolved review finding may still block merge or release." if proposed == BLOCKER_OR_RISK else "",
+            recommended_next_step="Close the thread or document why it is intentionally deferred." if finding["status"] != "resolved" else "", tests_or_checks=[],
+            section_hint="Reviews", review_status=finding["status"], gate_impact=finding["gate_impact"], pr_number=finding["pr_number"],
+        ))
+    for run in workflow_failures:
+        inventory.append(candidate_base(
+            candidate_id=f"run-{run['database_id']}", source_type="workflow_run", source_id=str(run["database_id"]), title=run["workflow_name"], summary=run["summary"],
+            proposed_classification=ACTUAL_INCIDENT, classification_rationale="The workflow run failed during the reporting window and materially affected validation evidence.",
+            materiality_evidence=list(run["materiality_reasons"]), concrete_failure_evidence=[run["summary"]], open_ambiguity="", confidence="high",
+            source_refs=[canonical_ref("run", f"run/{run['database_id']}", run.get("url"))],
+            excerpt_bundle=excerpt_bundle(failure_text=run["summary"], materiality_text=metadata_excerpt(run.get("created_at"), run.get("updated_at")), ambiguity_text=None, source_ref=f"run/{run['database_id']}", source_type="workflow_run"),
+            raw_reread_reason=None, packet_membership=["mapping_packet", "incidents_packet"], risk="Failed workflow run affected validation or release evidence.",
+            recommended_next_step="Confirm remediation or rerun outcome before reusing this evidence.", tests_or_checks=[], section_hint="Incidents",
+        ))
+    return inventory
+
+
+def collect_context(
+    *,
+    repo_root: str,
+    profile: str | None = None,
+    state_file: str | None = None,
+    window_days: int = 7,
+    now_utc: str | None = None,
+) -> dict[str, Any]:
+    repo_path = resolve_repo_root(repo_root)
+    profile_path = resolve_profile_path(profile, repo_root=repo_path)
+    repo_profile = load_repo_profile(profile_path)
+    runtime_settings = weekly_update_runtime_settings(repo_profile)
+    verify_gh_auth(repo_path)
+    repo_meta = get_repo_metadata(repo_path)
+    branch_state = get_branch_state(repo_path)
+    repo_hash = compute_repo_hash(repo_path)
+    resolved_state_file = (
+        Path(state_file).resolve()
+        if state_file
+        else default_state_file(
+            repo_hash, namespace=runtime_settings["state_namespace"]
+        )
+    )
+    marker, marker_warnings = load_state_marker(resolved_state_file)
+    current_now = parse_iso8601(now_utc) or utc_now()
+    reporting_window = select_reporting_window(now_utc=current_now, window_days=window_days, state_marker=marker)
+    window_start = parse_iso8601(reporting_window["start_utc"])
+    window_end = parse_iso8601(reporting_window["end_utc"])
+    assert window_start is not None and window_end is not None
+    source_gaps = list(marker_warnings)
+    releases, release_warnings = list_releases(repo_path, repo_meta["repo_slug"], window_start=window_start, window_end=window_end)
+    issues, issue_warnings = list_issues(repo_path, repo_meta["repo_slug"])
+    pr_summaries, pr_summary_warnings = list_merged_pr_summaries(repo_path, repo_meta["repo_slug"], window_start=window_start, window_end=window_end)
+    source_gaps.extend(release_warnings)
+    source_gaps.extend(issue_warnings)
+    source_gaps.extend(pr_summary_warnings)
+    merged_prs: list[dict[str, Any]] = []
+    for summary in pr_summaries:
+        detail, detail_warnings = fetch_pr_detail(repo_path, repo_meta["repo_slug"], int(summary["number"]))
+        merged_prs.append(detail)
+        source_gaps.extend(detail_warnings)
+    top_level_prs, nested_prs, pr_lineage = build_pr_lineage(merged_prs, repo_meta["default_branch"])
+    release_issue_linkage = link_releases_to_issues(
+        releases,
+        issues,
+        release_title_re=runtime_settings["release_title_re"],
+    )
+    linked_issue_numbers = build_issue_linkage_set(top_level_prs)
+    active_release_tags = {release["tag_name"] for release in releases}
+    classified_issues = [
+        classified
+        for classified in (
+            classify_issue(
+                issue,
+                window_start=window_start,
+                window_end=window_end,
+                linked_issue_numbers=linked_issue_numbers,
+                active_release_tags=active_release_tags,
+                release_title_re=runtime_settings["release_title_re"],
+            )
+            for issue in issues
+        )
+        if classified["classification"] != IGNORE
+    ]
+    review_findings: list[dict[str, Any]] = []
+    for pr in top_level_prs:
+        review_comments, review_warnings = fetch_review_comments(repo_path, repo_meta["repo_slug"], int(pr["number"]))
+        source_gaps.extend(review_warnings)
+        review_findings.extend(
+            extract_review_findings(
+                int(pr["number"]),
+                str(pr.get("url") or ""),
+                review_comments,
+                window_start=window_start,
+                window_end=window_end,
+                review_ack_patterns=runtime_settings["review_ack_patterns"],
+                review_complete_patterns=runtime_settings["review_complete_patterns"],
+                priority_marker_re=runtime_settings["priority_marker_re"],
+            )
+        )
+    workflow_runs, workflow_warnings = list_workflow_runs(repo_path, repo_meta["repo_slug"], window_start=window_start, window_end=window_end)
+    source_gaps.extend(workflow_warnings)
+    workflow_failures = [classified for classified in (classify_workflow_run(run, window_start=window_start, window_end=window_end) for run in workflow_runs) if classified is not None]
+    context = {
+        "skill_name": SKILL_NAME,
+        "skill_version": SKILL_VERSION,
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "repo_root": repo_path.as_posix(),
+        "repo_hash": repo_hash,
+        "repo_slug": repo_meta["repo_slug"],
+        "repo_url": repo_meta["repo_url"],
+        "default_branch": repo_meta["default_branch"],
+        "current_branch": branch_state["current_branch"],
+        "head_sha": branch_state["head_sha"],
+        "repo_profile_name": repo_profile.get("name"),
+        "repo_profile_path": profile_path.as_posix(),
+        "repo_profile_summary": repo_profile.get("summary"),
+        "repo_profile": repo_profile,
+        "builder_compatibility": build_builder_compatibility(repo_profile),
+        "state_namespace": runtime_settings["state_namespace"],
+        "state_file": resolved_state_file.as_posix(),
+        "state_marker": marker,
+        "reporting_window": reporting_window,
+        "collected_at": isoformat_utc(current_now),
+        "authority_order": AUTHORITY_ORDER,
+        "stop_conditions": STOP_CONDITIONS,
+        "releases": releases,
+        "release_issue_linkage": release_issue_linkage,
+        "top_level_prs": top_level_prs,
+        "nested_prs": nested_prs,
+        "pr_lineage": pr_lineage,
+        "classified_issues": classified_issues,
+        "review_findings": review_findings,
+        "workflow_failures": workflow_failures,
+        "source_gaps": stable_unique(source_gaps),
+        "notes": [f"Loaded repo profile from {profile_path.as_posix()}."],
+    }
+    context["candidate_inventory"] = build_candidate_inventory(context, releases, top_level_prs, issues, classified_issues, review_findings, workflow_failures, release_issue_linkage)
+    context["counts"] = {
+        "releases": len(releases),
+        "top_level_prs": len(top_level_prs),
+        "nested_prs": len(nested_prs),
+        "selected_issues": len(classified_issues),
+        "review_findings": len(review_findings),
+        "workflow_failures": len(workflow_failures),
+        "actual_incident_items": sum(1 for candidate in context["candidate_inventory"] if candidate["proposed_classification"] == ACTUAL_INCIDENT),
+        "changed_files": sum(len(pr.get("files") or []) for pr in merged_prs),
+        "task_packet_count": len(PACKET_NAMES),
+        "batch_count": 0,
+    }
+    context["override_signals"] = {
+        "high_churn": context["counts"]["top_level_prs"] >= 6 or context["counts"]["selected_issues"] >= 10,
+        "multi_surface_active": bool(context["counts"]["releases"] and context["counts"]["actual_incident_items"] and context["counts"]["review_findings"]),
+        "nested_lineage_complexity": bool(context["counts"]["nested_prs"] and context["counts"]["workflow_failures"]),
+    }
+    context["context_fingerprint"] = build_context_fingerprint(context)
+    context["context_id"] = f"{SKILL_NAME}:{current_now.strftime('%Y%m%dT%H%M%SZ')}:{repo_hash}"
+    return context
+
+
+def emit_builder_compatibility_warning(compatibility: dict[str, Any]) -> None:
+    if compatibility.get("status") == "current":
+        return
+    print(format_runtime_warning(compatibility), file=sys.stderr)
+
+
+def validate_candidate(candidate: dict[str, Any]) -> list[str]:
+    errors = [f"Candidate {candidate.get('candidate_id')} is missing required field `{field}`." for field in CANDIDATE_REQUIRED_FIELDS if field not in candidate]
+    if "evidence_files_or_links" in candidate:
+        errors.append(f"Candidate {candidate.get('candidate_id')} still uses forbidden field `evidence_files_or_links`.")
+    if candidate.get("proposed_classification") not in PROPOSED_CLASSIFICATIONS:
+        errors.append(f"Candidate {candidate.get('candidate_id')} has invalid proposed_classification.")
+    if candidate.get("confidence") not in CONFIDENCE_VALUES:
+        errors.append(f"Candidate {candidate.get('candidate_id')} has invalid confidence.")
+    if candidate.get("raw_reread_reason") is not None and candidate.get("raw_reread_reason") not in RAW_REREAD_REASONS:
+        errors.append(f"Candidate {candidate.get('candidate_id')} has invalid raw_reread_reason.")
+    if not isinstance(candidate.get("source_refs"), list) or not candidate.get("source_refs"):
+        errors.append(f"Candidate {candidate.get('candidate_id')} is missing canonical source_refs.")
+    return errors
+
+
+def lint_context(context: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    info: list[str] = [f"Collected {len(context.get('candidate_inventory') or [])} candidates."]
+    for candidate in context.get("candidate_inventory") or []:
+        errors.extend(validate_candidate(candidate))
+        if candidate.get("raw_reread_reason"):
+            warnings.append(f"Candidate {candidate['candidate_id']} requires raw reread: {candidate['raw_reread_reason']}.")
+        if candidate.get("proposed_classification") == ARTIFACT_ONLY and candidate.get("section_hint") == "Blockers / Risks":
+            errors.append(f"artifact_only candidate {candidate['candidate_id']} cannot target Blockers / Risks directly.")
+    if context.get("reporting_window", {}).get("source") == "state_marker" and float(context.get("reporting_window", {}).get("span_hours") or 0) > 14 * 24:
+        warnings.append("Reporting window spans more than 14 days; this is a catch-up window.")
+    warnings.extend(str(item) for item in context.get("source_gaps") or [])
+    return {"findings": {"errors": errors, "warnings": warnings, "info": info}, "override_signals": context.get("override_signals") or {}, "can_proceed": not errors}
+
+
+def select_review_mode(context: dict[str, Any], lint_report: dict[str, Any]) -> str:
+    counts = context.get("counts") or {}
+    relevant_candidates = sum(1 for candidate in context.get("candidate_inventory") or [] if candidate.get("section_hint") in {"Incidents", "Reviews", "Blockers / Risks"})
+    overrides = {}
+    overrides.update(context.get("override_signals") or {})
+    overrides.update(lint_report.get("override_signals") or {})
+    if int(counts.get("top_level_prs") or 0) <= 2 and relevant_candidates <= 4 and int(counts.get("releases") or 0) == 0 and int(counts.get("workflow_failures") or 0) == 0:
+        return "local-only"
+    if int(counts.get("top_level_prs") or 0) >= 6 or relevant_candidates >= 10 or any(bool(value) for value in overrides.values()):
+        return "broad-delegation"
+    return "targeted-delegation"
+
+
+def build_packets(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    review_mode = select_review_mode(context, lint_report)
+    candidate_lookup = {candidate["candidate_id"]: candidate for candidate in context.get("candidate_inventory") or []}
+    pr_ids = [candidate["candidate_id"] for candidate in context.get("candidate_inventory") or [] if candidate.get("section_hint") == "PRs"]
+    incident_ids = [candidate["candidate_id"] for candidate in context.get("candidate_inventory") or [] if candidate["proposed_classification"] == ACTUAL_INCIDENT or candidate.get("section_hint") == "Incidents"]
+    risk_ids = [
+        candidate["candidate_id"]
+        for candidate in context.get("candidate_inventory") or []
+        if candidate["proposed_classification"] in {BLOCKER_OR_RISK, ARTIFACT_ONLY}
+        or (candidate.get("section_hint") == "Reviews" and candidate["proposed_classification"] == BLOCKER_OR_RISK)
+    ]
+    workers = routed_workers_for_review_mode(review_mode)
+    optional_workers = derived_optional_workers(workers)
+    worker_selection_guidance = {
+        "routing_authority": "packet_worker_map",
+        "notes": "worker_selection_guidance is explanatory only; packet_worker_map is the concrete routing source.",
+        "agent_type_guidance": WORKER_SELECTION_GUIDANCE,
+    }
+    global_packet = {
+        "skill_name": SKILL_NAME,
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "primary_goal": PRIMARY_GOAL,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "repo_profile": context.get("repo_profile"),
+        "reporting_window": context.get("reporting_window"),
+        "output_sections": OUTPUT_SECTIONS,
+        "authority_order": AUTHORITY_ORDER,
+        "stop_conditions": STOP_CONDITIONS,
+        "review_mode": review_mode,
+        "review_mode_overrides": REVIEW_MODE_OVERRIDES,
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "candidate_field_bundles": CANDIDATE_FIELD_BUNDLES,
+        "worker_footer_fields": WORKER_FOOTER_FIELDS,
+        "reread_reason_values": [None, *RAW_REREAD_REASONS],
+        "domain_overlay": DOMAIN_OVERLAY,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": PACKET_WORKER_MAP,
+        "worker_selection_guidance": worker_selection_guidance,
+        "source_gaps": context.get("source_gaps") or [],
+        "candidate_schema": {"required_fields": CANDIDATE_REQUIRED_FIELDS, "proposed_classification_values": PROPOSED_CLASSIFICATIONS, "confidence_values": CONFIDENCE_VALUES, "raw_reread_reason_values": [None, *RAW_REREAD_REASONS], "source_refs_rule": "canonical citation list only; do not use evidence_files_or_links", "artifact_only_rule": "artifact_only candidates are reference-only and do not appear as standalone final section items"},
+        "worker_output_contract": {
+            "worker_output_shape": WORKER_OUTPUT_SHAPE,
+            "candidates_container": "candidates",
+            "footer_container": "footer",
+            "candidate_level_fields": CANDIDATE_REQUIRED_FIELDS,
+            "worker_footer_fields": WORKER_FOOTER_FIELDS,
+            "candidate_ids_order_rule": "candidate_ids must follow candidates[] stable discovery order exactly",
+        },
+        "reviews_rules": {"resolved_review_findings": "Reviews only", "unresolved_gate_impact_findings": "Reviews and Blockers / Risks may both include them", "excluded_noise": "generic notice, bot noise, and empty self-review"},
+        "apply_contract": {"plan_file": "weekly-update-plan.json", "reads_only": ["overall_confidence", "stop_reasons", "allow_marker_update"]},
+    }
+    mapping_packet = {
+        "packet_id": "mapping_packet",
+        "reporting_window": context.get("reporting_window"),
+        "default_branch": context.get("default_branch"),
+        "release_issue_linkage": context.get("release_issue_linkage"),
+        "top_level_pr_numbers": [pr["number"] for pr in context.get("top_level_prs") or []],
+        "nested_pr_numbers": [pr["number"] for pr in context.get("nested_prs") or []],
+        "pr_lineage": context.get("pr_lineage"),
+        "candidate_inventory_index": [{"candidate_id": candidate["candidate_id"], "source_type": candidate["source_type"], "source_id": candidate["source_id"], "section_hint": candidate.get("section_hint"), "proposed_classification": candidate["proposed_classification"], "confidence": candidate["confidence"], "packet_membership": candidate["packet_membership"], "raw_reread_reason": candidate["raw_reread_reason"], "source_refs": candidate["source_refs"]} for candidate in context.get("candidate_inventory") or []],
+        "raw_reread_candidate_ids": [candidate["candidate_id"] for candidate in context.get("candidate_inventory") or [] if candidate.get("raw_reread_reason") is not None],
+        "packet_worker_map": PACKET_WORKER_MAP,
+        "worker_selection_guidance": worker_selection_guidance,
+    }
+    changes_candidates = [{**candidate_lookup[candidate_id], "review_followups": [candidate_lookup[review_id]["summary"] for review_id in candidate_lookup[candidate_id].get("review_candidate_items") or [] if review_id in candidate_lookup]} for candidate_id in pr_ids]
+    changes_packet = focused_packet_contract("changes_packet", changes_candidates)
+    changes_packet["candidate_ids"] = pr_ids
+    incidents_packet = focused_packet_contract("incidents_packet", [candidate_lookup[candidate_id] for candidate_id in incident_ids])
+    incidents_packet["candidate_ids"] = incident_ids
+    risks_packet = focused_packet_contract("risks_packet", [candidate_lookup[candidate_id] for candidate_id in risk_ids])
+    risks_packet["candidate_ids"] = risk_ids
+    risks_packet["artifact_reference_candidate_ids"] = [candidate_id for candidate_id in risk_ids if candidate_lookup[candidate_id]["proposed_classification"] == ARTIFACT_ONLY]
+    orchestrator = {
+        "skill_name": SKILL_NAME,
+        "workflow_family": WORKFLOW_FAMILY,
+        "archetype": ARCHETYPE,
+        "orchestrator_profile": ORCHESTRATOR_PROFILE,
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "decision_ready_packets": DECISION_READY_PACKETS,
+        "worker_return_contract": WORKER_RETURN_CONTRACT,
+        "worker_output_shape": WORKER_OUTPUT_SHAPE,
+        "preferred_worker_families": PREFERRED_WORKER_FAMILIES,
+        "packet_worker_map": PACKET_WORKER_MAP,
+        "worker_selection_guidance": worker_selection_guidance,
+        "recommended_worker_count": len(workers),
+        "recommended_workers": workers,
+        "optional_workers": optional_workers,
+        "local_responsibilities": ["final adjudication", "section inclusion and exclusion", "exception-path raw reread only when needed", "final wording", "state marker update gate"],
+        "shared_packet": "global_packet.json",
+        "selected_packets": PACKET_NAMES,
+        "common_path_contract": COMMON_PATH_CONTRACT,
+        "analysis_targets": {"candidate_count": len(context.get("candidate_inventory") or []), "batch_count": 0},
+        "review_mode_overrides": REVIEW_MODE_OVERRIDES,
+    }
+    return {"orchestrator.json": orchestrator, "global_packet.json": global_packet, "mapping_packet.json": mapping_packet, "changes_packet.json": changes_packet, "incidents_packet.json": incidents_packet, "risks_packet.json": risks_packet}
+
+
+def count_candidates_by_proposed_classification(candidates: Iterable[dict[str, Any]]) -> dict[str, int]:
+    counts = {value: 0 for value in PROPOSED_CLASSIFICATIONS}
+    for candidate in candidates:
+        classification = str(candidate.get("proposed_classification") or "").strip()
+        if classification in counts:
+            counts[classification] += 1
+    return counts
+
+
+def count_raw_reread_reasons(candidates: Iterable[dict[str, Any]]) -> dict[str, int]:
+    counts = {value: 0 for value in RAW_REREAD_REASONS}
+    for candidate in candidates:
+        reason = str(candidate.get("raw_reread_reason") or "").strip()
+        if reason in counts:
+            counts[reason] += 1
+    return {reason: count for reason, count in counts.items() if count > 0}
+
+
+def compute_packet_metrics(packet_payloads: dict[str, Any], *, raw_local_sources: dict[str, Any]) -> dict[str, int]:
+    packet_sizes = {name: json_bytes(payload) for name, payload in packet_payloads.items()}
+    total_packet_bytes = sum(packet_sizes.values())
+    largest_sizes = sorted(packet_sizes.values(), reverse=True)
+    focused_packet_files = ["changes_packet.json", "incidents_packet.json", "risks_packet.json"]
+    common_path_bytes = packet_sizes.get("global_packet.json", 0) + packet_sizes.get("mapping_packet.json", 0)
+    common_path_bytes += max((packet_sizes.get(name, 0) for name in focused_packet_files), default=0)
+    local_only_bytes = sum(json_bytes(payload) for payload in raw_local_sources.values())
+    estimated_local_only_tokens = estimate_tokens_from_bytes(local_only_bytes)
+    estimated_packet_tokens = estimate_tokens_from_bytes(common_path_bytes)
+    return {
+        "packet_count": len(packet_payloads),
+        "packet_size_bytes": total_packet_bytes,
+        "largest_packet_bytes": largest_sizes[0] if largest_sizes else 0,
+        "largest_two_packets_bytes": sum(largest_sizes[:2]),
+        "estimated_local_only_tokens": estimated_local_only_tokens,
+        "estimated_packet_tokens": estimated_packet_tokens,
+        "estimated_delegation_savings": max(0, estimated_local_only_tokens - estimated_packet_tokens),
+    }
+
+
+def build_packet_artifacts(context: dict[str, Any], lint_report: dict[str, Any]) -> dict[str, Any]:
+    packets = build_packets(context, lint_report)
+    candidates = list(context.get("candidate_inventory") or [])
+    packet_metrics = compute_packet_metrics(
+        packets,
+        raw_local_sources={"context": context, "lint": lint_report},
+    )
+    raw_reread_reason_counts = count_raw_reread_reasons(candidates)
+    build_result = {
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "review_mode": packets["orchestrator.json"].get("review_mode"),
+        "selected_packets": list(packets["orchestrator.json"].get("selected_packets") or []),
+        "recommended_worker_count": packets["orchestrator.json"].get("recommended_worker_count"),
+        "recommended_workers": list(packets["orchestrator.json"].get("recommended_workers") or []),
+        "optional_workers": list(packets["orchestrator.json"].get("optional_workers") or []),
+        "packet_metrics": packet_metrics,
+        "candidate_counts_by_proposed_classification": count_candidates_by_proposed_classification(candidates),
+        "raw_reread_reason_counts": raw_reread_reason_counts,
+        "coverage_gap_count": len(context.get("source_gaps") or []),
+        "common_path_sufficient": not raw_reread_reason_counts,
+        "raw_reread_count": sum(raw_reread_reason_counts.values()),
+    }
+    return {"packets": packets, "packet_metrics": packet_metrics, "build_result": build_result}
+
+
+def aggregate_plan_confidence(plan: dict[str, Any], context: dict[str, Any]) -> str:
+    if plan.get("overall_confidence") in CONFIDENCE_VALUES:
+        return str(plan["overall_confidence"])
+    candidate_confidences = [candidate.get("confidence") for candidate in context.get("candidate_inventory") or []]
+    return "low" if "low" in candidate_confidences else "medium" if "medium" in candidate_confidences else "high"
+
+
+def unresolved_reread_candidate_ids(plan: dict[str, Any], context: dict[str, Any]) -> list[str]:
+    explicit = plan.get("unresolved_raw_reread_candidate_ids")
+    if isinstance(explicit, list):
+        return [str(item) for item in explicit]
+    return [candidate["candidate_id"] for candidate in context.get("candidate_inventory") or [] if candidate.get("raw_reread_reason") is not None]
+
+
+def apply_gate_summary(plan: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "overall_confidence": aggregate_plan_confidence(plan, context),
+        "unresolved_raw_reread_candidate_ids": stable_unique(unresolved_reread_candidate_ids(plan, context)),
+        "stop_reasons": stable_unique(str(item) for item in (plan.get("stop_reasons") or [])),
+        "allow_marker_update": bool(plan.get("allow_marker_update")),
+    }
+
+
+def section_items(section_payload: Any) -> list[Any]:
+    if isinstance(section_payload, list):
+        return section_payload
+    if isinstance(section_payload, dict) and isinstance(section_payload.get("items"), list):
+        return list(section_payload["items"])
+    return []
+
+
+def iter_plan_section_candidate_ids(plan: dict[str, Any]) -> list[tuple[str, str]]:
+    section_refs: list[tuple[str, str]] = []
+    sections = plan.get("sections")
+    if not isinstance(sections, dict):
+        return section_refs
+    for section_name, payload in sections.items():
+        for item in section_items(payload):
+            if isinstance(item, dict):
+                candidate_id = item.get("candidate_id")
+                if isinstance(candidate_id, str) and candidate_id.strip():
+                    section_refs.append((section_name, candidate_id.strip()))
+                candidate_ids = item.get("candidate_ids")
+                if isinstance(candidate_ids, list):
+                    section_refs.extend((section_name, str(value).strip()) for value in candidate_ids if str(value).strip())
+    return section_refs
+
+
+def dedupe_stable_strings(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        item = str(value or "").strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        ordered.append(item)
+    return ordered
+
+
+def derived_optional_workers(recommended_workers: list[dict[str, str]]) -> list[str]:
+    recommended_types = {str(worker.get("agent_type") or "").strip() for worker in recommended_workers if str(worker.get("agent_type") or "").strip()}
+    surfaced = []
+    for family_name in WORKER_FAMILY_ORDER:
+        surfaced.extend(PREFERRED_WORKER_FAMILIES.get(family_name, []))
+    return [worker_type for worker_type in dedupe_stable_strings(surfaced) if worker_type not in recommended_types]
+
+
+def routed_workers_for_review_mode(review_mode: str) -> list[dict[str, str]]:
+    active_packets = [] if review_mode == "local-only" else ["mapping_packet", "changes_packet"] if review_mode == "targeted-delegation" else PACKET_NAMES
+    workers: list[dict[str, str]] = []
+    seen_pairs: set[tuple[str, str]] = set()
+    instructions = {
+        "mapping_packet": "Confirm the evidence map and packet membership.",
+        "changes_packet": "Review shipped changes and review follow-ups only.",
+        "incidents_packet": "Review incident and workflow candidates only.",
+        "risks_packet": "Condense blocker, review, and artifact references.",
+    }
+    for packet_name in active_packets:
+        for agent_type in PACKET_WORKER_MAP.get(packet_name, []):
+            pair = (agent_type, f"{packet_name}.json")
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            workers.append({"agent_type": agent_type, "packet": f"{packet_name}.json", "instruction": instructions.get(packet_name, "Read the assigned packet only.")})
+    return workers
+
+
+def focused_packet_contract(packet_id: str, candidates: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "packet_id": packet_id,
+        "candidates": candidates,
+        "footer": {
+            "packet_ids": [packet_id],
+            "candidate_ids": [candidate.get("candidate_id") for candidate in candidates],
+            "primary_outcome": "",
+            "overall_confidence": "",
+            "coverage_gaps": [],
+            "overall_risk": "",
+        },
+        "candidate_template": {
+            "required_fields": CANDIDATE_REQUIRED_FIELDS,
+            "field_bundles": CANDIDATE_FIELD_BUNDLES,
+        },
+        "worker_footer_fields": WORKER_FOOTER_FIELDS,
+        "reread_reason_values": [None, *RAW_REREAD_REASONS],
+        "domain_overlay": DOMAIN_OVERLAY,
+    }
+
+
+def validate_weekly_update_plan(context: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    info: list[str] = []
+    missing_fields = [field for field in PLAN_REQUIRED_FIELDS if field not in plan]
+    if missing_fields:
+        errors.extend(f"weekly-update-plan.json is missing required field `{field}`." for field in missing_fields)
+    if "overall_confidence" in plan and plan.get("overall_confidence") not in CONFIDENCE_VALUES:
+        errors.append("weekly-update-plan.json has invalid `overall_confidence`.")
+    if "stop_reasons" in plan and not isinstance(plan.get("stop_reasons"), list):
+        errors.append("weekly-update-plan.json field `stop_reasons` must be a list.")
+    if "allow_marker_update" in plan and not isinstance(plan.get("allow_marker_update"), bool):
+        errors.append("weekly-update-plan.json field `allow_marker_update` must be a bool.")
+    if "sections" in plan and not isinstance(plan.get("sections"), dict):
+        errors.append("weekly-update-plan.json field `sections` must be an object keyed by final section name.")
+    section_candidate_refs = iter_plan_section_candidate_ids(plan)
+    sections = plan.get("sections")
+    if isinstance(sections, dict):
+        section_names = list(sections.keys())
+        missing_sections = [section for section in OUTPUT_SECTIONS if section not in sections]
+        unexpected_sections = [section for section in section_names if section not in OUTPUT_SECTIONS]
+        if missing_sections:
+            errors.append(f"weekly-update-plan.json is missing section keys: {', '.join(missing_sections)}.")
+        if unexpected_sections:
+            errors.append(f"weekly-update-plan.json has unexpected section keys: {', '.join(unexpected_sections)}.")
+        if section_names and section_names != OUTPUT_SECTIONS:
+            warnings.append("weekly-update-plan.json section order does not match the locked output order.")
+        for section_name, payload in sections.items():
+            if not isinstance(payload, (list, dict)):
+                errors.append(f"Section `{section_name}` must be a list or an object with `items`.")
+            elif isinstance(payload, dict) and "items" in payload and not isinstance(payload.get("items"), list):
+                errors.append(f"Section `{section_name}` object must use a list-valued `items` field.")
+    gate = apply_gate_summary(plan, context)
+    if str(plan.get("context_id") or "") != str(context.get("context_id") or ""):
+        errors.append("weekly-update-plan.json `context_id` does not match the collected context.")
+    if str(plan.get("context_fingerprint") or "") != str(context.get("context_fingerprint") or ""):
+        errors.append("weekly-update-plan.json `context_fingerprint` does not match the collected context.")
+    if gate["allow_marker_update"] and gate["unresolved_raw_reread_candidate_ids"]:
+        errors.append("allow_marker_update=true but unresolved raw reread candidates remain.")
+    if gate["allow_marker_update"] and gate["overall_confidence"] == "low":
+        errors.append("allow_marker_update=true is not permitted when overall_confidence=low.")
+    candidate_lookup = {candidate["candidate_id"]: candidate for candidate in context.get("candidate_inventory") or []}
+    artifact_only_refs: list[str] = []
+    unknown_refs: list[str] = []
+    for section_name, candidate_id in section_candidate_refs:
+        candidate = candidate_lookup.get(candidate_id)
+        if candidate is None:
+            unknown_refs.append(candidate_id)
+            continue
+        if candidate.get("proposed_classification") == ARTIFACT_ONLY:
+            artifact_only_refs.append(f"{section_name}:{candidate_id}")
+    if artifact_only_refs:
+        errors.append(
+            "artifact_only candidates cannot appear as direct section items: "
+            + ", ".join(artifact_only_refs)
+            + "."
+        )
+    if unknown_refs:
+        warnings.append("Section candidate references were not present in the collected context: " + ", ".join(stable_unique(unknown_refs)) + ".")
+    info.append(f"Validated weekly-update plan against {len(candidate_lookup)} collected candidates.")
+    return {
+        "valid": not errors,
+        "required_fields": PLAN_REQUIRED_FIELDS,
+        "errors": errors,
+        "warnings": warnings,
+        "info": info,
+        "overall_confidence": gate["overall_confidence"],
+        "allow_marker_update": gate["allow_marker_update"],
+        "stop_reasons": gate["stop_reasons"],
+        "unresolved_raw_reread_candidate_ids": gate["unresolved_raw_reread_candidate_ids"],
+        "artifact_only_section_candidate_ids": artifact_only_refs,
+    }
+
+
+def apply_plan(*, context: dict[str, Any], plan: dict[str, Any], state_file: str | None = None, dry_run: bool = False) -> dict[str, Any]:
+    repo_hash = str(context.get("repo_hash") or compute_repo_hash(Path(context["repo_root"])))
+    resolved_state_file = (
+        Path(state_file).resolve()
+        if state_file
+        else default_state_file(
+            repo_hash,
+            namespace=str(context.get("state_namespace") or DEFAULT_STATE_NAMESPACE),
+        )
+    )
+    gate = apply_gate_summary(plan, context)
+    overall_confidence = gate["overall_confidence"]
+    unresolved = list(gate["unresolved_raw_reread_candidate_ids"])
+    stop_reasons = list(gate["stop_reasons"])
+    allow_marker_update = gate["allow_marker_update"]
+    if unresolved and "unresolved raw reread exceptions remain" not in stop_reasons:
+        stop_reasons.append("unresolved raw reread exceptions remain")
+    if overall_confidence == "low" and "low confidence" not in stop_reasons:
+        stop_reasons.append("low confidence")
+    if not allow_marker_update and "allow_marker_update=false" not in stop_reasons:
+        stop_reasons.append("allow_marker_update=false")
+    marker_update_written = False
+    marker_payload = {"repo_slug": context.get("repo_slug"), "window_start_utc": context.get("reporting_window", {}).get("start_utc"), "window_end_utc": context.get("reporting_window", {}).get("end_utc"), "completed_at_utc": isoformat_utc(utc_now()), "primary_ref_digest": str(context.get("head_sha") or "")[:12], "evidence_fingerprint": str(plan.get("context_fingerprint") or context.get("context_fingerprint") or "")}
+    if not dry_run and allow_marker_update and overall_confidence != "low" and not unresolved and not stop_reasons:
+        write_json(resolved_state_file, marker_payload)
+        marker_update_written = True
+    return {"skill_name": SKILL_NAME, "context_id": context.get("context_id"), "dry_run": dry_run, "apply_succeeded": True, "mutation_type": "state-marker" if marker_update_written else "none", "message": f"Wrote weekly-update state marker to {resolved_state_file}." if marker_update_written else "Did not update the weekly-update state marker.", "stop_reasons": stop_reasons, "overall_confidence": overall_confidence, "allow_marker_update": allow_marker_update, "marker_update_attempted": not dry_run and allow_marker_update, "marker_update_written": marker_update_written, "unresolved_raw_reread_candidate_ids": unresolved, "primary_artifact": str(resolved_state_file) if marker_update_written else None, "secondary_artifacts": [], "mutations": ([{"kind": "state-marker", "path": str(resolved_state_file)}] if marker_update_written else []), "fingerprint_match": str(plan.get("context_id") or context.get("context_id") or "") == str(context.get("context_id") or "") and str(plan.get("context_fingerprint") or context.get("context_fingerprint") or "") == str(context.get("context_fingerprint") or ""), "result_status": "dry-run" if dry_run else "completed"}
+
+
+
+

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/write_evaluation_log.py
@@ -1,0 +1,1091 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    explicit = [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+    if explicit:
+        return explicit
+    derived: list[str] = []
+    shared_packet = str(orchestrator.get("shared_packet") or "").strip()
+    if shared_packet:
+        derived.append(shared_packet)
+    for item in orchestrator.get("selected_packets", []):
+        name = str(item or "").strip()
+        if not name:
+            continue
+        derived.append(name if name.endswith(".json") else f"{name}.json")
+    return list(dict.fromkeys(derived))
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    if skill_name == "weekly-update":
+        candidates = list(context.get("candidate_inventory") or [])
+        classification_counts: dict[str, int] = {}
+        raw_reread_reason_counts: dict[str, int] = {}
+        for candidate in candidates:
+            classification = str(candidate.get("proposed_classification") or "").strip()
+            if classification:
+                classification_counts[classification] = classification_counts.get(classification, 0) + 1
+            raw_reread_reason = str(candidate.get("raw_reread_reason") or "").strip()
+            if raw_reread_reason:
+                raw_reread_reason_counts[raw_reread_reason] = raw_reread_reason_counts.get(raw_reread_reason, 0) + 1
+        return {
+            "reporting_window": context.get("reporting_window"),
+            "review_mode": orchestrator.get("review_mode"),
+            "selected_packets": list(orchestrator.get("selected_packets") or []),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_mix": worker_roles(orchestrator),
+            "candidate_counts_by_proposed_classification": classification_counts,
+            "raw_reread_reason_counts": raw_reread_reason_counts,
+            "coverage_gap_count": len(context.get("source_gaps") or []),
+            "packet_count": None,
+            "estimated_packet_tokens": None,
+            "estimated_delegation_savings": None,
+            "common_path_sufficient": not raw_reread_reason_counts,
+            "raw_reread_count": sum(raw_reread_reason_counts.values()),
+            "plan_overall_confidence": None,
+            "allow_marker_update": None,
+            "marker_update_attempted": None,
+            "marker_update_written": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+            "efficiency_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        baseline = log.setdefault("baseline", {})
+        measurement = log.setdefault("measurement", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+            skill_specific["worker_count"] = worker_count
+        workers = result.get("recommended_workers")
+        if isinstance(workers, list):
+            roles = []
+            for worker in workers:
+                if isinstance(worker, dict):
+                    role = str(worker.get("agent_type") or worker.get("role") or worker.get("name") or "").strip()
+                    if role:
+                        roles.append(role)
+            if roles:
+                orchestration["worker_roles"] = roles
+                skill_specific["worker_mix"] = roles
+        selected_packets = result.get("selected_packets")
+        if isinstance(selected_packets, list):
+            skill_specific["selected_packets"] = [str(item) for item in selected_packets if str(item).strip()]
+        if isinstance(result.get("candidate_counts_by_proposed_classification"), dict):
+            skill_specific["candidate_counts_by_proposed_classification"] = result["candidate_counts_by_proposed_classification"]
+        if isinstance(result.get("raw_reread_reason_counts"), dict):
+            skill_specific["raw_reread_reason_counts"] = result["raw_reread_reason_counts"]
+            raw_reread_count = sum(safe_int(value) or 0 for value in result["raw_reread_reason_counts"].values())
+            skill_specific["raw_reread_count"] = raw_reread_count
+            orchestration["raw_reread_required"] = raw_reread_count > 0
+            active_reasons = [str(reason) for reason, count in result["raw_reread_reason_counts"].items() if safe_int(count)]
+            orchestration["raw_reread_reason"] = ", ".join(active_reasons) if active_reasons else None
+        coverage_gap_count = safe_int(result.get("coverage_gap_count"))
+        if coverage_gap_count is not None:
+            skill_specific["coverage_gap_count"] = coverage_gap_count
+        common_path_sufficient = to_bool(result.get("common_path_sufficient"))
+        if common_path_sufficient is not None:
+            skill_specific["common_path_sufficient"] = common_path_sufficient
+        packet_metrics = result.get("packet_metrics")
+        if isinstance(packet_metrics, dict):
+            packet_count = safe_int(packet_metrics.get("packet_count"))
+            if packet_count is not None:
+                skill_specific["packet_count"] = packet_count
+            estimated_packet_tokens = safe_int(packet_metrics.get("estimated_packet_tokens"))
+            if estimated_packet_tokens is not None:
+                skill_specific["estimated_packet_tokens"] = estimated_packet_tokens
+            estimated_local_only_tokens = safe_int(packet_metrics.get("estimated_local_only_tokens"))
+            if estimated_local_only_tokens is not None:
+                baseline["estimated_local_only_tokens"] = estimated_local_only_tokens
+            estimated_delegation_savings = safe_int(packet_metrics.get("estimated_delegation_savings"))
+            if estimated_delegation_savings is not None:
+                baseline["estimated_delegation_savings"] = estimated_delegation_savings
+                baseline["estimated_token_savings"] = estimated_delegation_savings
+                skill_specific["estimated_delegation_savings"] = estimated_delegation_savings
+            measurement["efficiency_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+            if log.get("skill", {}).get("name") == "weekly-update":
+                skill_specific["stop_reasons"] = existing
+        if log.get("skill", {}).get("name") == "weekly-update":
+            if result.get("overall_confidence") is not None:
+                skill_specific["plan_overall_confidence"] = result.get("overall_confidence")
+            if result.get("allow_marker_update") is not None:
+                skill_specific["allow_marker_update"] = to_bool(result.get("allow_marker_update"))
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        skill_specific = log.setdefault("skill_specific", {}).setdefault("data", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        if log.get("skill", {}).get("name") == "weekly-update":
+            if result.get("overall_confidence") is not None:
+                skill_specific["plan_overall_confidence"] = result.get("overall_confidence")
+            if result.get("allow_marker_update") is not None:
+                skill_specific["allow_marker_update"] = to_bool(result.get("allow_marker_update"))
+            if "marker_update_attempted" in result:
+                skill_specific["marker_update_attempted"] = to_bool(result.get("marker_update_attempted"))
+            if "marker_update_written" in result:
+                skill_specific["marker_update_written"] = to_bool(result.get("marker_update_written"))
+            if stop_reasons:
+                skill_specific["stop_reasons"] = list(orchestration.get("stop_reasons") or stop_reasons)
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_plan_low.json
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_plan_low.json
@@ -1,0 +1,25 @@
+{
+  "context_id": "weekly-update:20260327T120000Z",
+  "context_fingerprint": "fixture-context-fingerprint",
+  "reporting_window": {
+    "start_utc": "2026-03-20T23:59:59Z",
+    "end_utc": "2026-03-27T12:00:00Z"
+  },
+  "selected_packets": [
+    "mapping_packet",
+    "changes_packet",
+    "incidents_packet",
+    "risks_packet"
+  ],
+  "overall_confidence": "low",
+  "stop_reasons": [],
+  "allow_marker_update": false,
+  "sections": {
+    "PRs": [],
+    "Rollouts": [],
+    "Incidents": [],
+    "Reviews": [],
+    "Blockers / Risks": [],
+    "Evidence reviewed": []
+  }
+}

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_plan_ready.json
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_plan_ready.json
@@ -1,0 +1,25 @@
+{
+  "context_id": "weekly-update:20260327T120000Z",
+  "context_fingerprint": "fixture-context-fingerprint",
+  "reporting_window": {
+    "start_utc": "2026-03-20T23:59:59Z",
+    "end_utc": "2026-03-27T12:00:00Z"
+  },
+  "selected_packets": [
+    "mapping_packet",
+    "changes_packet",
+    "incidents_packet",
+    "risks_packet"
+  ],
+  "overall_confidence": "medium",
+  "stop_reasons": [],
+  "allow_marker_update": true,
+  "sections": {
+    "PRs": [],
+    "Rollouts": [],
+    "Incidents": [],
+    "Reviews": [],
+    "Blockers / Risks": [],
+    "Evidence reviewed": []
+  }
+}

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_plan_reread.json
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_plan_reread.json
@@ -1,0 +1,30 @@
+{
+  "context_id": "weekly-update:20260327T120000Z",
+  "context_fingerprint": "fixture-context-fingerprint",
+  "reporting_window": {
+    "start_utc": "2026-03-20T23:59:59Z",
+    "end_utc": "2026-03-27T12:00:00Z"
+  },
+  "selected_packets": [
+    "mapping_packet",
+    "changes_packet",
+    "incidents_packet",
+    "risks_packet"
+  ],
+  "overall_confidence": "medium",
+  "stop_reasons": [
+    "raw reread exception unresolved"
+  ],
+  "allow_marker_update": false,
+  "sections": {
+    "PRs": [],
+    "Rollouts": [],
+    "Incidents": [],
+    "Reviews": [],
+    "Blockers / Risks": [],
+    "Evidence reviewed": []
+  },
+  "unresolved_raw_reread_candidate_ids": [
+    "fixture-reread-candidate"
+  ]
+}

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_sample.json
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/fixtures/weekly_update_sample.json
@@ -1,0 +1,184 @@
+{
+  "now_utc": "2026-03-27T12:00:00Z",
+  "window_days": 7,
+  "state_marker": {
+    "window_end_utc": "2026-03-20T23:59:59Z"
+  },
+  "default_branch": "master",
+  "releases": [
+    {
+      "tag_name": "v0.2.2",
+      "published_at": "2026-03-25T09:00:00Z",
+      "release_issue_number": 105
+    },
+    {
+      "tag_name": "v0.2.3",
+      "published_at": "2026-03-26T15:00:00Z",
+      "release_issue_number": 106
+    },
+    {
+      "tag_name": "v0.2.1",
+      "published_at": "2026-03-18T09:00:00Z",
+      "release_issue_number": 104
+    }
+  ],
+  "prs": [
+    {
+      "number": 90,
+      "title": "Backfill telemetry guard",
+      "base_ref_name": "develop",
+      "merged_at": "2026-03-22T10:00:00Z",
+      "absorbed_into": 97,
+      "linked_issue_numbers": [],
+      "shipped_change_bullets": [
+        "Added a telemetry guard for the backfill path."
+      ],
+      "review_followups": [
+        "Fold the guard into the release branch after validation."
+      ]
+    },
+    {
+      "number": 93,
+      "title": "Normalize release evidence wording",
+      "base_ref_name": "develop",
+      "merged_at": "2026-03-23T10:00:00Z",
+      "absorbed_into": 97,
+      "linked_issue_numbers": [],
+      "shipped_change_bullets": [
+        "Normalized evidence wording for the release checklist."
+      ],
+      "review_followups": [
+        "Confirm the checklist text matches the published release note."
+      ]
+    },
+    {
+      "number": 97,
+      "title": "Land growable office demand hotfix",
+      "base_ref_name": "master",
+      "merged_at": "2026-03-24T10:00:00Z",
+      "linked_issue_numbers": [110],
+      "shipped_change_bullets": [
+        "Guarded the growable office demand transition path.",
+        "Stabilized the validation hook that runs after the fix lands."
+      ],
+      "review_followups": [
+        "Adjust the release-note wording to mention the validation gate."
+      ]
+    },
+    {
+      "number": 101,
+      "title": "Refresh docs and release copy",
+      "base_ref_name": "master",
+      "merged_at": "2026-03-25T08:00:00Z",
+      "linked_issue_numbers": [],
+      "shipped_change_bullets": [
+        "Refreshed release-facing copy and doc references."
+      ],
+      "review_followups": [
+        "Keep the public copy aligned with the published tag."
+      ]
+    }
+  ],
+  "issues": [
+    {
+      "number": 110,
+      "title": "[Investigation] Reproduce growable upgrade stall in office demand flow",
+      "body": "Summary: the stall is reproducible when growable upgrades cross the existing office demand boundary.\nCurrent evidence: the validation path fails on the affected scenario.\nConclusion: this is an actual failure that blocks delivery.",
+      "labels": ["investigation", "compatibility"],
+      "state": "OPEN",
+      "created_at": "2026-03-23T08:00:00Z",
+      "updated_at": "2026-03-24T09:00:00Z",
+      "linked_from_pr_numbers": [97]
+    },
+    {
+      "number": 111,
+      "title": "[Software Investigation] Classify post-v0.2.x default runtime behavior changes",
+      "body": "Summary: track the release-gate classification for the runtime behavior shift.\nCurrent evidence: no reproduced signal yet.\nConclusion: keep this as a blocker tracker until more evidence arrives.",
+      "labels": ["software investigation"],
+      "state": "OPEN",
+      "created_at": "2026-03-24T08:00:00Z",
+      "updated_at": "2026-03-25T08:00:00Z"
+    },
+    {
+      "number": 103,
+      "title": "[Software Evidence] Mixed buyer recovery in validation trace",
+      "body": "Evidence summary: captured logs and counters for reference.\nCurrent evidence: the trace is reusable but does not add a new failure signal this week.\nConclusion: artifact collection only.",
+      "labels": ["software evidence"],
+      "state": "OPEN",
+      "created_at": "2026-03-25T09:00:00Z",
+      "updated_at": "2026-03-26T09:00:00Z"
+    },
+    {
+      "number": 112,
+      "title": "[Bug] Regression in telemetry counters after load",
+      "body": "Summary: telemetry counters reset after load.\nExpected: counters remain stable.\nSteps to reproduce: load a saved state and inspect the counter values.",
+      "labels": ["bug"],
+      "state": "OPEN",
+      "created_at": "2026-03-26T08:00:00Z",
+      "updated_at": "2026-03-26T10:00:00Z"
+    }
+  ],
+  "review_threads": [
+    {
+      "pr_number": 107,
+      "comments": [
+        {
+          "id": 2992368622,
+          "body": "Potential off-by-one in the validation loop.",
+          "author": "codex",
+          "created_at": "2026-03-26T09:00:00Z",
+          "in_reply_to_id": null,
+          "path": "ExampleProduct/Systems/PerformanceTelemetrySystem.cs"
+        },
+        {
+          "id": 2992368623,
+          "body": "phase=complete resolved in the next commit.",
+          "author": "codex",
+          "created_at": "2026-03-26T11:00:00Z",
+          "in_reply_to_id": 2992368622,
+          "path": "ExampleProduct/Systems/PerformanceTelemetrySystem.cs"
+        }
+      ]
+    },
+    {
+      "pr_number": 107,
+      "comments": [
+        {
+          "id": 2992369000,
+          "body": "Need to verify the release gate wording before merge.",
+          "author": "codex",
+          "created_at": "2026-03-26T13:00:00Z",
+          "in_reply_to_id": null,
+          "path": "ExampleProduct/Properties/PublishConfiguration.xml"
+        }
+      ]
+    },
+    {
+      "pr_number": 107,
+      "comments": [
+        {
+          "id": 2992369999,
+          "body": "Looks good to me.",
+          "author": "github-actions[bot]",
+          "created_at": "2026-03-26T14:00:00Z",
+          "in_reply_to_id": null,
+          "path": "ExampleProduct/Properties/PublishConfiguration.xml"
+        }
+      ]
+    }
+  ],
+  "workflow_runs": [
+    {
+      "databaseId": 23635553980,
+      "workflowName": "CI",
+      "conclusion": "failure",
+      "status": "completed",
+      "event": "push",
+      "headBranch": "master",
+      "headSha": "abc1234",
+      "createdAt": "2026-03-26T12:00:00Z",
+      "updatedAt": "2026-03-26T12:30:00Z",
+      "url": "https://example.invalid/run/23635553980"
+    }
+  ]
+}

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_refresh_weekly_update_live_fixture.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_refresh_weekly_update_live_fixture.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import refresh_weekly_update_live_fixture as refresh
+import weekly_update_lib as wl
+from test_weekly_update_contract import load_json, review_comments_by_pr
+
+
+class RefreshWeeklyUpdateLiveFixtureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sample = load_json("weekly_update_sample.json")
+
+    def test_build_plan_fixtures_match_validator_shape(self) -> None:
+        plans = refresh.build_plan_fixtures(
+            context_id="weekly-update:20260327T120000Z",
+            context_fingerprint="fixture-context-fingerprint",
+            reporting_window={"start_utc": "2026-03-20T23:59:59Z", "end_utc": "2026-03-27T12:00:00Z"},
+        )
+        ready = plans["weekly_update_plan_ready.json"]
+        self.assertEqual(ready["selected_packets"], ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"])
+        self.assertEqual(list(ready["sections"].keys()), wl.OUTPUT_SECTIONS)
+        self.assertEqual(plans["weekly_update_plan_low.json"]["overall_confidence"], "low")
+        self.assertIn("unresolved_raw_reread_candidate_ids", plans["weekly_update_plan_reread.json"])
+
+    def test_build_review_threads_groups_root_comments_with_replies(self) -> None:
+        comments = review_comments_by_pr(self.sample)[107]
+        threads = refresh.build_review_threads(107, comments)
+        self.assertEqual(len(threads), 3)
+        self.assertEqual(threads[0]["pr_number"], 107)
+        self.assertEqual([comment["id"] for comment in threads[0]["comments"]], [2992368622, 2992368623])
+        self.assertEqual([comment["id"] for comment in threads[1]["comments"]], [2992369000])
+        self.assertEqual([comment["id"] for comment in threads[2]["comments"]], [2992369999])
+
+    def test_fixture_state_marker_keeps_window_end_only_when_marker_is_reused(self) -> None:
+        marker = {"window_end_utc": "2026-03-20T23:59:59Z", "completed_at_utc": "2026-03-21T00:00:00Z"}
+        reporting_window = {"source": "state_marker", "start_utc": "2026-03-20T23:59:59Z"}
+        self.assertEqual(refresh.fixture_state_marker(marker, reporting_window), {"window_end_utc": "2026-03-20T23:59:59Z"})
+        self.assertIsNone(refresh.fixture_state_marker(marker, {"source": "last_7_days"}))
+
+    def test_parse_args_leaves_profile_unset_until_repo_root_is_known(self) -> None:
+        with patch.object(sys, "argv", ["refresh_weekly_update_live_fixture.py", "--repo-root", "C:/repo"]):
+            args = refresh.parse_args()
+        self.assertIsNone(args.profile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_smoke_weekly_update.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_smoke_weekly_update.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent / "scripts"
+for candidate in (str(TEST_DIR), str(SCRIPT_DIR)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+import smoke_weekly_update as smoke  # noqa: E402
+
+
+class SmokeWeeklyUpdateTests(unittest.TestCase):
+    def test_explicit_non_repo_root_returns_blocked_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir = Path(tmp_dir_name)
+            argv = ["smoke_weekly_update.py", "--repo-root", str(tmp_dir)]
+            with patch.object(sys, "argv", argv):
+                buffer = io.StringIO()
+                with patch("sys.stdout", buffer):
+                    self.assertEqual(smoke.main(), 0)
+
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["reason"], "git_repo_required")
+        self.assertEqual(payload["next_action"], "run_from_repo_or_pass_repo_root")
+        self.assertEqual(payload["repo_root"], str(tmp_dir.resolve()))
+
+    def test_repo_root_path_returns_none_when_cwd_is_not_in_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir = Path(tmp_dir_name)
+            previous = Path.cwd()
+            os.chdir(tmp_dir)
+            try:
+                self.assertIsNone(smoke.repo_root_path(None))
+            finally:
+                os.chdir(previous)
+
+    def test_smoke_uses_collect_default_profile_when_not_explicit(self) -> None:
+        repo_root = Path("C:/repo")
+        calls: list[list[str]] = []
+
+        def fail_after_collect(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+            calls.append(args)
+            raise RuntimeError("stop-after-collect")
+
+        argv = ["smoke_weekly_update.py", "--repo-root", str(repo_root)]
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(smoke, "repo_root_path", return_value=repo_root),
+            patch.object(smoke, "run_script", side_effect=fail_after_collect),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "stop-after-collect"):
+                smoke.main()
+
+        collect_args = calls[0]
+        self.assertEqual(collect_args[0], str(smoke.script_path("collect_weekly_update_context.py")))
+        self.assertNotIn("--profile", collect_args)
+
+    def test_smoke_forwards_explicit_profile_to_collect_wrapper(self) -> None:
+        repo_root = Path("C:/repo")
+        profile_path = "C:/profiles/weekly-update.json"
+        calls: list[list[str]] = []
+
+        def fail_after_collect(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+            calls.append(args)
+            raise RuntimeError("stop-after-collect")
+
+        argv = [
+            "smoke_weekly_update.py",
+            "--repo-root",
+            str(repo_root),
+            "--profile",
+            profile_path,
+        ]
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(smoke, "repo_root_path", return_value=repo_root),
+            patch.object(smoke, "run_script", side_effect=fail_after_collect),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "stop-after-collect"):
+                smoke.main()
+
+        collect_args = calls[0]
+        profile_index = collect_args.index("--profile")
+        self.assertEqual(collect_args[profile_index + 1], profile_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_contract.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_contract.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import weekly_update_lib as wl
+import build_weekly_update_packets as build_packets_script
+import smoke_weekly_update as smoke
+
+
+def load_json(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8-sig"))
+
+
+def pr_body(pr: dict[str, Any]) -> str:
+    sections = [
+        "## What changed",
+        *[f"- {bullet}" for bullet in pr.get("shipped_change_bullets", [])],
+        "",
+        "## Risk / Rollback",
+        *[f"- {bullet}" for bullet in pr.get("review_followups", [])],
+        "",
+        "## Validation",
+        "- Weekly fixture check.",
+    ]
+    return "\n".join(sections)
+
+
+def to_issue(issue: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "number": issue["number"],
+        "title": issue["title"],
+        "body": issue["body"],
+        "labels": issue.get("labels", []),
+        "state": issue.get("state", "OPEN"),
+        "createdAt": issue.get("created_at"),
+        "updatedAt": issue.get("updated_at"),
+        "url": f"https://example.invalid/issues/{issue['number']}",
+    }
+
+
+def to_pr(pr: dict[str, Any]) -> dict[str, Any]:
+    head_ref_name = pr.get("head_ref_name")
+    if not head_ref_name:
+        head_ref_name = "develop" if pr["number"] == 97 else f"branch/{pr['number']}"
+    return {
+        "number": pr["number"],
+        "title": pr["title"],
+        "url": f"https://example.invalid/pull/{pr['number']}",
+        "body": pr_body(pr),
+        "base_ref_name": pr["base_ref_name"],
+        "head_ref_name": head_ref_name,
+        "merged_at": pr["merged_at"],
+        "merge_commit_sha": f"deadbeef{pr['number']}",
+        "linked_issue_numbers": pr.get("linked_issue_numbers", []),
+        "files": [{"path": f"src/file_{pr['number']}.cs"}],
+        "changed_file_groups": {"runtime": [f"src/file_{pr['number']}.cs"], "automation": [], "docs": [], "tests": [], "config": [], "other": []},
+        "shipped_change_bullets": list(pr.get("shipped_change_bullets", [])),
+        "risk_bullets": list(pr.get("review_followups", [])),
+        "validation_bullets": ["Weekly fixture check."],
+    }
+
+
+def review_comments_by_pr(sample: dict[str, Any]) -> dict[int, list[dict[str, Any]]]:
+    grouped: dict[int, list[dict[str, Any]]] = {}
+    for thread in sample["review_threads"]:
+        bucket = grouped.setdefault(int(thread["pr_number"]), [])
+        for comment in thread["comments"]:
+            bucket.append(
+                {
+                    "id": comment["id"],
+                    "body": comment["body"],
+                    "created_at": comment["created_at"],
+                    "updated_at": comment["created_at"],
+                    "in_reply_to_id": comment.get("in_reply_to_id"),
+                    "path": comment.get("path"),
+                    "html_url": f"https://example.invalid/review/{comment['id']}",
+                    "user": {"login": comment.get("author", "")},
+                }
+            )
+    return grouped
+
+
+def build_fixture_context(sample: dict[str, Any]) -> dict[str, Any]:
+    profile_path = wl.default_repo_profile_path()
+    repo_profile = wl.load_repo_profile(profile_path)
+    runtime_settings = wl.weekly_update_runtime_settings(repo_profile)
+    now_utc = wl.parse_iso8601(sample["now_utc"])
+    reporting_window = wl.select_reporting_window(now_utc=now_utc, window_days=int(sample["window_days"]), state_marker=sample["state_marker"])
+    start = wl.parse_iso8601(reporting_window["start_utc"])
+    end = wl.parse_iso8601(reporting_window["end_utc"])
+    assert start is not None and end is not None
+
+    releases = [
+        {
+            "tag_name": release["tag_name"],
+            "name": release["tag_name"],
+            "url": f"https://example.invalid/releases/{release['tag_name']}",
+            "published_at": release["published_at"],
+            "body": "",
+        }
+        for release in sample["releases"]
+        if wl.window_contains(release.get("published_at"), start, end)
+    ]
+    prs = [to_pr(pr) for pr in sample["prs"] if wl.window_contains(pr.get("merged_at"), start, end)]
+    top_level_prs, nested_prs, pr_lineage = wl.build_pr_lineage(prs, sample["default_branch"])
+    issues = [to_issue(issue) for issue in sample["issues"]]
+    release_issue_linkage = wl.link_releases_to_issues(
+        releases,
+        issues,
+        release_title_re=runtime_settings["release_title_re"],
+    )
+    linked_issue_numbers = wl.build_issue_linkage_set(top_level_prs)
+    active_release_tags = {release["tag_name"] for release in releases}
+    classified_issues = [
+        classified
+        for classified in (
+            wl.classify_issue(
+                issue,
+                window_start=start,
+                window_end=end,
+                linked_issue_numbers=linked_issue_numbers,
+                active_release_tags=active_release_tags,
+                release_title_re=runtime_settings["release_title_re"],
+            )
+            for issue in issues
+        )
+        if classified["classification"] != wl.IGNORE
+    ]
+    review_findings: list[dict[str, Any]] = []
+    for pr_number, comments in review_comments_by_pr(sample).items():
+        review_findings.extend(
+            wl.extract_review_findings(
+                pr_number,
+                f"https://example.invalid/pull/{pr_number}",
+                comments,
+                window_start=start,
+                window_end=end,
+                review_ack_patterns=runtime_settings["review_ack_patterns"],
+                review_complete_patterns=runtime_settings["review_complete_patterns"],
+                priority_marker_re=runtime_settings["priority_marker_re"],
+            )
+        )
+    workflow_failures = [
+        candidate
+        for candidate in (
+            wl.classify_workflow_run(run, window_start=start, window_end=end)
+            for run in sample["workflow_runs"]
+        )
+        if candidate is not None
+    ]
+    context = {
+        "skill_name": wl.SKILL_NAME,
+        "skill_version": wl.SKILL_VERSION,
+        "workflow_family": wl.WORKFLOW_FAMILY,
+        "archetype": wl.ARCHETYPE,
+        "repo_root": str(wl.skill_root().parents[3]),
+        "repo_hash": "fixturehash",
+        "repo_slug": "example/repo",
+        "repo_profile_name": str(repo_profile.get("name") or ""),
+        "repo_profile_path": str(profile_path),
+        "repo_profile_summary": str(repo_profile.get("summary") or ""),
+        "repo_profile": repo_profile,
+        "state_namespace": runtime_settings["state_namespace"],
+        "default_branch": sample["default_branch"],
+        "reporting_window": reporting_window,
+        "releases": releases,
+        "release_issue_linkage": release_issue_linkage,
+        "top_level_prs": top_level_prs,
+        "nested_prs": nested_prs,
+        "pr_lineage": pr_lineage,
+        "classified_issues": classified_issues,
+        "review_findings": review_findings,
+        "workflow_failures": workflow_failures,
+        "source_gaps": [],
+        "override_signals": {},
+        "context_id": "weekly-update:20260327T120000Z:fixturehash",
+        "head_sha": "abcdef123456",
+    }
+    context["candidate_inventory"] = wl.build_candidate_inventory(context, releases, top_level_prs, issues, classified_issues, review_findings, workflow_failures, release_issue_linkage)
+    context["counts"] = {
+        "releases": len(releases),
+        "top_level_prs": len(top_level_prs),
+        "nested_prs": len(nested_prs),
+        "selected_issues": len(classified_issues),
+        "review_findings": len(review_findings),
+        "workflow_failures": len(workflow_failures),
+        "actual_incident_items": sum(1 for candidate in context["candidate_inventory"] if candidate["proposed_classification"] == wl.ACTUAL_INCIDENT),
+        "changed_files": sum(len(pr.get("files") or []) for pr in prs),
+        "task_packet_count": len(wl.PACKET_NAMES),
+        "batch_count": 0,
+    }
+    context["override_signals"] = {
+        "high_churn": False,
+        "multi_surface_active": True,
+        "nested_lineage_complexity": False,
+    }
+    context["context_fingerprint"] = wl.build_context_fingerprint(context)
+    return context
+
+
+class WeeklyUpdateContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sample = load_json("weekly_update_sample.json")
+        self.context = build_fixture_context(self.sample)
+        self.lint = wl.lint_context(self.context)
+        self.artifacts = wl.build_packet_artifacts(self.context, self.lint)
+        self.packets = wl.build_packets(self.context, self.lint)
+        self.packet_metrics = self.artifacts["packet_metrics"]
+        self.build_result = self.artifacts["build_result"]
+        self.ready_plan = load_json("weekly_update_plan_ready.json")
+        self.low_plan = load_json("weekly_update_plan_low.json")
+        self.reread_plan = load_json("weekly_update_plan_reread.json")
+
+    def test_reporting_window_reuses_last_success_marker(self) -> None:
+        window = self.context["reporting_window"]
+        self.assertEqual(window["source"], "state_marker")
+        self.assertEqual(window["start_utc"], "2026-03-20T23:59:59Z")
+        self.assertEqual(window["end_utc"], "2026-03-27T12:00:00Z")
+
+    def test_nested_pr_lineage_dedups_into_top_level_pr(self) -> None:
+        self.assertEqual([pr["number"] for pr in self.context["top_level_prs"]], [97, 101])
+        self.assertEqual([pr["number"] for pr in self.context["nested_prs"]], [90, 93])
+        self.assertEqual(self.context["pr_lineage"]["90"]["root_top_level_pr"], 97)
+        self.assertEqual(self.context["pr_lineage"]["93"]["root_top_level_pr"], 97)
+        self.assertEqual(self.context["top_level_prs"][0]["absorbed_nested_pr_numbers"], [90, 93])
+
+    def test_releases_are_window_bounded(self) -> None:
+        self.assertEqual([release["tag_name"] for release in self.context["releases"]], ["v0.2.2", "v0.2.3"])
+
+    def test_issue_classification_matches_contract_examples(self) -> None:
+        candidates = {candidate["candidate_id"]: candidate for candidate in self.context["candidate_inventory"] if candidate["source_type"] == "issue"}
+        self.assertEqual(candidates["issue-110"]["proposed_classification"], wl.ACTUAL_INCIDENT)
+        self.assertEqual(candidates["issue-111"]["proposed_classification"], wl.BLOCKER_OR_RISK)
+        self.assertEqual(candidates["issue-103"]["proposed_classification"], wl.ARTIFACT_ONLY)
+
+    def test_review_noise_is_filtered_and_real_findings_survive(self) -> None:
+        review_candidates = [candidate for candidate in self.context["candidate_inventory"] if candidate["source_type"] == "review_finding"]
+        self.assertEqual([candidate["candidate_id"] for candidate in review_candidates], ["review-pr107-comment2992368622", "review-pr107-comment2992369000"])
+        self.assertEqual(review_candidates[0]["proposed_classification"], wl.IGNORE)
+        self.assertEqual(review_candidates[1]["proposed_classification"], wl.BLOCKER_OR_RISK)
+
+    def test_schema_uses_source_refs_and_forbidden_field_is_absent(self) -> None:
+        self.assertIn("overall_confidence", self.packets["global_packet.json"]["worker_output_contract"]["worker_footer_fields"])
+        self.assertEqual(self.packets["global_packet.json"]["worker_output_contract"]["worker_output_shape"], "hierarchical")
+        self.assertEqual(self.packets["global_packet.json"]["worker_output_contract"]["footer_container"], "footer")
+        for candidate in self.context["candidate_inventory"]:
+            self.assertIn("source_refs", candidate)
+            self.assertNotIn("evidence_files_or_links", candidate)
+            self.assertTrue(candidate["packet_membership"])
+            for ref in candidate["source_refs"]:
+                self.assertIn("kind", ref)
+                self.assertIn("ref", ref)
+
+    def test_active_profile_metadata_is_propagated_to_context_packets_and_build_result(self) -> None:
+        global_packet = self.packets["global_packet.json"]
+        orchestrator = self.packets["orchestrator.json"]
+        self.assertEqual(self.context["repo_profile_name"], "default")
+        self.assertEqual(self.context["state_namespace"], "weekly-update")
+        self.assertEqual(
+            self.context["repo_profile"]["extra"]["weekly_update"]["review_markers"]["acknowledged"],
+            ["phase=ack"],
+        )
+        self.assertEqual(global_packet["repo_profile_name"], "default")
+        self.assertEqual(orchestrator["repo_profile_name"], "default")
+        self.assertEqual(self.build_result["repo_profile_name"], "default")
+        self.assertEqual(Path(self.context["repo_profile_path"]).parts[-3:], ("profiles", "default", "profile.json"))
+        self.assertEqual(Path(global_packet["repo_profile_path"]).parts[-3:], ("profiles", "default", "profile.json"))
+        self.assertEqual(Path(orchestrator["repo_profile_path"]).parts[-3:], ("profiles", "default", "profile.json"))
+        self.assertEqual(Path(self.build_result["repo_profile_path"]).parts[-3:], ("profiles", "default", "profile.json"))
+
+    def test_domain_overlay_uses_normalized_builder_keys(self) -> None:
+        overlay = self.packets["global_packet.json"]["domain_overlay"]
+        self.assertEqual(
+            overlay["output_inclusion_rules"],
+            {
+                "standalone": [wl.ACTUAL_INCIDENT, wl.BLOCKER_OR_RISK],
+                "reference_only": [wl.ARTIFACT_ONLY],
+                "excluded": [wl.IGNORE],
+            },
+        )
+
+    def test_changes_packet_separates_shipped_changes_from_review_followups(self) -> None:
+        changes_packet = self.packets["changes_packet.json"]
+        self.assertEqual([candidate["source_id"] for candidate in changes_packet["candidates"]], ["#97", "#101"])
+        self.assertEqual(changes_packet["footer"]["candidate_ids"], changes_packet["candidate_ids"])
+        self.assertEqual(changes_packet["candidate_template"]["field_bundles"], wl.CANDIDATE_FIELD_BUNDLES)
+        for candidate in changes_packet["candidates"]:
+            self.assertIn("shipped_change_bullets", candidate)
+            self.assertIn("review_followups", candidate)
+            self.assertIsInstance(candidate["shipped_change_bullets"], list)
+            self.assertIsInstance(candidate["review_followups"], list)
+
+    def test_orchestrator_exposes_packet_worker_map_and_optional_workers(self) -> None:
+        orchestrator = self.packets["orchestrator.json"]
+        self.assertEqual(orchestrator["orchestrator_profile"], "standard")
+        self.assertTrue(orchestrator["decision_ready_packets"])
+        self.assertEqual(orchestrator["worker_return_contract"], "classification-oriented")
+        self.assertEqual(orchestrator["worker_output_shape"], "hierarchical")
+        self.assertEqual(orchestrator["packet_worker_map"], wl.PACKET_WORKER_MAP)
+        self.assertIn("common_path_contract", orchestrator)
+        self.assertNotIn("estimated_packet_tokens", orchestrator)
+        self.assertNotIn("packet_size_bytes", orchestrator)
+        self.assertEqual(
+            [worker["agent_type"] for worker in orchestrator["recommended_workers"]],
+            ["repo_mapper", "large_diff_auditor", "log_triager", "evidence_summarizer"],
+        )
+        self.assertEqual(orchestrator["optional_workers"], ["docs_verifier"])
+        self.assertEqual(orchestrator["worker_selection_guidance"]["routing_authority"], "packet_worker_map")
+
+    def test_build_artifacts_emit_eval_side_packet_metrics_and_result(self) -> None:
+        self.assertEqual(self.packet_metrics["packet_count"], len(smoke.EXPECTED_PACKET_FILES))
+        self.assertGreater(self.packet_metrics["estimated_delegation_savings"], 0)
+        self.assertLess(self.packet_metrics["estimated_packet_tokens"], self.packet_metrics["estimated_local_only_tokens"])
+        self.assertEqual(self.build_result["repo_profile_name"], "default")
+        self.assertEqual(self.build_result["packet_metrics"]["packet_count"], self.packet_metrics["packet_count"])
+        self.assertEqual(self.build_result["selected_packets"], ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"])
+        self.assertIn("candidate_counts_by_proposed_classification", self.build_result)
+        self.assertIn("raw_reread_reason_counts", self.build_result)
+
+    def test_build_wrapper_writes_packet_metrics_and_build_result(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            context_path = temp_path / "context.json"
+            lint_path = temp_path / "lint.json"
+            output_dir = temp_path / "packets"
+            result_path = temp_path / "build-result.json"
+            context_path.write_text(json.dumps(self.context, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+            lint_path.write_text(json.dumps(self.lint, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "build_weekly_update_packets.py",
+                    "--context",
+                    str(context_path),
+                    "--lint",
+                    str(lint_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--result-output",
+                    str(result_path),
+                ],
+            ):
+                exit_code = build_packets_script.main()
+
+            self.assertEqual(exit_code, 0)
+            packet_metrics = json.loads((output_dir / "packet_metrics.json").read_text(encoding="utf-8"))
+            build_result = json.loads(result_path.read_text(encoding="utf-8"))
+            orchestrator = json.loads((output_dir / "orchestrator.json").read_text(encoding="utf-8"))
+            self.assertEqual(packet_metrics["packet_count"], len(smoke.EXPECTED_PACKET_FILES))
+            self.assertEqual(build_result["packet_metrics"]["estimated_packet_tokens"], packet_metrics["estimated_packet_tokens"])
+            self.assertEqual(orchestrator["orchestrator_profile"], "standard")
+            self.assertEqual(orchestrator["repo_profile_name"], "default")
+            self.assertEqual(build_result["repo_profile_name"], "default")
+            self.assertNotIn("estimated_packet_tokens", orchestrator)
+
+    def test_packet_membership_is_consistent_across_packets(self) -> None:
+        mapping_index = {item["candidate_id"]: item for item in self.packets["mapping_packet.json"]["candidate_inventory_index"]}
+        for candidate in self.packets["incidents_packet.json"]["candidates"]:
+            self.assertIn("incidents_packet", mapping_index[candidate["candidate_id"]]["packet_membership"])
+        for candidate in self.packets["risks_packet.json"]["candidates"]:
+            self.assertIn("risks_packet", mapping_index[candidate["candidate_id"]]["packet_membership"])
+
+    def test_artifact_only_candidates_do_not_surface_as_blockers(self) -> None:
+        risk_candidates = {candidate["candidate_id"]: candidate for candidate in self.packets["risks_packet.json"]["candidates"]}
+        self.assertIn("issue-103", risk_candidates)
+        blocker_ids = [candidate_id for candidate_id, candidate in risk_candidates.items() if candidate["proposed_classification"] != wl.ARTIFACT_ONLY]
+        self.assertNotIn("issue-103", blocker_ids)
+
+    def test_apply_gating_blocks_low_confidence_and_raw_reread_exceptions(self) -> None:
+        ready = dict(self.ready_plan)
+        ready["context_id"] = self.context["context_id"]
+        ready["context_fingerprint"] = self.context["context_fingerprint"]
+        reread = dict(self.reread_plan)
+        reread["context_id"] = self.context["context_id"]
+        reread["context_fingerprint"] = self.context["context_fingerprint"]
+        reread["unresolved_raw_reread_candidate_ids"] = ["issue-111"]
+        low = dict(self.low_plan)
+        low["context_id"] = self.context["context_id"]
+        low["context_fingerprint"] = self.context["context_fingerprint"]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            ready_result = wl.apply_plan(context=self.context, plan=ready, state_file=str(Path(temp_dir) / "ready.json"), dry_run=False)
+            low_result = wl.apply_plan(context=self.context, plan=low, state_file=str(Path(temp_dir) / "low.json"), dry_run=False)
+            reread_result = wl.apply_plan(context=self.context, plan=reread, state_file=str(Path(temp_dir) / "reread.json"), dry_run=False)
+        self.assertTrue(ready_result["marker_update_written"])
+        self.assertFalse(low_result["marker_update_written"])
+        self.assertFalse(reread_result["marker_update_written"])
+
+    def test_final_output_sections_follow_the_locked_order(self) -> None:
+        self.assertEqual(wl.OUTPUT_SECTIONS, ["PRs", "Rollouts", "Incidents", "Reviews", "Blockers / Risks", "Evidence reviewed"])
+
+    def test_agent_interface_describes_top_level_orchestrator(self) -> None:
+        agent_yaml = (Path(__file__).resolve().parents[1] / "agents" / "openai.yaml").read_text(encoding="utf-8")
+        self.assertIn('short_description: "Top-level packet-driven weekly update orchestrator with profile-aware repo conventions"', agent_yaml)
+        self.assertIn("Use $weekly-update to collect context, build packets, optionally delegate", agent_yaml)
+        self.assertNotIn("ExampleProduct", agent_yaml)
+        self.assertNotIn("worker-only packet analyst", agent_yaml)
+
+    def test_retained_builder_assets_exist(self) -> None:
+        skill_dir = Path(__file__).resolve().parents[1]
+        self.assertTrue((skill_dir / "builder-spec.json").is_file())
+        self.assertTrue((skill_dir / "migration-worksheet.md").is_file())
+        self.assertTrue((skill_dir / "references" / "core-contract.md").is_file())
+        self.assertTrue((skill_dir / "profiles" / "default" / "profile.json").is_file())
+
+    def test_smoke_script_targets_all_expected_packets(self) -> None:
+        self.assertEqual(
+            smoke.EXPECTED_PACKET_FILES,
+            (
+                "orchestrator.json",
+                "global_packet.json",
+                "mapping_packet.json",
+                "changes_packet.json",
+                "incidents_packet.json",
+                "risks_packet.json",
+            ),
+        )
+        self.assertEqual(len(smoke.EXPECTED_PACKET_FILES), 6)
+        self.assertEqual(smoke.EXPECTED_EVAL_FILES, ("packet_metrics.json",))
+
+    def test_smoke_plan_disables_marker_updates(self) -> None:
+        plan = smoke.build_minimal_plan({"context_id": "ctx-1", "context_fingerprint": "fp-1"})
+        self.assertEqual(plan["context_id"], "ctx-1")
+        self.assertEqual(plan["context_fingerprint"], "fp-1")
+        self.assertEqual(plan["overall_confidence"], "high")
+        self.assertEqual(plan["stop_reasons"], [])
+        self.assertFalse(plan["allow_marker_update"])
+        self.assertEqual(plan["selected_packets"], ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"])
+        self.assertEqual(list(plan["sections"].keys()), wl.OUTPUT_SECTIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_failures.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_failures.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import weekly_update_lib as wl
+from test_weekly_update_contract import build_fixture_context, load_json
+
+
+def valid_plan(context: dict[str, object]) -> dict[str, object]:
+    return {
+        "context_id": context.get("context_id"),
+        "context_fingerprint": context.get("context_fingerprint"),
+        "reporting_window": context.get("reporting_window"),
+        "selected_packets": ["mapping_packet", "changes_packet", "incidents_packet", "risks_packet"],
+        "overall_confidence": "medium",
+        "stop_reasons": [],
+        "allow_marker_update": False,
+        "sections": wl.empty_plan_sections(),
+    }
+
+
+class WeeklyUpdateFailurePathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sample = load_json("weekly_update_sample.json")
+        self.context = build_fixture_context(self.sample)
+
+    def test_collect_context_stops_immediately_when_gh_auth_is_invalid(self) -> None:
+        repo_path = Path("C:/repo")
+        with (
+            patch.object(wl, "resolve_repo_root", return_value=repo_path),
+            patch.object(wl, "verify_gh_auth", side_effect=SystemExit("[ERROR] GitHub evidence is required but gh auth is invalid: auth failed")),
+            patch.object(wl, "get_repo_metadata") as mocked_repo_metadata,
+        ):
+            with self.assertRaises(SystemExit):
+                wl.collect_context(repo_root=str(repo_path), now_utc="2026-03-27T12:00:00Z")
+        mocked_repo_metadata.assert_not_called()
+
+    def test_verify_gh_auth_stops_cleanly_when_gh_is_missing(self) -> None:
+        with patch.object(wl.subprocess, "run", side_effect=FileNotFoundError("gh")):
+            with self.assertRaises(SystemExit) as exc_info:
+                wl.verify_gh_auth(Path("C:/repo"))
+        self.assertIn("gh auth is invalid", str(exc_info.exception))
+
+    def test_quiet_window_uses_local_only_review_mode(self) -> None:
+        quiet_context = dict(self.context)
+        quiet_context["releases"] = []
+        quiet_context["top_level_prs"] = []
+        quiet_context["nested_prs"] = []
+        quiet_context["pr_lineage"] = {}
+        quiet_context["classified_issues"] = []
+        quiet_context["review_findings"] = []
+        quiet_context["workflow_failures"] = []
+        quiet_context["candidate_inventory"] = []
+        quiet_context["counts"] = {
+            "releases": 0,
+            "top_level_prs": 0,
+            "nested_prs": 0,
+            "selected_issues": 0,
+            "review_findings": 0,
+            "workflow_failures": 0,
+            "actual_incident_items": 0,
+            "changed_files": 0,
+            "task_packet_count": len(wl.PACKET_NAMES),
+            "batch_count": 0,
+        }
+        quiet_context["override_signals"] = {
+            "high_churn": False,
+            "multi_surface_active": False,
+            "nested_lineage_complexity": False,
+        }
+        lint = wl.lint_context(quiet_context)
+        packets = wl.build_packets(quiet_context, lint)
+        self.assertTrue(lint["can_proceed"])
+        self.assertEqual(packets["orchestrator.json"]["review_mode"], "local-only")
+        self.assertEqual(packets["orchestrator.json"]["recommended_workers"], [])
+        self.assertEqual(packets["changes_packet.json"]["candidate_ids"], [])
+        self.assertEqual(packets["incidents_packet.json"]["candidate_ids"], [])
+        self.assertEqual(packets["risks_packet.json"]["candidate_ids"], [])
+
+    def test_collect_context_surfaces_truncation_warnings_in_source_gaps(self) -> None:
+        repo_path = Path("C:/repo")
+        with (
+            patch.object(wl, "resolve_repo_root", return_value=repo_path),
+            patch.object(wl, "verify_gh_auth", return_value=None),
+            patch.object(wl, "get_repo_metadata", return_value={"repo_slug": "example/repo", "default_branch": "master", "repo_url": "https://example.invalid/repo"}),
+            patch.object(wl, "get_branch_state", return_value={"current_branch": "master", "head_sha": "deadbeef"}),
+            patch.object(wl, "compute_repo_hash", return_value="fixturehash"),
+            patch.object(wl, "load_state_marker", return_value=(None, [])),
+            patch.object(wl, "list_releases", return_value=([], [])),
+            patch.object(wl, "list_issues", return_value=([], ["issues may be truncated after 20 pages."])),
+            patch.object(wl, "list_merged_pr_summaries", return_value=([], [])),
+            patch.object(wl, "list_workflow_runs", return_value=([], [])),
+        ):
+            context = wl.collect_context(repo_root=str(repo_path), state_file="C:/state.json", now_utc="2026-03-27T12:00:00Z")
+        self.assertIn("issues may be truncated after 20 pages.", context["source_gaps"])
+        self.assertEqual(context["counts"]["top_level_prs"], 0)
+
+    def test_validator_blocks_marker_updates_when_conflicting_reread_candidates_remain(self) -> None:
+        context = dict(self.context)
+        context["candidate_inventory"] = [dict(candidate) for candidate in self.context["candidate_inventory"]]
+        issue_110 = next(candidate for candidate in context["candidate_inventory"] if candidate["candidate_id"] == "issue-110")
+        issue_110["raw_reread_reason"] = "conflicting_signals"
+        issue_110["confidence"] = "low"
+        plan = valid_plan(context)
+        plan["allow_marker_update"] = True
+        result = wl.validate_weekly_update_plan(context, plan)
+        self.assertFalse(result["valid"])
+        self.assertIn("allow_marker_update=true but unresolved raw reread candidates remain.", result["errors"])
+
+    def test_validator_rejects_artifact_only_candidates_as_direct_section_items(self) -> None:
+        plan = valid_plan(self.context)
+        plan["sections"]["Blockers / Risks"] = [{"candidate_id": "issue-103", "text": "Artifact should not surface as a blocker."}]
+        result = wl.validate_weekly_update_plan(self.context, plan)
+        self.assertFalse(result["valid"])
+        self.assertIn("issue-103", "".join(result["errors"]))
+
+    def test_validator_rejects_low_confidence_marker_updates(self) -> None:
+        plan = valid_plan(self.context)
+        plan["overall_confidence"] = "low"
+        plan["allow_marker_update"] = True
+        result = wl.validate_weekly_update_plan(self.context, plan)
+        self.assertFalse(result["valid"])
+        self.assertIn("allow_marker_update=true is not permitted when overall_confidence=low.", result["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_pagination.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_pagination.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import weekly_update_lib as wl
+
+
+class WeeklyUpdatePaginationTests(unittest.TestCase):
+    def test_paginate_gh_api_aggregates_pages_until_empty_page(self) -> None:
+        responses = [
+            [{"id": 1}, {"id": 2}],
+            [{"id": 3}],
+        ]
+        seen_paths: list[str] = []
+
+        def fake_run_gh_json(repo_root: Path, args: list[str]) -> list[dict[str, int]]:
+            seen_paths.append(args[-1])
+            return responses.pop(0)
+
+        with patch.object(wl, "run_gh_json", side_effect=fake_run_gh_json), patch.object(wl, "DEFAULT_PAGE_SIZE", 2):
+            items, warnings = wl.paginate_gh_api(
+                Path("C:/repo"),
+                "repos/example/project/issues",
+                params={"state": "all"},
+                label="issues",
+            )
+
+        self.assertEqual([item["id"] for item in items], [1, 2, 3])
+        self.assertEqual(warnings, [])
+        self.assertEqual(len(seen_paths), 2)
+        self.assertIn("per_page=2", seen_paths[0])
+        self.assertIn("page=1", seen_paths[0])
+        self.assertIn("page=2", seen_paths[1])
+
+    def test_paginate_gh_api_reports_truncation_at_page_cap(self) -> None:
+        def fake_run_gh_json(repo_root: Path, args: list[str]) -> list[dict[str, int]]:
+            return [{"id": 1}]
+
+        with patch.object(wl, "run_gh_json", side_effect=fake_run_gh_json) as mocked, patch.object(wl, "DEFAULT_PAGE_SIZE", 1):
+            items, warnings = wl.paginate_gh_api(
+                Path("C:/repo"),
+                "repos/example/project/issues",
+                max_pages=2,
+                label="issues",
+            )
+
+        self.assertEqual([item["id"] for item in items], [1, 1])
+        self.assertEqual(warnings, ["issues may be truncated after 2 pages."])
+        self.assertEqual(mocked.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_write_evaluation_log_weekly_update.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_write_evaluation_log_weekly_update.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+script_dir = str(SCRIPT_DIR)
+while script_dir in sys.path:
+    sys.path.remove(script_dir)
+sys.path.insert(0, script_dir)
+
+sys.modules.pop("write_evaluation_log", None)
+import write_evaluation_log as eval_log  # noqa: E402
+
+
+class WeeklyUpdateEvaluationLogTests(unittest.TestCase):
+    def test_skill_specific_data_reads_weekly_update_contract_fields(self) -> None:
+        context = {
+            "reporting_window": {"start_utc": "2026-03-20T00:00:00Z", "end_utc": "2026-03-27T00:00:00Z"},
+            "source_gaps": ["release notes may be truncated"],
+            "candidate_inventory": [
+                {"proposed_classification": "actual_incident", "raw_reread_reason": None},
+                {"proposed_classification": "blocker_or_risk", "raw_reread_reason": "conflicting_signals"},
+                {"proposed_classification": "artifact_only", "raw_reread_reason": None},
+            ],
+        }
+        orchestrator = {
+            "review_mode": "targeted-delegation",
+            "selected_packets": ["mapping_packet", "changes_packet", "risks_packet"],
+            "recommended_worker_count": 2,
+            "recommended_workers": [
+                {"agent_type": "repo_mapper"},
+                {"agent_type": "large_diff_auditor"},
+            ],
+        }
+
+        payload = eval_log.skill_specific_data("weekly-update", context, orchestrator, None)
+
+        self.assertEqual(payload["review_mode"], "targeted-delegation")
+        self.assertEqual(payload["worker_count"], 2)
+        self.assertEqual(payload["worker_mix"], ["repo_mapper", "large_diff_auditor"])
+        self.assertEqual(payload["candidate_counts_by_proposed_classification"]["actual_incident"], 1)
+        self.assertEqual(payload["candidate_counts_by_proposed_classification"]["blocker_or_risk"], 1)
+        self.assertEqual(payload["raw_reread_reason_counts"], {"conflicting_signals": 1})
+        self.assertEqual(payload["coverage_gap_count"], 1)
+        self.assertFalse(payload["common_path_sufficient"])
+        self.assertEqual(payload["raw_reread_count"], 1)
+
+    def test_build_phase_merges_packet_metrics_and_common_path_signals(self) -> None:
+        log = {
+            "skill": {"name": "weekly-update"},
+            "measurement": {"efficiency_source": "unavailable"},
+            "baseline": {},
+            "orchestration": {},
+            "skill_specific": {"data": {}},
+        }
+        result = {
+            "review_mode": "targeted-delegation",
+            "recommended_worker_count": 2,
+            "recommended_workers": [{"agent_type": "repo_mapper"}, {"agent_type": "large_diff_auditor"}],
+            "selected_packets": ["mapping_packet", "changes_packet", "risks_packet"],
+            "candidate_counts_by_proposed_classification": {"actual_incident": 1, "blocker_or_risk": 2},
+            "raw_reread_reason_counts": {"conflicting_signals": 1},
+            "coverage_gap_count": 2,
+            "common_path_sufficient": False,
+            "raw_reread_count": 1,
+            "packet_metrics": {
+                "packet_count": 6,
+                "packet_size_bytes": 4096,
+                "largest_packet_bytes": 1024,
+                "largest_two_packets_bytes": 1800,
+                "estimated_local_only_tokens": 1200,
+                "estimated_packet_tokens": 400,
+                "estimated_delegation_savings": 800,
+            },
+        }
+
+        eval_log.apply_phase_update(log, "build", result, 1.5)
+
+        self.assertEqual(log["orchestration"]["review_mode"], "targeted-delegation")
+        self.assertEqual(log["orchestration"]["worker_count"], 2)
+        self.assertEqual(log["skill_specific"]["data"]["selected_packets"], ["mapping_packet", "changes_packet", "risks_packet"])
+        self.assertEqual(log["skill_specific"]["data"]["packet_count"], 6)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_packet_tokens"], 400)
+        self.assertEqual(log["skill_specific"]["data"]["estimated_delegation_savings"], 800)
+        self.assertFalse(log["skill_specific"]["data"]["common_path_sufficient"])
+        self.assertTrue(log["orchestration"]["raw_reread_required"])
+        self.assertEqual(log["baseline"]["estimated_local_only_tokens"], 1200)
+        self.assertEqual(log["baseline"]["estimated_token_savings"], 800)
+        self.assertEqual(log["measurement"]["efficiency_source"], "estimated")
+
+    def test_validate_and_apply_merge_plan_and_marker_fields(self) -> None:
+        log = {
+            "skill": {"name": "weekly-update"},
+            "measurement": {},
+            "orchestration": {},
+            "safety": {},
+            "quality": {},
+            "outputs": {},
+            "skill_specific": {"data": {}},
+        }
+
+        eval_log.apply_phase_update(
+            log,
+            "validate",
+            {
+                "valid": True,
+                "overall_confidence": "medium",
+                "allow_marker_update": False,
+                "stop_reasons": ["allow_marker_update=false"],
+            },
+            None,
+        )
+        eval_log.apply_phase_update(
+            log,
+            "apply",
+            {
+                "dry_run": True,
+                "apply_succeeded": True,
+                "overall_confidence": "medium",
+                "allow_marker_update": False,
+                "marker_update_attempted": False,
+                "marker_update_written": False,
+                "stop_reasons": ["allow_marker_update=false"],
+            },
+            None,
+        )
+
+        self.assertTrue(log["safety"]["validation_run"])
+        self.assertEqual(log["skill_specific"]["data"]["plan_overall_confidence"], "medium")
+        self.assertFalse(log["skill_specific"]["data"]["allow_marker_update"])
+        self.assertFalse(log["skill_specific"]["data"]["marker_update_attempted"])
+        self.assertFalse(log["skill_specific"]["data"]["marker_update_written"])
+        self.assertEqual(log["quality"]["result_status"], "dry-run")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/scripts/check_skill_versions.py
+++ b/builders/packet-workflow/scripts/check_skill_versions.py
@@ -1,0 +1,71 @@
+﻿#!/usr/bin/env python3
+"""Check retained packet-workflow skill compatibility metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from packet_workflow_versioning import (
+    canonical_retained_skills_root,
+    evaluate_skill_dir,
+    load_builder_versioning,
+    retained_skill_dirs,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skills-root",
+        default=str(canonical_retained_skills_root()),
+        help="Directory containing retained skill folders.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional output path for the JSON report. Prints to stdout when omitted.",
+    )
+    return parser.parse_args()
+
+
+def build_report(skills_root: Path) -> dict[str, object]:
+    current_builder = load_builder_versioning()
+    skills = [
+        evaluate_skill_dir(skill_dir, current_builder=current_builder)
+        for skill_dir in retained_skill_dirs(skills_root)
+    ]
+    summary: dict[str, int] = {}
+    blocking_count = 0
+    for skill in skills:
+        status = str(skill["status"])
+        summary[status] = summary.get(status, 0) + 1
+        if bool(skill["blocking"]):
+            blocking_count += 1
+    return {
+        "builder_version": current_builder,
+        "skills_root": skills_root.as_posix(),
+        "skills": skills,
+        "summary": summary,
+        "blocking_count": blocking_count,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    skills_root = Path(args.skills_root).resolve()
+    report = build_report(skills_root)
+    payload = json.dumps(report, indent=2, ensure_ascii=True) + "\n"
+    if args.output:
+        output_path = Path(args.output).resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload, encoding="utf-8")
+    else:
+        sys.stdout.write(payload)
+    return 1 if int(report["blocking_count"]) > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/builders/packet-workflow/scripts/init_packet_skill.py
+++ b/builders/packet-workflow/scripts/init_packet_skill.py
@@ -1,0 +1,2621 @@
+#!/usr/bin/env python3
+"""Generate a packet-driven repo workflow skill scaffold from builder-spec.json."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import pprint
+import re
+import sys
+import tomllib
+from collections.abc import Mapping
+from pathlib import Path
+
+from packet_workflow_versioning import (
+    compare_builder_semver,
+    load_builder_versioning,
+    normalize_versioning_block,
+)
+
+
+def foundry_root_dir() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def core_templates_dir() -> Path:
+    return foundry_root_dir() / "core" / "templates" / "packet-workflow"
+
+
+def core_defaults_dir() -> Path:
+    return foundry_root_dir() / "core" / "defaults" / "packet-workflow"
+
+
+def retained_skills_root(root_dir: Path) -> Path:
+    return root_dir / "builders" / "packet-workflow" / "retained-skills"
+
+
+def wrapper_skills_root(root_dir: Path) -> Path:
+    return root_dir / ".agents" / "skills"
+
+
+def load_json_document(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def load_string_list_default(filename: str, *, key: str | None = None) -> list[str]:
+    payload = load_json_document(core_defaults_dir() / filename)
+    if key is not None:
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Default file must be an object: {filename}")
+        payload = payload.get(key)
+    if not isinstance(payload, list) or any(not isinstance(item, str) for item in payload):
+        raise RuntimeError(f"Default file must resolve to a list of strings: {filename}")
+    return payload
+
+
+REVIEW_MODE_DEFAULTS = load_json_document(core_defaults_dir() / "review-modes.json")
+if not isinstance(REVIEW_MODE_DEFAULTS, dict):
+    raise RuntimeError("review-modes.json must be an object")
+
+
+ARCHETYPE_DEFAULTS = {
+    "audit-only": {"needs_lint": False, "needs_validate": False, "needs_apply": False},
+    "audit-and-apply": {"needs_lint": True, "needs_validate": True, "needs_apply": True},
+    "plan-validate-apply": {"needs_lint": False, "needs_validate": True, "needs_apply": True},
+}
+DEFAULT_ORCHESTRATOR_PROFILE = "standard"
+ORCHESTRATOR_PROFILES = {"standard", "packet-heavy-orchestrator"}
+
+REQUIRED_FIELDS = [
+    "skill_name",
+    "description",
+    "domain_slug",
+    "workflow_family",
+    "archetype",
+    "primary_goal",
+    "trigger_phrases",
+]
+
+DEFAULT_AUTHORITY_ORDER = load_string_list_default("authority-order.json")
+DEFAULT_STOP_CONDITIONS = load_string_list_default(
+    "stop-taxonomy.json", key="default_stop_conditions"
+)
+SUPPORTED_REVIEW_MODES = load_string_list_default(
+    "review-modes.json", key="supported_modes"
+)
+DEFAULT_REVIEW_MODE_OVERRIDES = load_string_list_default(
+    "review-modes.json", key="default_override_signals"
+)
+CURRENT_BUILDER_VERSIONING = load_builder_versioning()
+DEFAULT_REPO_PROFILE = {
+    "name": "default",
+    "summary": (
+        "Replace this scaffold profile with repo-specific path bindings, "
+        "packet review docs, and lint expectations before trusting deterministic checks."
+    ),
+    "repo_match": {
+        "root_markers": [],
+        "remote_patterns": [],
+    },
+    "bindings": {
+        "primary_readme_path": "README.md",
+        "settings_source_path": None,
+        "publish_config_path": None,
+    },
+    "packet_defaults": {
+        "review_docs": {},
+        "source_path_globs": {},
+    },
+    "lint_rules": {
+        "require_readme_settings_table": False,
+        "missing_review_docs_are_errors": False,
+    },
+    "extra": {},
+    "notes": [
+        "Populate repo-specific doc paths, code bindings, and packet ownership rules here.",
+        "Keep the repo profile data-only: store declarative paths, globs, doc lists, booleans, and notes only.",
+        "Add more profiles under profiles/<name>/profile.json when one skill must support multiple repositories.",
+    ],
+}
+PACKET_HEAVY_COMMON_PATH_CONTRACT = {
+    "shared_local_packet": "synthesis_packet.json",
+    "max_additional_focused_packets": 1,
+    "raw_reread_policy": "exception-only",
+    "packet_insufficiency_is_failure": True,
+}
+
+DEFAULT_WORKER_RETURN_CONTRACT = "generic"
+WORKER_RETURN_CONTRACTS = {"generic", "classification-oriented"}
+DEFAULT_WORKER_OUTPUT_SHAPE = "flat"
+WORKER_OUTPUT_SHAPES = {"flat", "hierarchical"}
+DEFAULT_XHIGH_REREAD_POLICY = (
+    "Do not reopen raw evidence by default after packet generation. "
+    "Only reopen raw evidence when reread control points to an allowed reason such as "
+    "conflicting signals, missing required evidence, schema mismatch, or insufficient "
+    "excerpt quality."
+)
+DEFAULT_CANDIDATE_FIELD_BUNDLES = [
+    {
+        "name": "fact_and_evidence",
+        "description": "Candidate-level factual summary and supporting references.",
+        "required": True,
+        "fields": ["fact_summary", "supporting_references"],
+    },
+    {
+        "name": "proposal_assessment",
+        "description": "Worker proposal, rationale, ambiguity, and confidence signals.",
+        "required": True,
+        "fields": [
+            "proposal_classification",
+            "classification_rationale",
+            "ambiguity",
+            "confidence",
+        ],
+    },
+    {
+        "name": "reread_control",
+        "description": "Exception-only raw reread control.",
+        "required": True,
+        "fields": ["reread_control"],
+    },
+]
+DEFAULT_WORKER_FOOTER_FIELDS = [
+    "packet_ids",
+    "candidate_ids",
+    "primary_outcome",
+    "overall_confidence",
+    "coverage_gaps",
+    "overall_risk",
+]
+DEFAULT_REREAD_REASON_VALUES = [
+    "conflicting_signals",
+    "missing_required_evidence",
+    "schema_mismatch",
+    "insufficient_excerpt_quality",
+]
+LEGACY_REQUIRED_BUNDLE_NAME = "legacy_required_fields"
+GENERIC_FIELD_DESCRIPTIONS = {
+    "fact_summary": "candidate-level factual summary",
+    "proposal_classification": "worker proposal classification",
+    "classification_rationale": "classification rationale for the worker proposal",
+    "supporting_references": "supporting references",
+    "ambiguity": "open ambiguity affecting adjudication",
+    "confidence": "worker confidence for the candidate",
+    "reread_control": "allowed reread reason or null",
+}
+GENERIC_FIELD_PLACEHOLDERS = {
+    "fact_summary": "Summarize the candidate facts here.",
+    "proposal_classification": "worker-proposal",
+    "classification_rationale": "Explain why the worker proposed this classification.",
+    "supporting_references": [],
+    "ambiguity": None,
+    "confidence": "medium",
+    "reread_control": None,
+}
+FOOTER_FIELD_DESCRIPTIONS = {
+    "packet_ids": "packets or packet slices the worker actually used",
+    "candidate_ids": "candidate ids in the same stable order as `candidates[]`",
+    "primary_outcome": "worker-level batch summary only",
+    "overall_confidence": "worker batch confidence only; final plan confidence is recomputed locally",
+    "coverage_gaps": "unread or insufficiently verified scope",
+    "overall_risk": "remaining worker batch risk",
+}
+OVERLAY_PRECEDENCE_RULES = [
+    "generic structural keys stay fixed and are never overridden by the domain overlay",
+    "generic `candidate_field_bundles` establish the workflow semantic slots first",
+    "overlay `bundle_overrides` adjust bundle composition or requiredness second",
+    "overlay `candidate_field_aliases` apply last to rename the resolved semantic slots",
+    "when no alias is provided for a resolved semantic slot, keep the generic slot name",
+]
+KNOWN_WORKER_AGENT_TYPES = [
+    "repo_mapper",
+    "packet_explorer",
+    "docs_verifier",
+    "evidence_summarizer",
+    "large_diff_auditor",
+    "log_triager",
+]
+KNOWN_WORKER_AGENT_TYPE_SET = set(KNOWN_WORKER_AGENT_TYPES)
+MANAGED_AGENTS_DIR_ENV_VAR = "CODEX_MANAGED_AGENTS_DIR"
+CODEX_HOME_ENV_VAR = "CODEX_HOME"
+DEFAULT_PREFERRED_WORKER_FAMILIES = {
+    "context_findings": ["repo_mapper", "packet_explorer", "docs_verifier"],
+    "candidate_producers": [
+        "evidence_summarizer",
+        "large_diff_auditor",
+        "log_triager",
+    ],
+    "verifiers": ["docs_verifier"],
+}
+WORKER_FAMILY_ORDER = [
+    "context_findings",
+    "candidate_producers",
+    "verifiers",
+]
+WORKER_FAMILY_DESCRIPTIONS = {
+    "context_findings": (
+        "mapping, packet-scoped code analysis, touched-surface, and packet-membership findings"
+    ),
+    "candidate_producers": (
+        "decision-ready candidate records for local adjudication-heavy workflows"
+    ),
+    "verifiers": "narrow claim or version-sensitive verification",
+}
+DEFAULT_WORKER_SELECTION_GUIDANCE = [
+    "Use `repo_mapper` when packet membership, execution path, touched surfaces, or authority mapping is unclear.",
+    "Use `packet_explorer` when one focused packet needs narrow code, behavior, or workflow analysis grounded by only the explicitly referenced file slices.",
+    "Use `docs_verifier` only when a disputed claim, version-sensitive assumption, or policy interpretation needs exact verification.",
+    "Use `evidence_summarizer` for long narrative evidence that should be condensed into decision-ready candidate records.",
+    "Use `large_diff_auditor` for large diffs, high-risk hotspots, regressions, invariants, and missing tests.",
+    "Use `log_triager` for logs, CI failures, runtime incidents, and earliest-useful-signal triage.",
+    "Treat `worker_selection_guidance` as explanatory only. `packet_worker_map` is the concrete routing authority when configured.",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="Path to builder-spec.json")
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help=(
+            "Repository-like root directory that will receive both "
+            "`builders/packet-workflow/retained-skills/<skill>` and "
+            "`.agents/skills/<skill>`."
+        ),
+    )
+    parser.add_argument(
+        "--managed-agents-dir",
+        help=(
+            "Optional override for the managed agents registry directory. "
+            "Resolution order otherwise uses environment overrides, the standard "
+            "install location, then the bundled test fixture."
+        ),
+    )
+    return parser.parse_args()
+
+
+def normalize_skill_name(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    normalized = re.sub(r"-{2,}", "-", normalized)
+    if not normalized:
+        raise ValueError("skill_name normalized to an empty value")
+    return normalized
+
+
+def normalize_domain_slug(value: str) -> str:
+    normalized = value.strip().lower().replace("-", "_")
+    normalized = re.sub(r"[^a-z0-9_]+", "_", normalized)
+    normalized = re.sub(r"_{2,}", "_", normalized).strip("_")
+    if not normalized:
+        raise ValueError("domain_slug normalized to an empty value")
+    return normalized
+
+
+def title_case(value: str) -> str:
+    return " ".join(part.capitalize() for part in value.replace("_", "-").split("-"))
+
+
+def ensure_non_empty_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def ensure_string_list(
+    value: object, field_name: str, *, allow_empty: bool = False
+) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be an array")
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{field_name} items must be non-empty strings")
+        normalized.append(item.strip())
+    if not allow_empty and not normalized:
+        raise ValueError(f"{field_name} must be a non-empty array")
+    return normalized
+
+
+def ensure_string_mapping(value: object, field_name: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    normalized: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{field_name} values must be non-empty strings")
+        normalized[key.strip()] = item.strip()
+    return normalized
+
+
+def ensure_optional_string(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return ensure_non_empty_string(value, field_name)
+
+
+def ensure_string_list_mapping(
+    value: object,
+    field_name: str,
+    *,
+    allow_empty_lists: bool = True,
+) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    normalized: dict[str, list[str]] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        normalized[key.strip()] = ensure_string_list(
+            item,
+            f"{field_name}.{key.strip()}",
+            allow_empty=allow_empty_lists,
+        )
+    return normalized
+
+
+def ensure_known_worker_agent_list(
+    value: object, field_name: str, *, allow_empty: bool = False
+) -> list[str]:
+    normalized = ensure_string_list(value, field_name, allow_empty=allow_empty)
+    duplicates: list[str] = []
+    seen: set[str] = set()
+    for item in normalized:
+        if item in seen and item not in duplicates:
+            duplicates.append(item)
+        seen.add(item)
+    if duplicates:
+        raise ValueError(
+            f"{field_name} contains duplicate agent types: {', '.join(duplicates)}"
+        )
+    unknown = sorted(set(normalized) - KNOWN_WORKER_AGENT_TYPE_SET)
+    if unknown:
+        raise ValueError(
+            f"{field_name} contains unknown agent types: {', '.join(unknown)}"
+        )
+    return normalized
+
+
+def unique_preserving_order(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            ordered.append(item)
+    return ordered
+
+
+def normalize_candidate_bundles(
+    value: object, field_name: str, *, allow_empty: bool = False
+) -> list[dict]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be an array")
+
+    bundles: list[dict] = []
+    bundle_names: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{field_name}[{index}] must be an object")
+        name = ensure_non_empty_string(item.get("name"), f"{field_name}[{index}].name")
+        if name in bundle_names:
+            raise ValueError(f"{field_name} bundle names must be unique: {name}")
+        fields = unique_preserving_order(
+            ensure_string_list(item.get("fields"), f"{field_name}[{index}].fields")
+        )
+        description = item.get("description")
+        description_value = (
+            ""
+            if description is None
+            else ensure_non_empty_string(description, f"{field_name}[{index}].description")
+        )
+        required_value = item.get("required", True)
+        if not isinstance(required_value, bool):
+            raise ValueError(f"{field_name}[{index}].required must be a boolean")
+        bundles.append(
+            {
+                "name": name,
+                "description": description_value,
+                "required": required_value,
+                "fields": fields,
+            }
+        )
+        bundle_names.add(name)
+
+    if not allow_empty and not bundles:
+        raise ValueError(f"{field_name} must be a non-empty array")
+    return bundles
+
+
+def normalize_output_inclusion_rules(value: object, field_name: str) -> dict[str, list[str]]:
+    if value is None:
+        return {"standalone": [], "reference_only": [], "excluded": []}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    allowed_keys = {"standalone", "reference_only", "excluded"}
+    unexpected = sorted(set(value) - allowed_keys)
+    if unexpected:
+        raise ValueError(
+            f"{field_name} contains unsupported keys: {', '.join(unexpected)}"
+        )
+    return {
+        key: ensure_string_list(value.get(key, []), f"{field_name}.{key}", allow_empty=True)
+        for key in sorted(allowed_keys)
+    }
+
+
+def normalize_bundle_overrides(value: object, field_name: str) -> dict[str, dict]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    overrides: dict[str, dict] = {}
+    for bundle_name, override in value.items():
+        if not isinstance(bundle_name, str) or not bundle_name.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        if not isinstance(override, dict):
+            raise ValueError(f"{field_name}.{bundle_name} must be an object")
+        normalized: dict[str, object] = {}
+        if "fields" in override:
+            normalized["fields"] = unique_preserving_order(
+                ensure_string_list(
+                    override["fields"], f"{field_name}.{bundle_name}.fields"
+                )
+            )
+        if "required" in override:
+            if not isinstance(override["required"], bool):
+                raise ValueError(
+                    f"{field_name}.{bundle_name}.required must be a boolean"
+                )
+            normalized["required"] = override["required"]
+        if "description" in override:
+            normalized["description"] = ensure_non_empty_string(
+                override["description"], f"{field_name}.{bundle_name}.description"
+            )
+        if not normalized:
+            raise ValueError(
+                f"{field_name}.{bundle_name} must set at least one of fields, required, or description"
+            )
+        overrides[bundle_name.strip()] = normalized
+    return overrides
+
+
+def normalize_json_data(value: object, field_name: str) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, list):
+        return [
+            normalize_json_data(item, f"{field_name}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, dict):
+        normalized: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError(f"{field_name} keys must be non-empty strings")
+            normalized[key] = normalize_json_data(item, f"{field_name}.{key}")
+        return normalized
+    raise ValueError(
+        f"{field_name} must contain only JSON-serializable data-only values"
+    )
+
+
+def normalize_domain_overlay(value: object) -> dict:
+    if value is None:
+        return {
+            "enabled": False,
+            "proposal_enum_values": [],
+            "candidate_field_aliases": {},
+            "reference_only_candidate_values": [],
+            "output_inclusion_rules": {
+                "standalone": [],
+                "reference_only": [],
+                "excluded": [],
+            },
+            "bundle_overrides": {},
+        }
+    if not isinstance(value, dict):
+        raise ValueError("domain_overlay must be an object when provided")
+
+    overlay = {
+        "enabled": True,
+        "proposal_enum_values": ensure_string_list(
+            value.get("proposal_enum_values", []),
+            "domain_overlay.proposal_enum_values",
+            allow_empty=True,
+        ),
+        "candidate_field_aliases": ensure_string_mapping(
+            value.get("candidate_field_aliases", {}),
+            "domain_overlay.candidate_field_aliases",
+        ),
+        "reference_only_candidate_values": ensure_string_list(
+            value.get("reference_only_candidate_values", []),
+            "domain_overlay.reference_only_candidate_values",
+            allow_empty=True,
+        ),
+        "output_inclusion_rules": normalize_output_inclusion_rules(
+            value.get("output_inclusion_rules"),
+            "domain_overlay.output_inclusion_rules",
+        ),
+        "bundle_overrides": normalize_bundle_overrides(
+            value.get("bundle_overrides"), "domain_overlay.bundle_overrides"
+        ),
+    }
+
+    proposal_values = set(overlay["proposal_enum_values"])
+    reference_only_values = set(overlay["reference_only_candidate_values"])
+    if proposal_values and not reference_only_values.issubset(proposal_values):
+        missing = sorted(reference_only_values - proposal_values)
+        raise ValueError(
+            "domain_overlay.reference_only_candidate_values must be a subset of "
+            "domain_overlay.proposal_enum_values: " + ", ".join(missing)
+        )
+
+    all_rule_values = set()
+    for values in overlay["output_inclusion_rules"].values():
+        all_rule_values.update(values)
+    if proposal_values and not all_rule_values.issubset(proposal_values):
+        missing = sorted(all_rule_values - proposal_values)
+        raise ValueError(
+            "domain_overlay.output_inclusion_rules values must be a subset of "
+            "domain_overlay.proposal_enum_values: " + ", ".join(missing)
+        )
+
+    if (
+        overlay["reference_only_candidate_values"]
+        and overlay["output_inclusion_rules"]["reference_only"]
+        and set(overlay["reference_only_candidate_values"])
+        != set(overlay["output_inclusion_rules"]["reference_only"])
+    ):
+        raise ValueError(
+            "domain_overlay.reference_only_candidate_values must match "
+            "domain_overlay.output_inclusion_rules.reference_only when both are set"
+        )
+
+    if (
+        overlay["reference_only_candidate_values"]
+        and not overlay["output_inclusion_rules"]["reference_only"]
+    ):
+        overlay["output_inclusion_rules"]["reference_only"] = list(
+            overlay["reference_only_candidate_values"]
+        )
+
+    return overlay
+
+
+def normalize_packet_name(value: str) -> str:
+    normalized = value.strip().lower().replace(".json", "")
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", normalized)
+    normalized = re.sub(r"-{2,}", "-", normalized).strip("-")
+    if not normalized:
+        raise ValueError("task_packet_names contains an empty packet name")
+    return normalized
+
+
+def normalize_profile_name(value: str) -> str:
+    normalized = normalize_skill_name(value)
+    if not normalized:
+        raise ValueError("repo_profile.name normalized to an empty value")
+    return normalized
+
+
+def normalize_preferred_worker_families(value: object | None) -> dict[str, list[str]]:
+    if value is None:
+        return copy.deepcopy(DEFAULT_PREFERRED_WORKER_FAMILIES)
+    if not isinstance(value, dict):
+        raise ValueError("preferred_worker_families must be an object")
+    unexpected = sorted(set(value) - set(WORKER_FAMILY_ORDER))
+    if unexpected:
+        raise ValueError(
+            "preferred_worker_families contains unsupported keys: "
+            + ", ".join(unexpected)
+        )
+    normalized: dict[str, list[str]] = {}
+    for family_name in WORKER_FAMILY_ORDER:
+        family_value = value.get(
+            family_name, copy.deepcopy(DEFAULT_PREFERRED_WORKER_FAMILIES[family_name])
+        )
+        normalized[family_name] = ensure_known_worker_agent_list(
+            family_value,
+            f"preferred_worker_families.{family_name}",
+            allow_empty=True,
+        )
+    return normalized
+
+
+def normalize_packet_worker_map(
+    value: object | None,
+    *,
+    task_packet_names: list[str],
+    uses_batch_packets: bool,
+) -> dict[str, list[str]]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("packet_worker_map must be an object")
+    allowed_packets = set(task_packet_names)
+    if uses_batch_packets:
+        allowed_packets.add("batch-packet-01")
+    normalized: dict[str, list[str]] = {}
+    for packet_name, agent_types in value.items():
+        if not isinstance(packet_name, str) or not packet_name.strip():
+            raise ValueError("packet_worker_map keys must be non-empty strings")
+        normalized_packet = normalize_packet_name(packet_name)
+        if normalized_packet not in allowed_packets:
+            raise ValueError(
+                "packet_worker_map contains unknown packet name: "
+                + normalized_packet
+            )
+        normalized[normalized_packet] = ensure_known_worker_agent_list(
+            agent_types,
+            f"packet_worker_map.{normalized_packet}",
+        )
+    ordered_packets: list[str] = []
+    if uses_batch_packets and "batch-packet-01" in normalized:
+        ordered_packets.append("batch-packet-01")
+    ordered_packets.extend(
+        packet_name for packet_name in task_packet_names if packet_name in normalized
+    )
+    return {packet_name: normalized[packet_name] for packet_name in ordered_packets}
+
+
+def normalize_repo_profile(
+    value: object | None,
+    *,
+    task_packet_names: list[str],
+    uses_batch_packets: bool,
+    builder_versioning: dict[str, object],
+) -> dict:
+    if value is None:
+        profile = copy.deepcopy(DEFAULT_REPO_PROFILE)
+    else:
+        if not isinstance(value, dict):
+            raise ValueError("repo_profile must be an object when provided")
+        allowed_top_level = {
+            "name",
+            "summary",
+            "repo_match",
+            "bindings",
+            "packet_defaults",
+            "lint_rules",
+            "extra",
+            "notes",
+        }
+        unexpected = sorted(set(value) - allowed_top_level)
+        if unexpected:
+            raise ValueError(
+                "repo_profile contains unsupported keys: " + ", ".join(unexpected)
+            )
+        profile = copy.deepcopy(DEFAULT_REPO_PROFILE)
+        if "name" in value:
+            profile["name"] = normalize_profile_name(
+                ensure_non_empty_string(value["name"], "repo_profile.name")
+            )
+        if "summary" in value:
+            profile["summary"] = ensure_non_empty_string(
+                value["summary"], "repo_profile.summary"
+            )
+
+        repo_match = value.get("repo_match")
+        if repo_match is not None:
+            if not isinstance(repo_match, dict):
+                raise ValueError("repo_profile.repo_match must be an object")
+            unexpected = sorted(set(repo_match) - {"root_markers", "remote_patterns"})
+            if unexpected:
+                raise ValueError(
+                    "repo_profile.repo_match contains unsupported keys: "
+                    + ", ".join(unexpected)
+                )
+            profile["repo_match"] = {
+                "root_markers": ensure_string_list(
+                    repo_match.get("root_markers", []),
+                    "repo_profile.repo_match.root_markers",
+                    allow_empty=True,
+                ),
+                "remote_patterns": ensure_string_list(
+                    repo_match.get("remote_patterns", []),
+                    "repo_profile.repo_match.remote_patterns",
+                    allow_empty=True,
+                ),
+            }
+
+        bindings = value.get("bindings")
+        if bindings is not None:
+            if not isinstance(bindings, dict):
+                raise ValueError("repo_profile.bindings must be an object")
+            unexpected = sorted(
+                set(bindings)
+                - {
+                    "primary_readme_path",
+                    "settings_source_path",
+                    "publish_config_path",
+                }
+            )
+            if unexpected:
+                raise ValueError(
+                    "repo_profile.bindings contains unsupported keys: "
+                    + ", ".join(unexpected)
+                )
+            profile["bindings"] = {
+                "primary_readme_path": ensure_non_empty_string(
+                    bindings.get(
+                        "primary_readme_path",
+                        DEFAULT_REPO_PROFILE["bindings"]["primary_readme_path"],
+                    ),
+                    "repo_profile.bindings.primary_readme_path",
+                ),
+                "settings_source_path": ensure_optional_string(
+                    bindings.get("settings_source_path"),
+                    "repo_profile.bindings.settings_source_path",
+                ),
+                "publish_config_path": ensure_optional_string(
+                    bindings.get("publish_config_path"),
+                    "repo_profile.bindings.publish_config_path",
+                ),
+            }
+
+        packet_defaults = value.get("packet_defaults")
+        if packet_defaults is not None:
+            if not isinstance(packet_defaults, dict):
+                raise ValueError("repo_profile.packet_defaults must be an object")
+            unexpected = sorted(
+                set(packet_defaults) - {"review_docs", "source_path_globs"}
+            )
+            if unexpected:
+                raise ValueError(
+                    "repo_profile.packet_defaults contains unsupported keys: "
+                    + ", ".join(unexpected)
+                )
+            allowed_packets = set(task_packet_names)
+            if uses_batch_packets:
+                allowed_packets.add("batch-packet-01")
+
+            def normalize_packet_mapping(
+                mapping_value: object,
+                field_name: str,
+            ) -> dict[str, list[str]]:
+                mapping = ensure_string_list_mapping(mapping_value, field_name)
+                normalized_mapping: dict[str, list[str]] = {}
+                for packet_name, items in mapping.items():
+                    normalized_packet = normalize_packet_name(packet_name)
+                    if normalized_packet not in allowed_packets:
+                        raise ValueError(
+                            f"{field_name} contains unknown packet name: {normalized_packet}"
+                        )
+                    normalized_mapping[normalized_packet] = items
+                ordered_packets: list[str] = []
+                if uses_batch_packets and "batch-packet-01" in normalized_mapping:
+                    ordered_packets.append("batch-packet-01")
+                ordered_packets.extend(
+                    packet_name
+                    for packet_name in task_packet_names
+                    if packet_name in normalized_mapping
+                )
+                return {
+                    packet_name: normalized_mapping[packet_name]
+                    for packet_name in ordered_packets
+                }
+
+            profile["packet_defaults"] = {
+                "review_docs": normalize_packet_mapping(
+                    packet_defaults.get("review_docs", {}),
+                    "repo_profile.packet_defaults.review_docs",
+                ),
+                "source_path_globs": normalize_packet_mapping(
+                    packet_defaults.get("source_path_globs", {}),
+                    "repo_profile.packet_defaults.source_path_globs",
+                ),
+            }
+
+        lint_rules = value.get("lint_rules")
+        if lint_rules is not None:
+            if not isinstance(lint_rules, dict):
+                raise ValueError("repo_profile.lint_rules must be an object")
+            unexpected = sorted(
+                set(lint_rules)
+                - {
+                    "require_readme_settings_table",
+                    "missing_review_docs_are_errors",
+                }
+            )
+            if unexpected:
+                raise ValueError(
+                    "repo_profile.lint_rules contains unsupported keys: "
+                    + ", ".join(unexpected)
+                )
+            normalized_lint_rules: dict[str, bool] = {}
+            for key, default_value in DEFAULT_REPO_PROFILE["lint_rules"].items():
+                lint_value = lint_rules.get(key, default_value)
+                if not isinstance(lint_value, bool):
+                    raise ValueError(f"repo_profile.lint_rules.{key} must be a boolean")
+                normalized_lint_rules[key] = lint_value
+            profile["lint_rules"] = normalized_lint_rules
+
+        if "extra" in value:
+            extra = value["extra"]
+            if not isinstance(extra, dict):
+                raise ValueError("repo_profile.extra must be an object")
+            profile["extra"] = normalize_json_data(extra, "repo_profile.extra")
+
+        if "notes" in value:
+            profile["notes"] = ensure_string_list(
+                value["notes"], "repo_profile.notes", allow_empty=True
+            )
+
+    profile["name"] = normalize_profile_name(profile["name"])
+    profile["profile_path"] = f"profiles/{profile['name']}/profile.json"
+    profile["metadata"] = {
+        "versioning": {
+            "builder_family": builder_versioning["builder_family"],
+            "builder_semver": builder_versioning["builder_semver"],
+            "compatibility_epoch": builder_versioning["compatibility_epoch"],
+            "repo_profile_schema_version": builder_versioning[
+                "repo_profile_schema_version"
+            ],
+        }
+    }
+    return profile
+
+
+def load_spec(path: Path) -> dict:
+    try:
+        payload = load_json_document(path)
+        if not isinstance(payload, dict):
+            raise SystemExit(f"[ERROR] Spec file must contain a JSON object: {path}")
+        return payload
+    except FileNotFoundError as exc:
+        raise SystemExit(f"[ERROR] Missing spec file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"[ERROR] Invalid JSON in {path}: {exc}") from exc
+
+
+def codex_home_dir() -> Path:
+    return foundry_root_dir()
+
+
+def managed_agents_dir() -> Path:
+    return codex_home_dir() / "agents"
+
+
+def managed_agents_fixture_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "agents"
+
+
+def normalize_directory_candidate(path_value: str | Path) -> Path:
+    return Path(path_value).expanduser().resolve()
+
+
+def environment_managed_agents_dir(
+    env: Mapping[str, str] | None = None,
+) -> tuple[Path | None, str | None]:
+    env_map = os.environ if env is None else env
+    explicit_dir = env_map.get(MANAGED_AGENTS_DIR_ENV_VAR)
+    if isinstance(explicit_dir, str) and explicit_dir.strip():
+        return normalize_directory_candidate(explicit_dir.strip()), MANAGED_AGENTS_DIR_ENV_VAR
+    codex_home = env_map.get(CODEX_HOME_ENV_VAR)
+    if isinstance(codex_home, str) and codex_home.strip():
+        return (
+            normalize_directory_candidate(Path(codex_home.strip()) / "agents"),
+            CODEX_HOME_ENV_VAR,
+        )
+    return None, None
+
+
+def resolve_managed_agents_dir(
+    override: str | Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    if override is not None:
+        explicit = normalize_directory_candidate(override)
+        if explicit.is_dir():
+            return explicit
+        raise ValueError(f"Managed agents override is not a directory: {explicit}")
+
+    env_path, env_source = environment_managed_agents_dir(env)
+    if env_path is not None:
+        if env_path.is_dir():
+            return env_path
+        raise ValueError(
+            f"{env_source} points to a missing managed agents directory: {env_path}"
+        )
+
+    standard_dir = managed_agents_dir()
+    if standard_dir.is_dir():
+        return standard_dir
+
+    fixture_dir = managed_agents_fixture_dir()
+    if fixture_dir.is_dir():
+        return fixture_dir
+
+    raise ValueError(
+        "Managed agents directory is missing. Checked "
+        f"standard default {standard_dir} and test fixture {fixture_dir}."
+    )
+
+
+def validate_managed_agent_registry(
+    agents_dir_override: str | Path | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    agents_dir = resolve_managed_agents_dir(agents_dir_override, env=env)
+    discovered_agent_types: set[str] = set()
+    for path in sorted(agents_dir.glob("*.toml")):
+        try:
+            with path.open("rb") as handle:
+                payload = tomllib.load(handle)
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(f"Invalid TOML in managed agent file {path}: {exc}") from exc
+        agent_name = payload.get("name")
+        if isinstance(agent_name, str) and agent_name.strip():
+            discovered_agent_types.add(agent_name.strip())
+    missing = sorted(KNOWN_WORKER_AGENT_TYPE_SET - discovered_agent_types)
+    if missing:
+        raise ValueError(
+            "Managed worker agents are missing from "
+            f"{agents_dir}: {', '.join(missing)}"
+        )
+    return agents_dir
+
+
+def apply_bundle_overrides(bundles: list[dict], overrides: dict[str, dict]) -> list[dict]:
+    resolved = copy.deepcopy(bundles)
+    index = {bundle["name"]: position for position, bundle in enumerate(resolved)}
+    for bundle_name, override in overrides.items():
+        if bundle_name not in index:
+            raise ValueError(
+                f"domain_overlay.bundle_overrides references unknown bundle: {bundle_name}"
+            )
+        target = resolved[index[bundle_name]]
+        if "fields" in override:
+            target["fields"] = unique_preserving_order(list(override["fields"]))
+        if "required" in override:
+            target["required"] = override["required"]
+        if "description" in override:
+            target["description"] = override["description"]
+    return resolved
+
+
+def flatten_bundle_fields(bundles: list[dict]) -> list[str]:
+    ordered: list[str] = []
+    for bundle in bundles:
+        ordered.extend(bundle["fields"])
+    return unique_preserving_order(ordered)
+
+
+def validate_alias_keys(bundles: list[dict], aliases: dict[str, str]) -> None:
+    bundle_fields = set(flatten_bundle_fields(bundles))
+    unknown = sorted(set(aliases) - bundle_fields)
+    if unknown:
+        raise ValueError(
+            "domain_overlay.candidate_field_aliases contains unknown semantic slots: "
+            + ", ".join(unknown)
+        )
+
+
+def resolve_candidate_bundles(
+    bundles: list[dict], aliases: dict[str, str]
+) -> list[dict]:
+    resolved_bundles: list[dict] = []
+    seen_resolved_names: dict[str, str] = {}
+    for bundle in bundles:
+        resolved_fields: list[dict] = []
+        for semantic_name in bundle["fields"]:
+            resolved_name = aliases.get(semantic_name, semantic_name)
+            prior = seen_resolved_names.get(resolved_name)
+            if prior is not None and prior != semantic_name:
+                raise ValueError(
+                    "domain_overlay.candidate_field_aliases produced duplicate resolved "
+                    f"field name `{resolved_name}` from `{prior}` and `{semantic_name}`"
+                )
+            seen_resolved_names[resolved_name] = semantic_name
+            resolved_fields.append(
+                {
+                    "semantic_name": semantic_name,
+                    "field_name": resolved_name,
+                    "description": GENERIC_FIELD_DESCRIPTIONS.get(
+                        semantic_name, f"domain-specific candidate field `{semantic_name}`"
+                    ),
+                }
+            )
+        resolved_bundles.append(
+            {
+                "name": bundle["name"],
+                "description": bundle["description"],
+                "required": bundle["required"],
+                "fields": resolved_fields,
+            }
+        )
+    return resolved_bundles
+
+
+def build_candidate_template(resolved_bundles: list[dict]) -> dict:
+    template = {"candidate_id": "candidate-001"}
+    for bundle in resolved_bundles:
+        for field in bundle["fields"]:
+            semantic_name = field["semantic_name"]
+            field_name = field["field_name"]
+            template[field_name] = copy.deepcopy(
+                GENERIC_FIELD_PLACEHOLDERS.get(semantic_name, "todo")
+            )
+    return template
+
+
+def build_footer_template(worker_footer_fields: list[str]) -> dict:
+    placeholders = {
+        "packet_ids": [],
+        "candidate_ids": [],
+        "primary_outcome": "Summarize the worker batch outcome here.",
+        "overall_confidence": "medium",
+        "coverage_gaps": [],
+        "overall_risk": "todo",
+    }
+    return {
+        field_name: copy.deepcopy(placeholders.get(field_name, "todo"))
+        for field_name in worker_footer_fields
+    }
+
+
+def active_worker_family_order(worker_return_contract: str) -> list[str]:
+    if worker_return_contract == "classification-oriented":
+        return list(WORKER_FAMILY_ORDER)
+    return ["context_findings", "verifiers"]
+
+
+def build_worker_selection_guidance() -> dict:
+    return {
+        "routing_authority": "packet_worker_map",
+        "notes": list(DEFAULT_WORKER_SELECTION_GUIDANCE),
+    }
+
+
+def surfaced_optional_worker_pool(spec: dict) -> list[str]:
+    ordered: list[str] = []
+    for family_name in active_worker_family_order(spec["worker_return_contract"]):
+        ordered.extend(spec["preferred_worker_families"][family_name])
+    return unique_preserving_order(ordered)
+
+
+def mapped_worker_types(spec: dict) -> list[str]:
+    ordered: list[str] = []
+    for packet_name in spec["packet_worker_map"]:
+        ordered.extend(spec["packet_worker_map"][packet_name])
+    return unique_preserving_order(ordered)
+
+
+def surfaced_optional_worker_list_for_docs(spec: dict) -> list[str]:
+    remaining = list(surfaced_optional_worker_pool(spec))
+    if not spec["packet_worker_map"]:
+        return remaining
+    mapped = set(mapped_worker_types(spec))
+    return [agent_type for agent_type in remaining if agent_type not in mapped]
+
+
+def worker_family_markdown(spec: dict) -> str:
+    sections: list[str] = []
+    for family_name in active_worker_family_order(spec["worker_return_contract"]):
+        sections.append(
+            f"- `{family_name}`: {WORKER_FAMILY_DESCRIPTIONS[family_name]}"
+        )
+        worker_types = spec["preferred_worker_families"][family_name]
+        if worker_types:
+            sections.append(
+                bullet_list([f"`{agent_type}`" for agent_type in worker_types], indent="  ")
+            )
+        else:
+            sections.append("  - no worker types configured")
+    return "\n".join(sections)
+
+
+def packet_worker_map_markdown(packet_worker_map: dict[str, list[str]]) -> str:
+    if not packet_worker_map:
+        return (
+            "- No `packet_worker_map` is configured for this scaffold.\n"
+            "- `worker_selection_guidance` stays explanatory only until a packet map is provided."
+        )
+    lines: list[str] = [
+        "- `packet_worker_map` is the routing authority when configured.",
+        "- The same agent type may appear on multiple packets when those assignments are intentional.",
+    ]
+    for packet_name, agent_types in packet_worker_map.items():
+        lines.append(f"- `{packet_name}`")
+        lines.append(
+            bullet_list([f"`{agent_type}`" for agent_type in agent_types], indent="  ")
+        )
+    return "\n".join(lines)
+
+
+def worker_selection_guidance_markdown(guidance: dict) -> str:
+    lines = [
+        "- `worker_selection_guidance` is explanatory only and does not override `packet_worker_map`.",
+        "- Guidance notes:",
+        bullet_list(guidance["notes"], indent="  "),
+    ]
+    return "\n".join(lines)
+
+
+def derive_spec(raw: dict) -> dict:
+    missing = [field for field in REQUIRED_FIELDS if field not in raw]
+    if missing:
+        raise ValueError(f"Missing required fields: {', '.join(missing)}")
+
+    builder_versioning = normalize_versioning_block(
+        raw.get("builder_versioning"),
+        require_builder_spec_schema_version=True,
+    )
+    if builder_versioning is None:
+        raise ValueError("builder_versioning is required and must be a valid object")
+    if builder_versioning["builder_family"] != CURRENT_BUILDER_VERSIONING["builder_family"]:
+        raise ValueError(
+            "builder_versioning.builder_family must match the current builder family"
+        )
+    if builder_versioning["compatibility_epoch"] != CURRENT_BUILDER_VERSIONING["compatibility_epoch"]:
+        raise ValueError(
+            "builder_versioning.compatibility_epoch must match the current builder compatibility epoch"
+        )
+    if (
+        builder_versioning["builder_spec_schema_version"]
+        != CURRENT_BUILDER_VERSIONING["builder_spec_schema_version"]
+    ):
+        raise ValueError(
+            "builder_versioning.builder_spec_schema_version must match the current builder spec schema version"
+        )
+    if (
+        builder_versioning["repo_profile_schema_version"]
+        != CURRENT_BUILDER_VERSIONING["repo_profile_schema_version"]
+    ):
+        raise ValueError(
+            "builder_versioning.repo_profile_schema_version must match the current repo profile schema version"
+        )
+    if compare_builder_semver(
+        builder_versioning["builder_semver"],
+        CURRENT_BUILDER_VERSIONING["builder_semver"],
+    ) > 0:
+        raise ValueError(
+            "builder_versioning.builder_semver cannot be ahead of the current builder"
+        )
+
+    archetype = raw["archetype"]
+    if archetype not in ARCHETYPE_DEFAULTS:
+        raise ValueError(
+            "archetype must be one of: " + ", ".join(sorted(ARCHETYPE_DEFAULTS))
+        )
+
+    trigger_phrases = ensure_string_list(raw["trigger_phrases"], "trigger_phrases")
+    task_packet_names = ensure_string_list(
+        raw.get("task_packet_names", ["task_packet"]), "task_packet_names"
+    )
+    task_packet_names = [normalize_packet_name(item) for item in task_packet_names]
+    uses_batch_packets = bool(raw.get("uses_batch_packets", False))
+    orchestrator_profile = ensure_non_empty_string(
+        raw.get("orchestrator_profile", DEFAULT_ORCHESTRATOR_PROFILE),
+        "orchestrator_profile",
+    )
+    if orchestrator_profile not in ORCHESTRATOR_PROFILES:
+        raise ValueError(
+            "orchestrator_profile must be one of: "
+            + ", ".join(sorted(ORCHESTRATOR_PROFILES))
+        )
+
+    optional_local_helper = raw.get("optional_local_helper")
+    if optional_local_helper is not None:
+        if not isinstance(optional_local_helper, dict):
+            raise ValueError("optional_local_helper must be an object when provided")
+        path_value = ensure_non_empty_string(
+            optional_local_helper.get("path"), "optional_local_helper.path"
+        )
+        description = optional_local_helper.get("description") or "optional local helper"
+        description = ensure_non_empty_string(
+            description, "optional_local_helper.description"
+        )
+        optional_local_helper = {
+            "path": path_value,
+            "description": description,
+            "is_authoritative": False,
+        }
+
+    defaults = ARCHETYPE_DEFAULTS[archetype]
+    authority_order = ensure_string_list(
+        raw.get("authority_order", DEFAULT_AUTHORITY_ORDER), "authority_order"
+    )
+    stop_conditions = ensure_string_list(
+        raw.get("stop_conditions", DEFAULT_STOP_CONDITIONS), "stop_conditions"
+    )
+    review_mode_overrides = ensure_string_list(
+        raw.get("review_mode_overrides", DEFAULT_REVIEW_MODE_OVERRIDES),
+        "review_mode_overrides",
+    )
+    decision_ready_packets = bool(raw.get("decision_ready_packets", False))
+    worker_return_contract = raw.get("worker_return_contract")
+    if worker_return_contract is None:
+        worker_return_contract = (
+            "classification-oriented"
+            if decision_ready_packets
+            else DEFAULT_WORKER_RETURN_CONTRACT
+        )
+    worker_return_contract = ensure_non_empty_string(
+        worker_return_contract, "worker_return_contract"
+    )
+    if worker_return_contract not in WORKER_RETURN_CONTRACTS:
+        raise ValueError(
+            "worker_return_contract must be one of: "
+            + ", ".join(sorted(WORKER_RETURN_CONTRACTS))
+        )
+
+    worker_output_shape = raw.get("worker_output_shape")
+    if worker_output_shape is None:
+        worker_output_shape = (
+            "hierarchical"
+            if decision_ready_packets or worker_return_contract == "classification-oriented"
+            else DEFAULT_WORKER_OUTPUT_SHAPE
+        )
+    worker_output_shape = ensure_non_empty_string(
+        worker_output_shape, "worker_output_shape"
+    )
+    if worker_output_shape not in WORKER_OUTPUT_SHAPES:
+        raise ValueError(
+            "worker_output_shape must be one of: "
+            + ", ".join(sorted(WORKER_OUTPUT_SHAPES))
+        )
+    if (
+        worker_output_shape == "hierarchical"
+        and worker_return_contract != "classification-oriented"
+    ):
+        raise ValueError(
+            "worker_output_shape=hierarchical requires "
+            "worker_return_contract=classification-oriented"
+        )
+    if (
+        worker_return_contract == "classification-oriented"
+        and not decision_ready_packets
+    ):
+        raise ValueError(
+            "worker_return_contract=classification-oriented requires "
+            "decision_ready_packets=true"
+        )
+
+    xhigh_reread_policy = raw.get(
+        "xhigh_reread_policy", DEFAULT_XHIGH_REREAD_POLICY
+    )
+    xhigh_reread_policy = ensure_non_empty_string(
+        xhigh_reread_policy, "xhigh_reread_policy"
+    )
+
+    required_candidate_fields = ensure_string_list(
+        raw.get("required_candidate_fields", []),
+        "required_candidate_fields",
+        allow_empty=True,
+    )
+
+    candidate_field_bundles_raw = raw.get("candidate_field_bundles")
+    if candidate_field_bundles_raw is None:
+        if worker_output_shape == "hierarchical" or decision_ready_packets:
+            if required_candidate_fields:
+                candidate_field_bundles = [
+                    {
+                        "name": LEGACY_REQUIRED_BUNDLE_NAME,
+                        "description": "Legacy shorthand bundle derived from required_candidate_fields.",
+                        "required": True,
+                        "fields": required_candidate_fields,
+                    }
+                ]
+            else:
+                candidate_field_bundles = copy.deepcopy(DEFAULT_CANDIDATE_FIELD_BUNDLES)
+        else:
+            candidate_field_bundles = []
+    else:
+        candidate_field_bundles = normalize_candidate_bundles(
+            candidate_field_bundles_raw, "candidate_field_bundles", allow_empty=True
+        )
+    if (
+        candidate_field_bundles_raw is not None
+        and worker_return_contract != "classification-oriented"
+    ):
+        raise ValueError(
+            "candidate_field_bundles requires "
+            "worker_return_contract=classification-oriented"
+        )
+
+    worker_footer_fields_raw = raw.get("worker_footer_fields")
+    if worker_footer_fields_raw is None:
+        worker_footer_fields = (
+            list(DEFAULT_WORKER_FOOTER_FIELDS)
+            if worker_output_shape == "hierarchical"
+            else []
+        )
+    else:
+        worker_footer_fields = ensure_string_list(
+            worker_footer_fields_raw, "worker_footer_fields", allow_empty=True
+        )
+    if worker_footer_fields_raw is not None and not decision_ready_packets:
+        raise ValueError(
+            "worker_footer_fields requires decision_ready_packets=true"
+        )
+    if worker_footer_fields_raw is not None and worker_output_shape != "hierarchical":
+        raise ValueError(
+            "worker_footer_fields requires worker_output_shape=hierarchical"
+        )
+
+    reread_reason_values_raw = raw.get("reread_reason_values")
+    if reread_reason_values_raw is None:
+        reread_reason_values = (
+            list(DEFAULT_REREAD_REASON_VALUES)
+            if decision_ready_packets or worker_return_contract == "classification-oriented"
+            else []
+        )
+    else:
+        reread_reason_values = ensure_string_list(
+            reread_reason_values_raw, "reread_reason_values", allow_empty=True
+        )
+
+    domain_overlay = normalize_domain_overlay(raw.get("domain_overlay"))
+    if domain_overlay["enabled"] and worker_return_contract != "classification-oriented":
+        raise ValueError(
+            "domain_overlay requires worker_return_contract=classification-oriented"
+        )
+
+    preferred_worker_families = normalize_preferred_worker_families(
+        raw.get("preferred_worker_families")
+    )
+    packet_worker_map = normalize_packet_worker_map(
+        raw.get("packet_worker_map"),
+        task_packet_names=task_packet_names,
+        uses_batch_packets=uses_batch_packets,
+    )
+    repo_profile = normalize_repo_profile(
+        raw.get("repo_profile"),
+        task_packet_names=task_packet_names,
+        uses_batch_packets=uses_batch_packets,
+        builder_versioning=builder_versioning,
+    )
+
+    if worker_output_shape == "hierarchical" and not candidate_field_bundles:
+        raise ValueError(
+            "worker_output_shape=hierarchical requires candidate_field_bundles or "
+            "required_candidate_fields"
+        )
+
+    candidate_field_bundles = apply_bundle_overrides(
+        candidate_field_bundles, domain_overlay["bundle_overrides"]
+    )
+    validate_alias_keys(candidate_field_bundles, domain_overlay["candidate_field_aliases"])
+    resolved_candidate_field_bundles = resolve_candidate_bundles(
+        candidate_field_bundles, domain_overlay["candidate_field_aliases"]
+    )
+
+    derived = {
+        "skill_name": normalize_skill_name(raw["skill_name"]),
+        "description": ensure_non_empty_string(raw["description"], "description"),
+        "domain_slug": normalize_domain_slug(raw["domain_slug"]),
+        "workflow_family": ensure_non_empty_string(
+            raw["workflow_family"], "workflow_family"
+        ),
+        "builder_versioning": builder_versioning,
+        "archetype": archetype,
+        "primary_goal": ensure_non_empty_string(raw["primary_goal"], "primary_goal"),
+        "trigger_phrases": trigger_phrases,
+        "task_packet_names": task_packet_names,
+        "uses_batch_packets": uses_batch_packets,
+        "orchestrator_profile": orchestrator_profile,
+        "needs_lint": bool(raw.get("needs_lint", defaults["needs_lint"])),
+        "needs_validate": bool(raw.get("needs_validate", defaults["needs_validate"])),
+        "needs_apply": bool(raw.get("needs_apply", defaults["needs_apply"])),
+        "optional_local_helper": optional_local_helper,
+        "authority_order": authority_order,
+        "stop_conditions": stop_conditions,
+        "review_mode_overrides": review_mode_overrides,
+        "decision_ready_packets": decision_ready_packets,
+        "worker_return_contract": worker_return_contract,
+        "worker_output_shape": worker_output_shape,
+        "xhigh_reread_policy": xhigh_reread_policy,
+        "required_candidate_fields": required_candidate_fields,
+        "candidate_field_bundles": candidate_field_bundles,
+        "resolved_candidate_field_bundles": resolved_candidate_field_bundles,
+        "worker_footer_fields": worker_footer_fields,
+        "reread_reason_values": reread_reason_values,
+        "known_worker_agent_types": list(KNOWN_WORKER_AGENT_TYPES),
+        "preferred_worker_families": preferred_worker_families,
+        "packet_worker_map": packet_worker_map,
+        "worker_selection_guidance": build_worker_selection_guidance(),
+        "repo_profile": repo_profile,
+        "domain_overlay": domain_overlay,
+        "candidate_template": build_candidate_template(resolved_candidate_field_bundles),
+        "footer_template": build_footer_template(worker_footer_fields),
+        "shared_local_packet": (
+            "synthesis_packet.json"
+            if orchestrator_profile == "packet-heavy-orchestrator"
+            else None
+        ),
+        "common_path_contract": (
+            copy.deepcopy(PACKET_HEAVY_COMMON_PATH_CONTRACT)
+            if orchestrator_profile == "packet-heavy-orchestrator"
+            else None
+        ),
+    }
+
+    if derived["needs_apply"] and not derived["needs_validate"]:
+        raise ValueError(
+            "needs_apply=true requires needs_validate=true in this scaffold"
+        )
+
+    return derived
+
+
+def templates_dir() -> Path:
+    return core_templates_dir()
+
+
+def load_template(template_name: str) -> str:
+    template_path = templates_dir() / template_name
+    return template_path.read_text(encoding="utf-8")
+
+
+def render(template_name: str, context: dict[str, str]) -> str:
+    rendered = load_template(template_name)
+    for key, value in sorted(context.items(), key=lambda item: len(item[0]), reverse=True):
+        rendered = rendered.replace(f"__{key}__", value)
+    return rendered
+
+
+def bullet_list(items: list[str], indent: str = "") -> str:
+    return "\n".join(f"{indent}- {item}" for item in items)
+
+
+def json_block(value: object) -> str:
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def python_block(value: object) -> str:
+    return pprint.pformat(value, sort_dicts=True)
+
+
+def short_description(value: str) -> str:
+    trimmed = value.strip()
+    if len(trimmed) <= 52:
+        return trimmed
+    return trimmed[:49].rstrip() + "..."
+
+
+def helper_note(spec: dict) -> str:
+    helper = spec["optional_local_helper"]
+    if not helper:
+        return "- No optional local helper is configured for this scaffold."
+    return (
+        f"- Treat `{helper['path']}` as an optional local-only helper for "
+        f"{helper['description']}; never treat it as an authoritative shared asset."
+    )
+
+
+def helper_collect_arg(spec: dict) -> str:
+    helper = spec["optional_local_helper"]
+    if not helper:
+        return ""
+    default_path = helper["path"].replace("\\", "/")
+    return (
+        '    parser.add_argument(\n'
+        '        "--local-helper",\n'
+        f'        default="{default_path}",\n'
+        '        help="Optional repo-relative local helper path.",\n'
+        "    )"
+    )
+
+
+def helper_collect_functions(spec: dict) -> str:
+    helper = spec["optional_local_helper"]
+    if not helper:
+        return ""
+    description = helper["description"]
+    return f"""
+def collect_optional_local_helper(repo_root: Path, helper_path: str) -> dict:
+    helper = Path(helper_path)
+    if helper.is_absolute():
+        raise SystemExit("[ERROR] --local-helper must stay repo-relative")
+    candidate = (repo_root / helper).resolve()
+    try:
+        candidate.relative_to(repo_root)
+    except ValueError as exc:
+        raise SystemExit("[ERROR] --local-helper must stay within the repo root") from exc
+
+    if not candidate.exists():
+        return {{
+            "path": helper.as_posix(),
+            "description": "{description}",
+            "status": "missing_optional_local_helper",
+            "is_authoritative": False,
+        }}
+
+    preview_lines = candidate.read_text(encoding="utf-8", errors="replace").splitlines()[:12]
+    return {{
+        "path": helper.as_posix(),
+        "description": "{description}",
+        "status": "present",
+        "is_authoritative": False,
+        "preview": preview_lines,
+    }}
+""".strip(
+        "\n"
+    )
+
+
+def helper_collect_context_line(spec: dict) -> str:
+    if spec["optional_local_helper"]:
+        return '    context["optional_local_helper"] = collect_optional_local_helper(repo_root, args.local_helper)'
+    return '    context["optional_local_helper"] = None'
+
+
+def format_profile_binding_value(value: str | None) -> str:
+    if value is None:
+        return "`null`"
+    return f"`{value}`"
+
+
+def repo_profile_note(spec: dict) -> str:
+    profile = spec["repo_profile"]
+    return "\n".join(
+        [
+            f"- Default repo profile scaffold: `{profile['profile_path']}`.",
+            "- Keep repo-specific paths, packet review docs, and deterministic lint toggles in the repo profile instead of hardcoding them into the generic core templates.",
+            "- Keep the repo profile data-only: paths, globs, doc lists, booleans, and notes only. Do not add executable hooks, prompt text, or worker-routing logic there.",
+        ]
+    )
+
+
+def repo_profile_bindings_markdown(spec: dict) -> str:
+    bindings = spec["repo_profile"]["bindings"]
+    return "\n".join(
+        [
+            f"- `primary_readme_path`: {format_profile_binding_value(bindings['primary_readme_path'])}",
+            f"- `settings_source_path`: {format_profile_binding_value(bindings['settings_source_path'])}",
+            f"- `publish_config_path`: {format_profile_binding_value(bindings['publish_config_path'])}",
+        ]
+    )
+
+
+def repo_profile_packet_defaults_markdown(spec: dict) -> str:
+    packet_defaults = spec["repo_profile"]["packet_defaults"]
+    review_docs = packet_defaults["review_docs"]
+    source_path_globs = packet_defaults["source_path_globs"]
+    lines = ["- review docs:"]
+    if review_docs:
+        for packet_name, docs in review_docs.items():
+            lines.append(f"  - `{packet_name}`")
+            lines.append(bullet_list([f"`{item}`" for item in docs], indent="    "))
+    else:
+        lines.append("  - none configured in the scaffold profile")
+    lines.append("- source path globs:")
+    if source_path_globs:
+        for packet_name, globs in source_path_globs.items():
+            lines.append(f"  - `{packet_name}`")
+            lines.append(bullet_list([f"`{item}`" for item in globs], indent="    "))
+    else:
+        lines.append("  - none configured in the scaffold profile")
+    return "\n".join(lines)
+
+
+def repo_profile_lint_rules_markdown(spec: dict) -> str:
+    lint_rules = spec["repo_profile"]["lint_rules"]
+    return "\n".join(
+        [
+            f"- `require_readme_settings_table`: {'true' if lint_rules['require_readme_settings_table'] else 'false'}",
+            f"- `missing_review_docs_are_errors`: {'true' if lint_rules['missing_review_docs_are_errors'] else 'false'}",
+        ]
+    )
+
+
+def repo_profile_notes_markdown(spec: dict) -> str:
+    notes = spec["repo_profile"].get("notes", [])
+    if not notes:
+        return "- no repo-profile notes are configured"
+    return bullet_list(notes)
+
+
+def format_resolved_candidate_field(field: dict) -> str:
+    semantic_name = field["semantic_name"]
+    field_name = field["field_name"]
+    label = GENERIC_FIELD_DESCRIPTIONS.get(semantic_name)
+    if label:
+        return f"{label} (`{field_name}`)"
+    if field_name != semantic_name:
+        return f"`{field_name}` (alias for `{semantic_name}`)"
+    return f"`{field_name}`"
+
+
+def candidate_bundle_markdown(bundles: list[dict]) -> str:
+    if not bundles:
+        return "- No candidate field bundles are configured for this scaffold."
+    sections: list[str] = []
+    for bundle in bundles:
+        lines = [
+            f"- `{bundle['name']}`",
+            f"  - required: {'yes' if bundle['required'] else 'no'}",
+        ]
+        if bundle["description"]:
+            lines.append(f"  - {bundle['description']}")
+        lines.append("  - fields:")
+        lines.extend(
+            [f"    - {format_resolved_candidate_field(field)}" for field in bundle["fields"]]
+        )
+        sections.append("\n".join(lines))
+    return "\n".join(sections)
+
+
+def worker_footer_markdown(fields: list[str]) -> str:
+    if not fields:
+        return "- No worker footer fields are configured for this scaffold."
+    return bullet_list(
+        [
+            f"`{field_name}`: {FOOTER_FIELD_DESCRIPTIONS.get(field_name, 'worker footer field')}"
+            for field_name in fields
+        ]
+    )
+
+
+def reread_reason_markdown(values: list[str]) -> str:
+    if not values:
+        return "- No explicit reread reasons are configured for this scaffold."
+    return bullet_list([f"`{value}`" for value in values])
+
+
+def overlay_precedence_markdown() -> str:
+    return bullet_list(OVERLAY_PRECEDENCE_RULES)
+
+
+def overlay_example_block() -> str:
+    example = {
+        "domain_overlay": {
+            "proposal_enum_values": [
+                "standalone_item",
+                "reference_only",
+                "ignore",
+            ],
+            "candidate_field_aliases": {
+                "fact_summary": "summary",
+                "proposal_classification": "proposed_classification",
+                "supporting_references": "source_refs",
+                "ambiguity": "open_ambiguity",
+                "reread_control": "raw_reread_reason",
+            },
+            "reference_only_candidate_values": ["reference_only"],
+            "output_inclusion_rules": {
+                "standalone": ["standalone_item"],
+                "reference_only": ["reference_only"],
+                "excluded": ["ignore"],
+            },
+            "bundle_overrides": {
+                "fact_and_evidence": {
+                    "fields": ["fact_summary", "supporting_references"],
+                }
+            },
+        }
+    }
+    return "\n".join(
+        [
+            "- No domain overlay is configured for this scaffold.",
+            "- Use a domain overlay when you need domain-specific proposal enums, field names, reference-only classes, or output inclusion rules.",
+            "```jsonc",
+            json_block(example),
+            "```",
+        ]
+    )
+
+
+def overlay_markdown(spec: dict) -> str:
+    overlay = spec["domain_overlay"]
+    if not overlay["enabled"]:
+        return overlay_example_block()
+
+    sections: list[str] = ["- Domain overlay is enabled for this scaffold."]
+    if overlay["proposal_enum_values"]:
+        sections.append("- Proposal enum values:")
+        sections.append(
+            bullet_list(
+                [f"`{value}`" for value in overlay["proposal_enum_values"]], indent="  "
+            )
+        )
+    else:
+        sections.append("- Proposal enum values are left to domain implementation.")
+
+    if overlay["candidate_field_aliases"]:
+        sections.append("- Candidate field aliases:")
+        sections.append(
+            bullet_list(
+                [
+                    f"`{semantic}` -> `{field_name}`"
+                    for semantic, field_name in overlay["candidate_field_aliases"].items()
+                ],
+                indent="  ",
+            )
+        )
+    else:
+        sections.append("- Candidate field aliases are not configured; generic slot names stay in place.")
+
+    if overlay["reference_only_candidate_values"]:
+        sections.append("- Reference-only candidate values:")
+        sections.append(
+            bullet_list(
+                [f"`{value}`" for value in overlay["reference_only_candidate_values"]],
+                indent="  ",
+            )
+        )
+
+    rules = overlay["output_inclusion_rules"]
+    if any(rules.values()):
+        sections.append("- Output inclusion rules:")
+        for rule_name in ["standalone", "reference_only", "excluded"]:
+            values = rules[rule_name]
+            if values:
+                sections.append(
+                    f"  - `{rule_name}`: " + ", ".join(f"`{value}`" for value in values)
+                )
+
+    if overlay["bundle_overrides"]:
+        sections.append("- Bundle overrides:")
+        sections.append(
+            bullet_list(
+                [f"`{bundle_name}`" for bundle_name in overlay["bundle_overrides"]],
+                indent="  ",
+            )
+        )
+
+    sections.extend(
+        [
+            "- Normalized overlay:",
+            "```json",
+            json_block(
+                {key: value for key, value in overlay.items() if key != "enabled"}
+            ),
+            "```",
+        ]
+    )
+    return "\n".join(sections)
+
+
+def lint_cli_section(spec: dict) -> tuple[str, str, str]:
+    if not spec["needs_lint"]:
+        return "", "", ""
+    step = (
+        f"- Run `<python-bin> -B <skill-dir>/scripts/lint_{spec['domain_slug']}.py --context <context-json> "
+        "--output <lint-json>`."
+    )
+    script_line = (
+        f"- `scripts/lint_{spec['domain_slug']}.py`\n"
+        "  - Run deterministic checks and emit warnings, errors, and override signals."
+    )
+    arg = " --lint <lint-json>"
+    return step, script_line, arg
+
+
+def workflow_tail(spec: dict) -> str:
+    step_number = 5
+    sections: list[str] = []
+    if spec["needs_validate"]:
+        sections.append(
+            "\n".join(
+                [
+                    f"{step_number}. Validate before mutating.",
+                    f"- Run `<python-bin> -B <skill-dir>/scripts/validate_{spec['domain_slug']}.py --context <context-json> --plan <plan-json> --output <validation-json>`.",
+                    "- Stop if validation reports errors, stale context, low-confidence findings, or an apply-gate failure.",
+                ]
+            )
+        )
+        step_number += 1
+    if spec["needs_apply"]:
+        sections.append(
+            "\n".join(
+                [
+                    f"{step_number}. Apply only after local verification.",
+                    f"- Run `<python-bin> -B <skill-dir>/scripts/apply_{spec['domain_slug']}.py --validation <validation-json>` after the validation output is locally reviewed.",
+                    "- Apply must consume validator-normalized output only; do not wire raw plan JSON directly into the mutation step.",
+                    "- If the user asked for `dry-run`, keep the same validation path and stop before any external mutation.",
+                ]
+            )
+        )
+    return "\n\n".join(sections)
+
+
+def mutation_output_note(spec: dict) -> str:
+    if spec["needs_apply"]:
+        return "- Tell the user whether the run stopped at planning, validation, or apply."
+    return "- Tell the user whether the run stopped at analysis or produced a non-mutating plan."
+
+
+def batch_note(spec: dict) -> str:
+    if spec["uses_batch_packets"]:
+        return "- Prefer `batch-packet-*.json` before singleton packets when both exist."
+    return "- This scaffold defaults to singleton focused packets only."
+
+
+def profile_runtime_note(spec: dict) -> str:
+    if spec["orchestrator_profile"] == "packet-heavy-orchestrator":
+        return "\n".join(
+            [
+                "- Orchestrator profile: `packet-heavy-orchestrator`.",
+                "- Keep runtime contract metadata lean. Put packet sizing, byte proxies, and delegation-efficiency counters in `packet_metrics.json` and evaluation logs instead of `orchestrator.json`.",
+                "- Read `synthesis_packet.json` as the shared local drafting packet before reopening raw artifacts.",
+            ]
+        )
+    return "\n".join(
+        [
+            "- Orchestrator profile: `standard`.",
+            "- Keep runtime metadata focused on routing, authority, stop conditions, and adjudication support only.",
+        ]
+    )
+
+
+def profile_runtime_artifacts(spec: dict) -> str:
+    if spec["orchestrator_profile"] == "packet-heavy-orchestrator":
+        return "\n".join(
+            [
+                "- Additional runtime packet:",
+                "  - `synthesis_packet.json` for common-path local drafting and synthesis.",
+            ]
+        )
+    return "- No additional orchestrator-profile-specific runtime packet is required."
+
+
+def profile_evaluation_artifacts(spec: dict) -> str:
+    if spec["orchestrator_profile"] == "packet-heavy-orchestrator":
+        return "\n".join(
+            [
+                "- Evaluation-only sidecar:",
+                "  - `packet_metrics.json` for packet sizing, byte proxies, and regression-oriented token-efficiency estimates.",
+            ]
+        )
+    return "- No orchestrator-profile-specific evaluation sidecar is required."
+
+
+def build_result_note(spec: dict) -> str:
+    if spec["orchestrator_profile"] == "packet-heavy-orchestrator":
+        return (
+            "- Recommended: add `--result-output <build-result-json>` so evaluation logging can merge build-phase packet metrics without expanding runtime contract metadata."
+        )
+    return (
+        "- Optional: add `--result-output <build-result-json>` when you want a machine-readable build summary for smoke runs or evaluation logging."
+    )
+
+
+def common_path_note(spec: dict) -> str:
+    if spec["orchestrator_profile"] != "packet-heavy-orchestrator":
+        return "- This scaffold does not add an orchestrator-profile-level common-path drafting packet."
+    return "\n".join(
+        [
+            "- Packet-heavy common path contract:",
+            "  - read `global_packet.json` first",
+            "  - keep `synthesis_packet.json` open for local drafting",
+            "  - reopen at most one focused packet in the common path",
+            "  - treat packet insufficiency as a build/contract failure instead of compensating with broad raw rereads",
+        ]
+    )
+
+
+def validate_result_contract(spec: dict) -> str:
+    if not spec["needs_validate"]:
+        return ""
+    return "\n".join(
+        [
+            "- Validation output must at least include:",
+            "  - `valid`",
+            "  - `can_apply`",
+            "  - `errors`",
+            "  - `warnings`",
+            "  - `stop_reasons`",
+            "  - `normalized_plan`",
+            "  - `normalized_plan_fingerprint`",
+            "  - `apply_gate_status`",
+        ]
+    )
+
+
+def validate_script_section(spec: dict) -> str:
+    if not spec["needs_validate"]:
+        return ""
+    return (
+        f"- `scripts/validate_{spec['domain_slug']}.py`\n"
+        "  - Validate the planned actions against the collected context, normalize the plan, and emit apply-gate status before apply."
+    )
+
+
+def apply_script_section(spec: dict) -> str:
+    if not spec["needs_apply"]:
+        return ""
+    return (
+        f"- `scripts/apply_{spec['domain_slug']}.py`\n"
+        "  - Dry-run or apply only from validator-normalized output after local verification."
+    )
+
+
+def contract_plan_note(spec: dict) -> str:
+    if not spec["needs_apply"] and not spec["needs_validate"]:
+        return "- This archetype does not require a dedicated plan file by default."
+    return (
+        "- Suggested plan artifact: `<domain>-plan.json` with `context_id`, "
+        "`overall_confidence`, `selected_packets`, `actions`, `stop_reasons`, and optional "
+        "`draft_basis` notes for common-path local drafting."
+    )
+
+
+def validate_plan_contract(spec: dict) -> str:
+    if not spec["needs_validate"]:
+        return ""
+    return "\n".join(
+        [
+            "## Validate Contract",
+            "",
+            f"- `scripts/validate_{spec['domain_slug']}.py` should accept:",
+            "  - `--context <json>`",
+            "  - `--plan <json>`",
+            "  - `--output <json>`",
+            "- Plan field policy for the generated skeleton:",
+            "  - required: `skill_name`, `context_id`, `selected_packets`, `actions`, `stop_reasons`",
+            "  - allowed: required fields plus `overall_confidence`, `review_mode`, `notes`, `draft_basis`",
+            "  - ignored: `metadata`",
+            "- Unknown extra plan fields should be dropped from the normalized plan and surfaced with a fixed warning code.",
+            validate_result_contract(spec),
+            "",
+        ]
+    )
+
+
+def apply_plan_contract(spec: dict) -> str:
+    if not spec["needs_apply"]:
+        return ""
+    return "\n".join(
+        [
+            "## Apply Contract",
+            "",
+            f"- `scripts/apply_{spec['domain_slug']}.py` should accept:",
+            "  - `--validation <json>`",
+            "  - optional `--dry-run`",
+            "  - optional `--result-output <json>`",
+            "- Apply must consume validator-normalized output only and recompute the normalized plan fingerprint before mutating.",
+            "- The default generated skeleton is intentionally conservative and does not perform real mutations until domain logic is implemented.",
+            "",
+        ]
+    )
+
+
+def lint_template_blocks(spec: dict) -> tuple[str, str]:
+    if spec["needs_lint"]:
+        return (
+            '    parser.add_argument("--lint", help="Optional lint findings JSON.")',
+            "    lint = load_json(Path(args.lint)) if args.lint else {}",
+        )
+    return "", "    lint = {}"
+
+
+def batch_block(spec: dict) -> str:
+    if not spec["uses_batch_packets"]:
+        return ""
+    return """
+    batch_packet = {
+        "packet_id": "batch-packet-01",
+        "packet_kind": "batch",
+        "packet_targets": PACKET_NAMES,
+        "context_id": context.get("context_id"),
+        "todo": "Group related singleton packets here when the workflow benefits from clustering.",
+    }
+    write_json(output_dir / "batch-packet-01.json", batch_packet)
+""".rstrip("\n")
+
+
+def lint_warning_block(spec: dict) -> str:
+    if spec["optional_local_helper"]:
+        return """
+    helper = context.get("optional_local_helper") or {}
+    if helper.get("status") == "missing_optional_local_helper":
+        findings["warnings"].append(
+            "Optional local helper is missing; omit handoff commands until the helper exists."
+        )
+"""
+    return ""
+
+
+def active_worker_contract_note(spec: dict) -> str:
+    if spec["worker_return_contract"] == "generic":
+        return "\n".join(
+            [
+                "- Active worker return contract: `generic`.",
+                "- Active worker output shape: `flat`.",
+                "- Return exactly:",
+                "  - `packet ids`",
+                "  - `primary outcome`",
+                "  - `evidence files`",
+                "  - `recommended next step`",
+                "  - `risk`",
+                "  - `tests or checks`",
+            ]
+        )
+
+    if spec["worker_output_shape"] == "hierarchical":
+        return "\n".join(
+            [
+                "- Active worker return contract: `classification-oriented`.",
+                "- Active worker output shape: `hierarchical`.",
+                "- Return exactly:",
+                "  - `candidates[]`",
+                "  - `footer`",
+                "- Each `candidates[]` entry must include:",
+                "  - fixed `candidate_id`",
+                candidate_bundle_markdown(spec["resolved_candidate_field_bundles"]).replace(
+                    "\n", "\n  "
+                ),
+                "- Keep candidate-level factual summaries inside `candidates[]` only.",
+                "- `footer` must include:",
+                worker_footer_markdown(spec["worker_footer_fields"]).replace("\n", "\n  "),
+                "- Use `footer.primary_outcome` as the worker-level batch summary only.",
+                "- Treat proposal classifications as worker proposal only; the main agent may override them.",
+                "- Treat `footer.overall_confidence` as worker batch confidence only; final plan confidence is recomputed locally.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "- Active worker return contract: `classification-oriented`.",
+            "- Active worker output shape: `flat`.",
+            "- Return exactly:",
+            "  - `packet ids`",
+            "  - `candidate records`",
+            "  - `packet confidence`",
+            "  - `missing evidence`",
+            "  - `candidate conflicts`",
+            "  - `recommended next step`",
+            "  - `tests or checks`",
+            "- Treat proposal classifications as worker proposal only; the main agent may override them.",
+        ]
+    )
+
+
+def worker_prompt_return_block(spec: dict) -> str:
+    if spec["worker_return_contract"] == "generic":
+        return "\n".join(
+            [
+                "Return exactly:",
+                "- packet ids",
+                "- primary outcome",
+                "- evidence files",
+                "- recommended next step",
+                "- risk",
+                "- tests or checks",
+            ]
+        )
+
+    if spec["worker_output_shape"] == "hierarchical":
+        return "\n".join(
+            [
+                "Return exactly:",
+                "- candidates[]",
+                "- footer",
+                "",
+                "Each candidate must include:",
+                "- candidate_id",
+                candidate_bundle_markdown(spec["resolved_candidate_field_bundles"]),
+                "",
+                "Footer must include:",
+                worker_footer_markdown(spec["worker_footer_fields"]),
+                "",
+                "Treat proposal classifications as worker proposal only.",
+                "Keep candidate-level factual summaries inside candidates[].",
+                "Use footer.primary_outcome as the worker-level batch summary only.",
+                "Treat footer.overall_confidence as worker batch confidence only; final plan confidence is recomputed locally.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "Return exactly:",
+            "- packet ids",
+            "- candidate records",
+            "- packet confidence",
+            "- missing evidence",
+            "- candidate conflicts",
+            "- recommended next step",
+            "- tests or checks",
+            "",
+            "Treat proposal classifications as worker proposal only.",
+        ]
+    )
+
+
+def worker_output_guidance(spec: dict) -> str:
+    if spec["worker_return_contract"] == "generic":
+        return "\n".join(
+            [
+                "- Keep final adjudication local.",
+                "- Keep worker outputs narrow and use them as inputs to local synthesis, not as final decisions.",
+                "- Recompute final plan confidence locally during synthesis from packet evidence, worker outputs, unresolved reread exceptions, and authority conflicts.",
+                "- Use the named context/findings worker family when delegation is needed and keep candidate-producing workers optional unless the workflow becomes adjudication-heavy.",
+            ]
+        )
+
+    lines = [
+        "- Final adjudication stays local even when mini workers propose candidate classifications.",
+        "- Treat proposal classifications as worker proposal only; the main agent may override them.",
+        "- Recompute final plan confidence locally during synthesis from packet evidence, worker outputs, unresolved reread exceptions, and authority conflicts.",
+        f"- Domain-specific candidate semantics come from `references/{spec['domain_slug'].replace('_', '-')}-contract.md`, not from the base builder contract.",
+        "- Prefer named worker families: `repo_mapper` and `docs_verifier` for context/findings, `evidence_summarizer`, `large_diff_auditor`, and `log_triager` for candidate production.",
+    ]
+    if spec["worker_output_shape"] == "hierarchical":
+        lines.extend(
+            [
+                "- Workers return `candidates[]` plus `footer` in hierarchical mode.",
+                "- Keep candidate-level fact summaries inside `candidates[]`.",
+                "- Keep the worker batch summary inside `footer.primary_outcome` only.",
+                "- Treat `footer.overall_confidence` as worker batch confidence only, not final plan confidence.",
+            ]
+        )
+    else:
+        lines.append(
+            "- Keep proposal-grade candidate records flat only when compatibility requires it; do not treat worker classifications as final adjudication."
+        )
+    return "\n".join(lines)
+
+
+def decision_ready_skill_guidance(spec: dict) -> str:
+    if spec["worker_return_contract"] != "classification-oriented":
+        return (
+            "- Start from packetized evidence first and only widen to raw artifact rereads when "
+            "the reread policy is triggered."
+        )
+    lines = [
+        "- Treat focused packets as decision-ready candidate inputs, not hint-only summaries.",
+        f"- Worker output shape for this skill: `{spec['worker_output_shape']}`.",
+        "- Keep final adjudication local even when workers propose classifications.",
+        "- Recompute final plan confidence locally from packet evidence, worker outputs, unresolved reread exceptions, and authority conflicts.",
+        f"- Use `references/{spec['domain_slug'].replace('_', '-')}-contract.md` for domain-specific proposal enums, candidate aliases, reference-only classes, and inclusion rules.",
+    ]
+    if spec["worker_output_shape"] == "hierarchical":
+        lines.extend(
+            [
+                "- Keep candidate-level fact summaries inside `candidates[]` and the worker batch summary inside `footer.primary_outcome` only.",
+                "- Treat `footer.overall_confidence` as worker batch confidence only, not final plan confidence.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def confidence_layering_note(spec: dict) -> str:
+    if spec["worker_return_contract"] == "classification-oriented":
+        if spec["worker_output_shape"] == "hierarchical":
+            return (
+                "Final plan confidence is recomputed locally even when "
+                "`footer.overall_confidence` is present."
+            )
+        return (
+            "Final plan confidence is recomputed locally even when packet or "
+            "candidate confidence signals are present."
+        )
+    return (
+        "Final plan confidence is recomputed locally even when worker confidence "
+        "signals are present."
+    )
+
+
+def generic_adjudication_section(spec: dict) -> str:
+    lines = [
+        "## Generic Adjudication Structure",
+        "",
+        f"- This scaffold uses the `{spec['worker_return_contract']}` worker return contract.",
+        f"- XHigh reread policy: {spec['xhigh_reread_policy']}",
+        "- Final plan confidence is recomputed locally during synthesis. Do not copy worker confidence through unchanged.",
+    ]
+    if spec["worker_return_contract"] == "classification-oriented":
+        lines.extend(
+            [
+                f"- Worker output shape: `{spec['worker_output_shape']}`",
+                "- Proposal classifications are worker proposal only. The main agent may override them during local adjudication.",
+            ]
+        )
+        if spec["worker_output_shape"] == "hierarchical":
+            lines.extend(
+                [
+                    "- Hierarchical worker output uses fixed top-level keys:",
+                    "  - `candidates[]`",
+                    "  - `footer`",
+                    "- Candidate field bundles:",
+                    candidate_bundle_markdown(spec["resolved_candidate_field_bundles"]),
+                    "- Worker footer fields:",
+                    worker_footer_markdown(spec["worker_footer_fields"]),
+                    "- Allowed reread reasons:",
+                    reread_reason_markdown(spec["reread_reason_values"]),
+                ]
+            )
+    else:
+        lines.extend(
+            [
+                "- Generic flat mode does not require hierarchical `candidates[]` plus `footer` worker output.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def worker_family_section(spec: dict) -> str:
+    lines = [
+        "## Worker Families",
+        "",
+        "- The builder keeps worker-family structure generic and reusable across packet-driven workflows.",
+        "- Preferred worker families for this scaffold:",
+        worker_family_markdown(spec),
+        "",
+        "- Surfaced optional worker pool for generated docs stays deduped even when a worker belongs to multiple families:",
+        bullet_list([f"`{agent_type}`" for agent_type in surfaced_optional_worker_pool(spec)]),
+        "",
+        "- Packet routing hook:",
+        packet_worker_map_markdown(spec["packet_worker_map"]),
+        "",
+        worker_selection_guidance_markdown(spec["worker_selection_guidance"]),
+    ]
+    return "\n".join(lines)
+
+
+def domain_overlay_section(spec: dict) -> str:
+    return "\n".join(
+        [
+            "## Domain Overlay",
+            "",
+            "- Domain overlays specialize semantics without changing the shared adjudication structure.",
+            "- Precedence order:",
+            overlay_precedence_markdown(),
+            "",
+            overlay_markdown(spec),
+        ]
+    )
+
+
+def focused_packet_template(spec: dict) -> str:
+    if spec["worker_return_contract"] == "classification-oriented":
+        if spec["worker_output_shape"] == "hierarchical":
+            return "\n".join(
+                [
+                    "{",
+                    '                "packet_id": packet_name,',
+                    '                "packet_kind": "focused",',
+                    '                "context_id": context.get("context_id"),',
+                    '                "repo_profile_name": context.get("repo_profile_name"),',
+                    '                "decision_ready": True,',
+                    '                "worker_return_contract": SPEC_METADATA["worker_return_contract"],',
+                    '                "worker_output_shape": SPEC_METADATA["worker_output_shape"],',
+                    '                "candidate_field_bundles": SPEC_METADATA["resolved_candidate_field_bundles"],',
+                    '                "worker_footer_fields": SPEC_METADATA["worker_footer_fields"],',
+                    '                "reread_reason_values": SPEC_METADATA["reread_reason_values"],',
+                    '                "domain_overlay": SPEC_METADATA["domain_overlay"],',
+                    '                "candidates": [],',
+                    '                "candidate_template": SPEC_METADATA["candidate_template"],',
+                    '                "footer": SPEC_METADATA["footer_template"],',
+                    '                "todo": "Populate candidates[] plus footer with decision-ready worker proposals. Keep final adjudication and final plan confidence local.",',
+                    "            }",
+                ]
+            )
+        return "\n".join(
+            [
+                "{",
+                '                "packet_id": packet_name,',
+                '                "packet_kind": "focused",',
+                '                "context_id": context.get("context_id"),',
+                '                "repo_profile_name": context.get("repo_profile_name"),',
+                '                "decision_ready": True,',
+                '                "worker_return_contract": SPEC_METADATA["worker_return_contract"],',
+                '                "worker_output_shape": SPEC_METADATA["worker_output_shape"],',
+                '                "candidate_field_bundles": SPEC_METADATA["resolved_candidate_field_bundles"],',
+                '                "reread_reason_values": SPEC_METADATA["reread_reason_values"],',
+                '                "domain_overlay": SPEC_METADATA["domain_overlay"],',
+                '                "todo": "Populate this packet with flat classification-oriented worker outputs only if hierarchical output is intentionally disabled for compatibility.",',
+                "            }",
+            ]
+        )
+    return "\n".join(
+        [
+            "{",
+            '                "packet_id": packet_name,',
+            '                "packet_kind": "focused",',
+            '                "context_id": context.get("context_id"),',
+            '                "repo_profile_name": context.get("repo_profile_name"),',
+            '                "decision_ready": False,',
+            '                "worker_return_contract": SPEC_METADATA["worker_return_contract"],',
+            '                "todo": "Populate this packet with one narrow workflow concern.",',
+            "            }",
+        ]
+    )
+
+
+def worker_instruction(agent_type: str, spec: dict) -> str:
+    if agent_type == "repo_mapper":
+        return (
+            "Read global_packet.json first and return packet-friendly mapping findings "
+            "covering execution path, touched surfaces, packet membership hints, "
+            "assumptions, unknowns, and exact refs."
+        )
+    if agent_type == "packet_explorer":
+        return (
+            "Read global_packet.json first, then exactly one focused packet or one "
+            "batch packet. Open extra file slices only when the packet cannot carry "
+            "enough evidence on its own. Return packet-friendly code, behavior, or "
+            "workflow findings without final adjudication or mutation."
+        )
+    if agent_type == "docs_verifier":
+        return (
+            "Read global_packet.json first and return narrow verification findings with "
+            "verified claims, inferred claims, unknowns or claim gaps, and exact refs."
+        )
+    if spec["worker_return_contract"] == "classification-oriented":
+        if spec["worker_output_shape"] == "hierarchical":
+            return (
+                "Read global_packet.json first and return hierarchical proposal-grade "
+                "candidate output with candidates[] plus footer."
+            )
+        return (
+            "Read global_packet.json first and return flat proposal-grade candidate output."
+        )
+    return "Read global_packet.json first and stay narrow."
+
+
+def worker_instruction_map(spec: dict) -> dict[str, str]:
+    return {
+        agent_type: worker_instruction(agent_type, spec)
+        for agent_type in KNOWN_WORKER_AGENT_TYPES
+    }
+
+
+def build_render_context(spec: dict) -> dict[str, str]:
+    lint_step, lint_script_section, build_lint_arg = lint_cli_section(spec)
+    skill_title = title_case(spec["skill_name"])
+    contract_file = spec["domain_slug"].replace("_", "-") + "-contract.md"
+    spec_metadata = {
+        "skill_name": spec["skill_name"],
+        "domain_slug": spec["domain_slug"],
+        "workflow_family": spec["workflow_family"],
+        "archetype": spec["archetype"],
+        "orchestrator_profile": spec["orchestrator_profile"],
+        "primary_goal": spec["primary_goal"],
+        "task_packet_names": spec["task_packet_names"],
+        "uses_batch_packets": spec["uses_batch_packets"],
+        "needs_lint": spec["needs_lint"],
+        "needs_validate": spec["needs_validate"],
+        "needs_apply": spec["needs_apply"],
+        "authority_order": spec["authority_order"],
+        "stop_conditions": spec["stop_conditions"],
+        "review_mode_overrides": spec["review_mode_overrides"],
+        "trigger_phrases": spec["trigger_phrases"],
+        "decision_ready_packets": spec["decision_ready_packets"],
+        "worker_return_contract": spec["worker_return_contract"],
+        "worker_output_shape": spec["worker_output_shape"],
+        "xhigh_reread_policy": spec["xhigh_reread_policy"],
+        "required_candidate_fields": spec["required_candidate_fields"],
+        "candidate_field_bundles": spec["candidate_field_bundles"],
+        "resolved_candidate_field_bundles": spec["resolved_candidate_field_bundles"],
+        "worker_footer_fields": spec["worker_footer_fields"],
+        "reread_reason_values": spec["reread_reason_values"],
+        "known_worker_agent_types": spec["known_worker_agent_types"],
+        "preferred_worker_families": spec["preferred_worker_families"],
+        "packet_worker_map": spec["packet_worker_map"],
+        "worker_selection_guidance": spec["worker_selection_guidance"],
+        "builder_versioning": spec["builder_versioning"],
+        "repo_profile": spec["repo_profile"],
+        "domain_overlay": spec["domain_overlay"],
+        "candidate_template": spec["candidate_template"],
+        "footer_template": spec["footer_template"],
+        "shared_local_packet": spec["shared_local_packet"],
+        "common_path_contract": spec["common_path_contract"],
+    }
+    if spec["optional_local_helper"]:
+        spec_metadata["optional_local_helper"] = spec["optional_local_helper"]
+
+    lint_arg_block, lint_load_block = lint_template_blocks(spec)
+    return {
+        "SKILL_NAME": spec["skill_name"],
+        "SKILL_TITLE": skill_title,
+        "DESCRIPTION": spec["description"],
+        "SHORT_DESCRIPTION": short_description(spec["primary_goal"]),
+        "DEFAULT_PROMPT": spec["primary_goal"],
+        "RETAINED_SKILL_DIR": (
+            f"../../../builders/packet-workflow/retained-skills/{spec['skill_name']}"
+        ),
+        "RETAINED_SKILL_MD": (
+            f"../../../builders/packet-workflow/retained-skills/{spec['skill_name']}/SKILL.md"
+        ),
+        "DOMAIN_SLUG": spec["domain_slug"],
+        "WORKFLOW_FAMILY": spec["workflow_family"],
+        "PRIMARY_GOAL": spec["primary_goal"],
+        "ARCHETYPE": spec["archetype"],
+        "ORCHESTRATOR_PROFILE": spec["orchestrator_profile"],
+        "TRIGGER_PHRASES_BULLETS": bullet_list(spec["trigger_phrases"]),
+        "TASK_PACKET_BULLETS": bullet_list(
+            [f"`{name}.json`" for name in spec["task_packet_names"]]
+        ),
+        "AUTHORITY_ORDER_BULLETS": bullet_list(spec["authority_order"]),
+        "STOP_CONDITIONS_BULLETS": bullet_list(spec["stop_conditions"]),
+        "REVIEW_MODE_OVERRIDES_BULLETS": bullet_list(spec["review_mode_overrides"]),
+        "OPTIONAL_LOCAL_HELPER_NOTE": helper_note(spec),
+        "REPO_PROFILE_NOTE": repo_profile_note(spec),
+        "REPO_PROFILE_FILE": spec["repo_profile"]["profile_path"],
+        "REPO_PROFILE_NAME": spec["repo_profile"]["name"],
+        "REPO_PROFILE_SUMMARY": spec["repo_profile"]["summary"],
+        "REPO_PROFILE_BINDINGS_MARKDOWN": repo_profile_bindings_markdown(spec),
+        "REPO_PROFILE_PACKET_DEFAULTS_MARKDOWN": repo_profile_packet_defaults_markdown(spec),
+        "REPO_PROFILE_LINT_RULES_MARKDOWN": repo_profile_lint_rules_markdown(spec),
+        "REPO_PROFILE_NOTES_MARKDOWN": repo_profile_notes_markdown(spec),
+        "REPO_PROFILE_JSON": json_block(spec["repo_profile"]),
+        "CORE_CONTRACT_FILE": "core-contract.md",
+        "WORKFLOW_TAIL": workflow_tail(spec),
+        "MUTATION_OUTPUT_NOTE": mutation_output_note(spec),
+        "BATCH_PACKET_NOTE": batch_note(spec),
+        "PROFILE_RUNTIME_NOTE": profile_runtime_note(spec),
+        "PROFILE_RUNTIME_ARTIFACTS": profile_runtime_artifacts(spec),
+        "PROFILE_EVALUATION_ARTIFACTS": profile_evaluation_artifacts(spec),
+        "BUILD_RESULT_NOTE": build_result_note(spec),
+        "COMMON_PATH_NOTE": common_path_note(spec),
+        "LINT_STEP": lint_step,
+        "LINT_SCRIPT_SECTION": lint_script_section,
+        "VALIDATE_SCRIPT_SECTION": validate_script_section(spec),
+        "APPLY_SCRIPT_SECTION": apply_script_section(spec),
+        "BUILD_LINT_ARG": build_lint_arg,
+        "DOMAIN_CONTRACT_FILE": contract_file,
+        "DOMAIN_CONTRACT_PLAN_NOTE": contract_plan_note(spec),
+        "VALIDATE_PLAN_CONTRACT": validate_plan_contract(spec),
+        "APPLY_PLAN_CONTRACT": apply_plan_contract(spec),
+        "DECISION_READY_PACKETS": "true" if spec["decision_ready_packets"] else "false",
+        "WORKER_RETURN_CONTRACT": spec["worker_return_contract"],
+        "WORKER_OUTPUT_SHAPE": spec["worker_output_shape"],
+        "XHIGH_REREAD_POLICY": spec["xhigh_reread_policy"],
+        "WORKER_OUTPUT_GUIDANCE": worker_output_guidance(spec),
+        "KNOWN_WORKER_AGENT_TYPES_BULLETS": bullet_list(
+            [f"`{agent_type}`" for agent_type in spec["known_worker_agent_types"]]
+        ),
+        "WORKER_FAMILY_MARKDOWN": worker_family_markdown(spec),
+        "PACKET_WORKER_MAP_MARKDOWN": packet_worker_map_markdown(
+            spec["packet_worker_map"]
+        ),
+        "WORKER_SELECTION_GUIDANCE_MARKDOWN": worker_selection_guidance_markdown(
+            spec["worker_selection_guidance"]
+        ),
+        "SURFACED_OPTIONAL_WORKERS_BULLETS": (
+            bullet_list(
+                [
+                    f"`{agent_type}`"
+                    for agent_type in surfaced_optional_worker_list_for_docs(spec)
+                ]
+            )
+            or "- no additional optional workers remain after explicit packet routing"
+        ),
+        "CANDIDATE_FIELD_BUNDLES_MARKDOWN": candidate_bundle_markdown(
+            spec["resolved_candidate_field_bundles"]
+        ),
+        "WORKER_FOOTER_FIELDS_MARKDOWN": worker_footer_markdown(
+            spec["worker_footer_fields"]
+        ),
+        "REREAD_REASON_VALUES_MARKDOWN": reread_reason_markdown(
+            spec["reread_reason_values"]
+        ),
+        "OVERLAY_PRECEDENCE_MARKDOWN": overlay_precedence_markdown(),
+        "DOMAIN_OVERLAY_MARKDOWN": overlay_markdown(spec),
+        "ACTIVE_WORKER_CONTRACT_NOTE": active_worker_contract_note(spec),
+        "WORKER_PROMPT_RETURN_BLOCK": worker_prompt_return_block(spec),
+        "CONFIDENCE_LAYERING_NOTE": confidence_layering_note(spec),
+        "DECISION_READY_SKILL_GUIDANCE": decision_ready_skill_guidance(spec),
+        "GENERIC_ADJUDICATION_SECTION": generic_adjudication_section(spec),
+        "WORKER_FAMILY_SECTION": worker_family_section(spec),
+        "DOMAIN_OVERLAY_SECTION": domain_overlay_section(spec),
+        "FOCUSED_PACKET_TEMPLATE": focused_packet_template(spec),
+        "WORKER_INSTRUCTION_MAP_JSON": python_block(worker_instruction_map(spec)),
+        "SPEC_METADATA_JSON": python_block(spec_metadata),
+        "TASK_PACKET_NAMES_JSON": python_block(spec["task_packet_names"]),
+        "USES_BATCH_PACKETS": "True" if spec["uses_batch_packets"] else "False",
+        "REVIEW_MODE_OVERRIDES_JSON": python_block(spec["review_mode_overrides"]),
+        "AUTHORITY_ORDER_JSON": python_block(spec["authority_order"]),
+        "STOP_CONDITIONS_JSON": python_block(spec["stop_conditions"]),
+        "LINT_ARG_BLOCK": lint_arg_block,
+        "LINT_LOAD_BLOCK": lint_load_block,
+        "BATCH_BLOCK": batch_block(spec),
+        "EXPECTS_LOCAL_HELPER": "True" if spec["optional_local_helper"] else "False",
+        "LINT_WARNING_BLOCK": lint_warning_block(spec),
+        "HELPER_COLLECT_ARG_BLOCK": helper_collect_arg(spec),
+        "HELPER_COLLECT_FUNCTIONS": helper_collect_functions(spec),
+        "HELPER_COLLECT_CONTEXT_LINE": helper_collect_context_line(spec),
+    }
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8", newline="\n")
+
+
+def generate_retained_files(skill_dir: Path, spec: dict) -> list[Path]:
+    context = build_render_context(spec)
+    generated: list[Path] = []
+
+    outputs = {
+        "SKILL.md": "skill_md.tmpl",
+        "agents/openai.yaml": "openai_yaml.tmpl",
+        "references/core-contract.md": "core_contract.tmpl",
+        "references/delegation-playbook.md": "delegation_playbook.tmpl",
+        f"references/{spec['domain_slug'].replace('_', '-')}-contract.md": "domain_contract.tmpl",
+        "references/evaluation-log-contract.md": "evaluation_log_contract.tmpl",
+        f"references/{spec['domain_slug'].replace('_', '-')}-evaluation-contract.md": "domain_evaluation_contract.tmpl",
+        f"scripts/collect_{spec['domain_slug']}_context.py": "collect_context.py.tmpl",
+        f"scripts/build_{spec['domain_slug']}_packets.py": "build_packets.py.tmpl",
+        "scripts/write_evaluation_log.py": "write_evaluation_log.py.tmpl",
+        spec["repo_profile"]["profile_path"]: "repo_profile_json.tmpl",
+    }
+    if spec["needs_lint"]:
+        outputs[f"scripts/lint_{spec['domain_slug']}.py"] = "lint.py.tmpl"
+    if spec["needs_validate"]:
+        outputs[f"scripts/validate_{spec['domain_slug']}.py"] = "validate.py.tmpl"
+    if spec["needs_apply"]:
+        outputs[f"scripts/apply_{spec['domain_slug']}.py"] = "apply.py.tmpl"
+
+    for relative_path, template_name in outputs.items():
+        destination = skill_dir / relative_path
+        write_text(destination, render(template_name, context))
+        generated.append(destination)
+
+    return generated
+
+
+def generate_wrapper_files(wrapper_dir: Path, spec: dict) -> list[Path]:
+    context = build_render_context(spec)
+    generated: list[Path] = []
+    outputs = {
+        "SKILL.md": "skill_wrapper_md.tmpl",
+        "agents/openai.yaml": "openai_yaml.tmpl",
+    }
+    for relative_path, template_name in outputs.items():
+        destination = wrapper_dir / relative_path
+        write_text(destination, render(template_name, context))
+        generated.append(destination)
+    return generated
+
+
+def generate_files(skill_dir: Path, spec: dict) -> list[Path]:
+    return generate_retained_files(skill_dir, spec)
+
+
+def ensure_target_is_empty(path: Path, *, label: str) -> None:
+    if path.exists() and any(path.iterdir()):
+        raise ValueError(f"Refusing to overwrite non-empty {label}: {path}")
+
+
+def generate_skill_layout(
+    output_root: Path, spec: dict
+) -> tuple[Path, list[Path], Path, list[Path]]:
+    retained_dir = retained_skills_root(output_root) / str(spec["skill_name"])
+    wrapper_dir = wrapper_skills_root(output_root) / str(spec["skill_name"])
+    ensure_target_is_empty(retained_dir, label="retained skill directory")
+    ensure_target_is_empty(wrapper_dir, label="wrapper skill directory")
+    retained_dir.mkdir(parents=True, exist_ok=True)
+    wrapper_dir.mkdir(parents=True, exist_ok=True)
+    retained_files = generate_retained_files(retained_dir, spec)
+    wrapper_files = generate_wrapper_files(wrapper_dir, spec)
+    return retained_dir, retained_files, wrapper_dir, wrapper_files
+
+
+def main() -> int:
+    args = parse_args()
+    spec_path = Path(args.spec).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    try:
+        validate_managed_agent_registry(args.managed_agents_dir)
+        spec = derive_spec(load_spec(spec_path))
+        retained_dir, retained_files, wrapper_dir, wrapper_files = generate_skill_layout(
+            output_dir, spec
+        )
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+    print(f"[OK] Generated retained {spec['skill_name']} kernel at {retained_dir}")
+    for path in retained_files:
+        print(f" - retained {path.relative_to(retained_dir)}")
+    print(f"[OK] Generated thin wrapper for {spec['skill_name']} at {wrapper_dir}")
+    for path in wrapper_files:
+        print(f" - wrapper {path.relative_to(wrapper_dir)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/builders/packet-workflow/scripts/packet_workflow_versioning.py
+++ b/builders/packet-workflow/scripts/packet_workflow_versioning.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Shared builder-version compatibility helpers for packet-workflow."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+STATUS_CURRENT = "current"
+STATUS_SEMVER_BEHIND_COMPATIBLE = "semver-behind-compatible"
+STATUS_STALE_SKILL = "stale-skill"
+STATUS_STALE_PROFILE = "stale-profile"
+STATUS_MISSING_SKILL_VERSIONING = "missing-skill-versioning"
+STATUS_MISSING_PROFILE_VERSIONING = "missing-profile-versioning"
+STATUS_AHEAD_OF_BUILDER = "ahead-of-builder"
+
+BLOCKING_STATUSES = {
+    STATUS_STALE_SKILL,
+    STATUS_STALE_PROFILE,
+    STATUS_MISSING_SKILL_VERSIONING,
+    STATUS_MISSING_PROFILE_VERSIONING,
+    STATUS_AHEAD_OF_BUILDER,
+}
+
+SEMVER_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+def foundry_root_dir() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def canonical_builder_version_path() -> Path:
+    return foundry_root_dir() / "builders" / "packet-workflow" / "version.json"
+
+
+def canonical_retained_skills_root() -> Path:
+    return foundry_root_dir() / "builders" / "packet-workflow" / "retained-skills"
+
+
+def load_json_document(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json_document(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def parse_semver(value: Any) -> tuple[int, int, int] | None:
+    text = str(value or "").strip()
+    match = SEMVER_RE.fullmatch(text)
+    if match is None:
+        return None
+    return tuple(int(match.group(name)) for name in ("major", "minor", "patch"))
+
+
+def normalize_versioning_block(
+    value: Any,
+    *,
+    require_builder_spec_schema_version: bool,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    builder_family = value.get("builder_family")
+    builder_semver = value.get("builder_semver")
+    compatibility_epoch = value.get("compatibility_epoch")
+    repo_profile_schema_version = value.get("repo_profile_schema_version")
+    if not isinstance(builder_family, str) or not builder_family.strip():
+        return None
+    if parse_semver(builder_semver) is None:
+        return None
+    if not isinstance(compatibility_epoch, int):
+        return None
+    if not isinstance(repo_profile_schema_version, int):
+        return None
+    normalized = {
+        "builder_family": builder_family.strip(),
+        "builder_semver": str(builder_semver).strip(),
+        "compatibility_epoch": compatibility_epoch,
+        "repo_profile_schema_version": repo_profile_schema_version,
+    }
+    if require_builder_spec_schema_version:
+        builder_spec_schema_version = value.get("builder_spec_schema_version")
+        if not isinstance(builder_spec_schema_version, int):
+            return None
+        normalized["builder_spec_schema_version"] = builder_spec_schema_version
+    return normalized
+
+
+def load_builder_versioning(path: Path | None = None) -> dict[str, Any]:
+    version_path = path or canonical_builder_version_path()
+    normalized = normalize_versioning_block(
+        load_json_document(version_path),
+        require_builder_spec_schema_version=True,
+    )
+    if normalized is None:
+        raise RuntimeError(f"Invalid builder version metadata: {version_path}")
+    return normalized
+
+
+def extract_skill_builder_versioning(spec_payload: Any) -> dict[str, Any] | None:
+    if not isinstance(spec_payload, dict):
+        return None
+    return normalize_versioning_block(
+        spec_payload.get("builder_versioning"),
+        require_builder_spec_schema_version=True,
+    )
+
+
+def extract_profile_versioning(profile_payload: Any) -> dict[str, Any] | None:
+    if not isinstance(profile_payload, dict):
+        return None
+    metadata = profile_payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    return normalize_versioning_block(
+        metadata.get("versioning"),
+        require_builder_spec_schema_version=False,
+    )
+
+
+def compare_builder_semver(left: str, right: str) -> int:
+    left_semver = parse_semver(left)
+    right_semver = parse_semver(right)
+    if left_semver is None or right_semver is None:
+        raise ValueError("Invalid semver comparison input")
+    if left_semver < right_semver:
+        return -1
+    if left_semver > right_semver:
+        return 1
+    return 0
+
+
+def blocking_for_status(status: str) -> bool:
+    return status in BLOCKING_STATUSES
+
+
+def classify_builder_compatibility(
+    *,
+    current_builder: dict[str, Any],
+    skill_versioning: dict[str, Any] | None,
+    profile_versioning: dict[str, Any] | None,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    status = STATUS_CURRENT
+
+    if skill_versioning is None:
+        status = STATUS_MISSING_SKILL_VERSIONING
+        warnings.append("Skill builder_versioning is missing or invalid.")
+    elif skill_versioning["builder_family"] != current_builder["builder_family"]:
+        status = STATUS_MISSING_SKILL_VERSIONING
+        warnings.append(
+            "Skill builder_versioning.builder_family does not match the current builder family."
+        )
+    elif profile_versioning is None:
+        status = STATUS_MISSING_PROFILE_VERSIONING
+        warnings.append("Profile metadata.versioning is missing or invalid.")
+    elif profile_versioning["builder_family"] != current_builder["builder_family"]:
+        status = STATUS_MISSING_PROFILE_VERSIONING
+        warnings.append(
+            "Profile metadata.versioning.builder_family does not match the current builder family."
+        )
+    else:
+        skill_semver_cmp = compare_builder_semver(
+            skill_versioning["builder_semver"],
+            current_builder["builder_semver"],
+        )
+        profile_semver_cmp = compare_builder_semver(
+            profile_versioning["builder_semver"],
+            current_builder["builder_semver"],
+        )
+
+        if (
+            skill_versioning["compatibility_epoch"] > current_builder["compatibility_epoch"]
+            or skill_versioning["builder_spec_schema_version"]
+            > current_builder["builder_spec_schema_version"]
+            or skill_versioning["repo_profile_schema_version"]
+            > current_builder["repo_profile_schema_version"]
+            or profile_versioning["compatibility_epoch"]
+            > current_builder["compatibility_epoch"]
+            or profile_versioning["repo_profile_schema_version"]
+            > current_builder["repo_profile_schema_version"]
+            or skill_semver_cmp > 0
+            or profile_semver_cmp > 0
+        ):
+            status = STATUS_AHEAD_OF_BUILDER
+        elif (
+            skill_versioning["compatibility_epoch"] < current_builder["compatibility_epoch"]
+            or skill_versioning["builder_spec_schema_version"]
+            < current_builder["builder_spec_schema_version"]
+            or skill_versioning["repo_profile_schema_version"]
+            < current_builder["repo_profile_schema_version"]
+        ):
+            status = STATUS_STALE_SKILL
+        elif (
+            profile_versioning["compatibility_epoch"] < current_builder["compatibility_epoch"]
+            or profile_versioning["repo_profile_schema_version"]
+            < current_builder["repo_profile_schema_version"]
+        ):
+            status = STATUS_STALE_PROFILE
+        elif skill_semver_cmp < 0 or profile_semver_cmp < 0:
+            status = STATUS_SEMVER_BEHIND_COMPATIBLE
+
+        if status in {STATUS_CURRENT, STATUS_SEMVER_BEHIND_COMPATIBLE}:
+            if compare_builder_semver(
+                skill_versioning["builder_semver"],
+                profile_versioning["builder_semver"],
+            ) != 0:
+                warnings.append(
+                    "Skill and active profile semver differ while remaining compatibility-safe."
+                )
+            if status == STATUS_SEMVER_BEHIND_COMPATIBLE:
+                if skill_semver_cmp < 0:
+                    warnings.append(
+                        f"Skill builder_semver {skill_versioning['builder_semver']} trails current builder {current_builder['builder_semver']}."
+                    )
+                if profile_semver_cmp < 0:
+                    warnings.append(
+                        f"Active profile builder_semver {profile_versioning['builder_semver']} trails current builder {current_builder['builder_semver']}."
+                    )
+
+    return {
+        "status": status,
+        "blocking": blocking_for_status(status),
+        "current_builder_semver": current_builder["builder_semver"],
+        "current_compatibility_epoch": current_builder["compatibility_epoch"],
+        "current_builder_spec_schema_version": current_builder["builder_spec_schema_version"],
+        "current_repo_profile_schema_version": current_builder["repo_profile_schema_version"],
+        "skill_builder_semver": None if skill_versioning is None else skill_versioning["builder_semver"],
+        "skill_compatibility_epoch": None if skill_versioning is None else skill_versioning["compatibility_epoch"],
+        "skill_builder_spec_schema_version": None if skill_versioning is None else skill_versioning["builder_spec_schema_version"],
+        "skill_repo_profile_schema_version": None if skill_versioning is None else skill_versioning["repo_profile_schema_version"],
+        "active_profile_builder_semver": None if profile_versioning is None else profile_versioning["builder_semver"],
+        "active_profile_compatibility_epoch": None if profile_versioning is None else profile_versioning["compatibility_epoch"],
+        "active_profile_repo_profile_schema_version": None if profile_versioning is None else profile_versioning["repo_profile_schema_version"],
+        "warnings": warnings,
+    }
+
+
+def format_runtime_warning(compatibility: dict[str, Any]) -> str:
+    warning_text = "; ".join(str(item) for item in compatibility.get("warnings") or [])
+    suffix = f" {warning_text}" if warning_text else ""
+    return (
+        "[WARN] packet-workflow builder compatibility "
+        f"status={compatibility.get('status')}.{suffix}"
+    ).strip()
+
+
+def retained_skill_dirs(skills_root: Path) -> list[Path]:
+    result: list[Path] = []
+    for path in sorted(skills_root.iterdir()):
+        if not path.is_dir():
+            continue
+        if (path / "builder-spec.json").is_file():
+            result.append(path)
+    return result
+
+
+def load_skill_artifacts(skill_dir: Path) -> tuple[Any, Any]:
+    spec_payload = load_json_document(skill_dir / "builder-spec.json")
+    profile_payload = load_json_document(skill_dir / "profiles" / "default" / "profile.json")
+    return spec_payload, profile_payload
+
+
+def evaluate_skill_dir(
+    skill_dir: Path,
+    *,
+    current_builder: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    builder_version = current_builder or load_builder_versioning()
+    spec_payload, profile_payload = load_skill_artifacts(skill_dir)
+    report = classify_builder_compatibility(
+        current_builder=builder_version,
+        skill_versioning=extract_skill_builder_versioning(spec_payload),
+        profile_versioning=extract_profile_versioning(profile_payload),
+    )
+    report.update(
+        {
+            "skill_name": skill_dir.name,
+            "builder_spec_path": (skill_dir / "builder-spec.json").as_posix(),
+            "profile_path": (skill_dir / "profiles" / "default" / "profile.json").as_posix(),
+        }
+    )
+    return report

--- a/builders/packet-workflow/scripts/stamp_skill_versions.py
+++ b/builders/packet-workflow/scripts/stamp_skill_versions.py
@@ -1,0 +1,104 @@
+﻿#!/usr/bin/env python3
+"""Stamp semver-only packet-workflow version metadata on retained skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from packet_workflow_versioning import (
+    STATUS_CURRENT,
+    STATUS_SEMVER_BEHIND_COMPATIBLE,
+    canonical_retained_skills_root,
+    evaluate_skill_dir,
+    load_builder_versioning,
+    load_json_document,
+    retained_skill_dirs,
+    write_json_document,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--skills-root",
+        default=str(canonical_retained_skills_root()),
+        help="Directory containing retained skill folders.",
+    )
+    parser.add_argument(
+        "skills",
+        nargs="*",
+        help="Optional skill names to stamp. Defaults to all retained skills under --skills-root.",
+    )
+    return parser.parse_args()
+
+
+def profile_versioning_from_builder(builder_version: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "builder_family": builder_version["builder_family"],
+        "builder_semver": builder_version["builder_semver"],
+        "compatibility_epoch": builder_version["compatibility_epoch"],
+        "repo_profile_schema_version": builder_version["repo_profile_schema_version"],
+    }
+
+
+def selected_skill_dirs(skills_root: Path, selected: list[str]) -> list[Path]:
+    retained = {path.name: path for path in retained_skill_dirs(skills_root)}
+    if not selected:
+        return [retained[name] for name in sorted(retained)]
+    missing = [name for name in selected if name not in retained]
+    if missing:
+        raise SystemExit(f"[ERROR] Unknown retained skill(s): {', '.join(sorted(missing))}")
+    return [retained[name] for name in selected]
+
+
+def stamp_skill(skill_dir: Path, *, builder_version: dict[str, Any]) -> dict[str, Any]:
+    report = evaluate_skill_dir(skill_dir, current_builder=builder_version)
+    if report["status"] not in {STATUS_CURRENT, STATUS_SEMVER_BEHIND_COMPATIBLE}:
+        raise SystemExit(
+            f"[ERROR] Refusing to stamp {skill_dir.name}: compatibility status is {report['status']}."
+        )
+
+    spec_path = skill_dir / "builder-spec.json"
+    profile_path = skill_dir / "profiles" / "default" / "profile.json"
+    spec_payload = load_json_document(spec_path)
+    profile_payload = load_json_document(profile_path)
+    if not isinstance(spec_payload, dict):
+        raise SystemExit(f"[ERROR] Invalid skill builder-spec payload: {spec_path}")
+    if not isinstance(profile_payload, dict):
+        raise SystemExit(f"[ERROR] Invalid skill profile payload: {profile_path}")
+
+    spec_payload["builder_versioning"] = dict(builder_version)
+    metadata = profile_payload.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        profile_payload["metadata"] = metadata
+    metadata["versioning"] = profile_versioning_from_builder(builder_version)
+
+    write_json_document(spec_path, spec_payload)
+    write_json_document(profile_path, profile_payload)
+    return {
+        "skill_name": skill_dir.name,
+        "status_before": report["status"],
+        "builder_semver": builder_version["builder_semver"],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    builder_version = load_builder_versioning()
+    skills_root = Path(args.skills_root).resolve()
+    updates = [
+        stamp_skill(skill_dir, builder_version=builder_version)
+        for skill_dir in selected_skill_dirs(skills_root, list(args.skills))
+    ]
+    sys.stdout.write(json.dumps({"updated": updates}, indent=2, ensure_ascii=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/builders/packet-workflow/scripts/write_evaluation_log.py
+++ b/builders/packet-workflow/scripts/write_evaluation_log.py
@@ -1,0 +1,993 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def foundry_root_dir(script_path: Path) -> Path:
+    return script_path.resolve().parents[3]
+
+
+def builder_skill_root(script_path: Path) -> Path:
+    return foundry_root_dir(script_path) / ".agents" / "skills" / "packet-workflow-skill-builder"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    runtime_root = script_path.resolve().parents[1]
+    skill_root = builder_skill_root(script_path)
+    if not (skill_root / "SKILL.md").is_file():
+        skill_root = runtime_root
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(runtime_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+        "runtime_root": str(runtime_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_orchestrator_profile": spec.get("orchestrator_profile"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/builders/packet-workflow/tests/fixtures/agents/docs_verifier.toml
+++ b/builders/packet-workflow/tests/fixtures/agents/docs_verifier.toml
@@ -1,0 +1,1 @@
+name = "docs_verifier"

--- a/builders/packet-workflow/tests/fixtures/agents/evidence_summarizer.toml
+++ b/builders/packet-workflow/tests/fixtures/agents/evidence_summarizer.toml
@@ -1,0 +1,1 @@
+name = "evidence_summarizer"

--- a/builders/packet-workflow/tests/fixtures/agents/large_diff_auditor.toml
+++ b/builders/packet-workflow/tests/fixtures/agents/large_diff_auditor.toml
@@ -1,0 +1,1 @@
+name = "large_diff_auditor"

--- a/builders/packet-workflow/tests/fixtures/agents/log_triager.toml
+++ b/builders/packet-workflow/tests/fixtures/agents/log_triager.toml
@@ -1,0 +1,1 @@
+name = "log_triager"

--- a/builders/packet-workflow/tests/fixtures/agents/packet_explorer.toml
+++ b/builders/packet-workflow/tests/fixtures/agents/packet_explorer.toml
@@ -1,0 +1,1 @@
+name = "packet_explorer"

--- a/builders/packet-workflow/tests/fixtures/agents/repo_mapper.toml
+++ b/builders/packet-workflow/tests/fixtures/agents/repo_mapper.toml
@@ -1,0 +1,1 @@
+name = "repo_mapper"

--- a/builders/packet-workflow/tests/test_packet_workflow_builder_contract.py
+++ b/builders/packet-workflow/tests/test_packet_workflow_builder_contract.py
@@ -735,10 +735,19 @@ class PacketWorkflowBuilderContractTests(unittest.TestCase):
                 "~/.codex/tmp/evaluation_logs/packet-explorer-smoke/<run-id>.json",
                 skill_md,
             )
+            self.assertIn(
+                "temporary, helper, scratch, or ad hoc operator-input file",
+                skill_md,
+            )
             self.assertIn(".codex/tmp/", skill_md)
             self.assertIn("profiles/sample-repo/profile.json", core_contract)
             self.assertIn(".codex/project/profiles/packet-explorer-smoke/profile.json", core_contract)
             self.assertIn("data-only", core_contract)
+            self.assertIn("## Shared Repo-Local Temporary File Policy", core_contract)
+            self.assertIn(
+                "transient file must live inside the repo, place it under `.codex/tmp/`",
+                core_contract,
+            )
             self.assertIn('display_name: "Packet Explorer Smoke"', agents_yaml)
             self.assertEqual(profile_json["name"], "sample-repo")
             self.assertEqual(

--- a/builders/packet-workflow/tests/test_packet_workflow_builder_contract.py
+++ b/builders/packet-workflow/tests/test_packet_workflow_builder_contract.py
@@ -1,0 +1,1143 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import py_compile
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+FIXTURE_AGENTS_DIR = Path(__file__).resolve().parent / "fixtures" / "agents"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import init_packet_skill as builder
+
+
+def current_builder_versioning() -> dict[str, object]:
+    return dict(builder.CURRENT_BUILDER_VERSIONING)
+
+
+def sample_spec() -> dict[str, object]:
+    return {
+        "builder_versioning": current_builder_versioning(),
+        "skill_name": "packet-explorer-smoke",
+        "description": "Verify packet explorer support in generated packet workflow skills.",
+        "domain_slug": "builder-tests",
+        "workflow_family": "repo-audit",
+        "archetype": "audit-and-apply",
+        "primary_goal": "Keep packet explorer routing normalized in generated scaffolds.",
+        "trigger_phrases": ["test packet workflow builder"],
+        "task_packet_names": ["rules_packet", "runtime_packet"],
+        "preferred_worker_families": {
+            "context_findings": ["repo_mapper", "packet_explorer", "docs_verifier"],
+            "candidate_producers": [
+                "evidence_summarizer",
+                "large_diff_auditor",
+                "log_triager",
+            ],
+            "verifiers": ["docs_verifier"],
+        },
+        "packet_worker_map": {
+            "runtime_packet": ["packet_explorer"],
+            "rules_packet": ["docs_verifier"],
+        },
+        "repo_profile": {
+            "name": "sample-repo",
+            "summary": "Bind the generated core to one sample repository layout.",
+            "bindings": {
+                "primary_readme_path": "README.md",
+                "settings_source_path": "src/Settings.cs",
+                "publish_config_path": "src/Properties/PublishConfiguration.xml",
+            },
+            "packet_defaults": {
+                "review_docs": {
+                    "rules_packet": ["README.md", "docs/rules.md"],
+                    "runtime_packet": ["docs/runtime.md"],
+                },
+                "source_path_globs": {
+                    "rules_packet": ["docs/**/*.md"],
+                    "runtime_packet": ["src/**/*.cs"],
+                },
+            },
+            "lint_rules": {
+                "require_readme_settings_table": True,
+                "missing_review_docs_are_errors": True,
+            },
+            "extra": {
+                "release_copy": {
+                    "maintaining_path": "MAINTAINING.md",
+                    "release_workflow_path": ".github/workflows/release.yml",
+                }
+            },
+            "notes": [
+                "Replace sample packet defaults before using this scaffold in production.",
+            ],
+        },
+    }
+
+
+def weekly_update_like_spec() -> dict[str, object]:
+    return {
+        "builder_versioning": current_builder_versioning(),
+        "skill_name": "weekly-update-like-smoke",
+        "description": (
+            "Verify weekly-update-like retained hierarchical packet workflow support."
+        ),
+        "domain_slug": "weekly_update_like",
+        "workflow_family": "repo-audit",
+        "archetype": "plan-validate-apply",
+        "primary_goal": (
+            "prepare a validated weekly operational summary from decision-ready packets"
+        ),
+        "trigger_phrases": ["build weekly update"],
+        "task_packet_names": [
+            "mapping_packet",
+            "changes_packet",
+            "incidents_packet",
+            "risks_packet",
+        ],
+        "orchestrator_profile": "standard",
+        "decision_ready_packets": True,
+        "worker_return_contract": "classification-oriented",
+        "worker_output_shape": "hierarchical",
+        "candidate_field_bundles": [
+            {
+                "name": "identity",
+                "description": "Stable candidate identity and source information.",
+                "required": True,
+                "fields": ["candidate_id", "source_type", "source_id", "title"],
+            },
+            {
+                "name": "proposal",
+                "description": "Proposal-grade summary and classification rationale.",
+                "required": True,
+                "fields": [
+                    "summary",
+                    "proposed_classification",
+                    "classification_rationale",
+                ],
+            },
+            {
+                "name": "evidence",
+                "description": "Decision-ready citations and reread control.",
+                "required": True,
+                "fields": ["source_refs", "confidence", "raw_reread_reason"],
+            },
+        ],
+        "worker_footer_fields": [
+            "packet_ids",
+            "candidate_ids",
+            "primary_outcome",
+            "overall_confidence",
+            "coverage_gaps",
+            "overall_risk",
+        ],
+        "reread_reason_values": [
+            "conflicting_signals",
+            "insufficient_excerpt_quality",
+        ],
+        "packet_worker_map": {
+            "mapping_packet": ["repo_mapper"],
+            "changes_packet": ["large_diff_auditor"],
+            "incidents_packet": ["log_triager"],
+            "risks_packet": ["evidence_summarizer"],
+        },
+        "domain_overlay": {
+            "proposal_enum_values": [
+                "actual_incident",
+                "blocker_or_risk",
+                "artifact_only",
+                "ignore",
+            ],
+            "reference_only_candidate_values": ["artifact_only"],
+            "output_inclusion_rules": {
+                "standalone": ["actual_incident", "blocker_or_risk"],
+                "reference_only": ["artifact_only"],
+                "excluded": ["ignore"],
+            },
+        },
+        "repo_profile": {
+            "name": "default",
+            "summary": (
+                "Default reusable profile scaffold for weekly-update workflows. "
+                "Replace review docs, path hints, and repo conventions in "
+                "project-local profiles when vendored."
+            ),
+            "repo_match": {
+                "root_markers": [".git", "README.md"],
+                "remote_patterns": [],
+            },
+            "bindings": {
+                "primary_readme_path": "README.md",
+                "settings_source_path": None,
+                "publish_config_path": None,
+            },
+            "packet_defaults": {
+                "review_docs": {
+                    "mapping_packet": ["README.md", "CONTRIBUTING.md"],
+                    "changes_packet": ["README.md", "CONTRIBUTING.md"],
+                    "incidents_packet": ["README.md", "CONTRIBUTING.md"],
+                    "risks_packet": ["README.md", "CONTRIBUTING.md"],
+                },
+                "source_path_globs": {
+                    "mapping_packet": ["**/*"],
+                    "changes_packet": ["**/*"],
+                    "incidents_packet": ["**/*"],
+                    "risks_packet": ["**/*"],
+                },
+            },
+            "lint_rules": {
+                "require_readme_settings_table": False,
+                "missing_review_docs_are_errors": False,
+            },
+            "extra": {
+                "weekly_update": {
+                    "state": {"namespace": "weekly-update"},
+                    "review_markers": {
+                        "acknowledged": ["phase=ack"],
+                        "resolved": ["phase=complete"],
+                    },
+                    "release_issue": {
+                        "title_regex": r"^\[Release\]\s*(?P<tag>v[0-9A-Za-z._-]+)",
+                    },
+                    "priority_markers": {
+                        "regex": r"\[(?:P[0-3]|medium|high|low)\]",
+                    },
+                }
+            },
+            "notes": [
+                "Keep repo-specific weekly-update conventions in project-local "
+                "profile data when vendored.",
+            ],
+        },
+    }
+
+
+def run_python(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def load_module_from_path(module_name: str, script_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Unable to load module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(script_path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        try:
+            sys.path.remove(str(script_path.parent))
+        except ValueError:
+            pass
+    return module
+
+
+EXECUTION_ROOTS_HEADER = "## Execution Roots"
+PYTHON_BIN_SKILL_PREFIX = "<python-bin> -B <skill-dir>/scripts/"
+FORBIDDEN_OPERATOR_DOC_PATTERNS = ("python scripts/", "py -3")
+
+
+def assert_skill_md_execution_contract(
+    testcase: unittest.TestCase, skill_md: str, *, source: Path | str
+) -> None:
+    label = str(source)
+    testcase.assertIn(EXECUTION_ROOTS_HEADER, skill_md, label)
+    testcase.assertIn(PYTHON_BIN_SKILL_PREFIX, skill_md, label)
+    for pattern in FORBIDDEN_OPERATOR_DOC_PATTERNS:
+        testcase.assertNotIn(pattern, skill_md, label)
+
+
+def operator_doc_scan_targets(foundry_root: Path) -> list[Path]:
+    scan_roots = [
+        foundry_root / "builders",
+        foundry_root / "core",
+    ]
+    allowed_suffixes = {".md", ".py", ".tmpl"}
+    excluded_parts = {"__pycache__", ".git", "tests"}
+    targets: list[Path] = []
+    for root in scan_roots:
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix not in allowed_suffixes:
+                continue
+            if any(part in excluded_parts for part in path.parts):
+                continue
+            targets.append(path)
+    return targets
+
+
+class PacketWorkflowBuilderContractTests(unittest.TestCase):
+    def test_retained_skill_builder_specs_generate_core_contract_and_profile(self) -> None:
+        foundry_root = builder.foundry_root_dir()
+        retained_specs = [
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "draft-release-copy"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "gh-create-pr"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "gh-address-review-threads"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "gh-fix-pr-writeup"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "git-split-and-commit"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "public-docs-sync"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "reword-recent-commits"
+            / "builder-spec.json",
+            foundry_root
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+            / "weekly-update"
+            / "builder-spec.json",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_root = Path(tmp)
+            for spec_path in retained_specs:
+                run_python(
+                    SCRIPT_DIR / "init_packet_skill.py",
+                    "--spec",
+                    str(spec_path),
+                    "--output-dir",
+                    str(output_root),
+                    "--managed-agents-dir",
+                    str(FIXTURE_AGENTS_DIR),
+                )
+                retained_dir = (
+                    output_root
+                    / "builders"
+                    / "packet-workflow"
+                    / "retained-skills"
+                    / spec_path.parent.name
+                )
+                wrapper_dir = output_root / ".agents" / "skills" / spec_path.parent.name
+                self.assertTrue((retained_dir / "references" / "core-contract.md").is_file())
+                self.assertTrue(
+                    (retained_dir / "profiles" / "default" / "profile.json").is_file()
+                )
+                assert_skill_md_execution_contract(
+                    self,
+                    (retained_dir / "SKILL.md").read_text(encoding="utf-8"),
+                    source=retained_dir / "SKILL.md",
+                )
+                wrapper_files = sorted(
+                    str(path.relative_to(wrapper_dir)).replace("\\", "/")
+                    for path in wrapper_dir.rglob("*")
+                    if path.is_file()
+                )
+                self.assertEqual(wrapper_files, ["SKILL.md", "agents/openai.yaml"])
+
+    def test_builder_uses_root_core_assets(self) -> None:
+        foundry_root = builder.foundry_root_dir()
+        self.assertEqual(builder.managed_agents_dir(), foundry_root / "agents")
+        self.assertEqual(
+            builder.templates_dir(),
+            foundry_root / "core" / "templates" / "packet-workflow",
+        )
+        review_mode_defaults = json.loads(
+            (
+                foundry_root
+                / "core"
+                / "defaults"
+                / "packet-workflow"
+                / "review-modes.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            builder.DEFAULT_REVIEW_MODE_OVERRIDES,
+            review_mode_defaults["default_override_signals"],
+        )
+        self.assertEqual(
+            builder.CURRENT_BUILDER_VERSIONING,
+            json.loads(
+                (foundry_root / "builders" / "packet-workflow" / "version.json").read_text(
+                    encoding="utf-8"
+                )
+            ),
+        )
+
+    def test_skill_subtree_stays_thin(self) -> None:
+        skills_root = builder.foundry_root_dir() / ".agents" / "skills"
+        for skill_dir in sorted(path for path in skills_root.iterdir() if path.is_dir()):
+            with self.subTest(skill=skill_dir.name):
+                files = sorted(
+                    str(path.relative_to(skill_dir)).replace("\\", "/")
+                    for path in skill_dir.rglob("*")
+                    if path.is_file()
+                )
+                self.assertEqual(files, ["SKILL.md", "agents/openai.yaml"])
+
+    def test_managed_agent_registry_contains_packet_explorer(self) -> None:
+        self.assertIn("packet_explorer", builder.KNOWN_WORKER_AGENT_TYPES)
+        resolved = builder.validate_managed_agent_registry(FIXTURE_AGENTS_DIR)
+        self.assertEqual(resolved, FIXTURE_AGENTS_DIR.resolve())
+
+    def test_managed_agents_dir_resolution_prefers_override_then_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_root = Path(tmp)
+            override_dir = tmp_root / "override-agents"
+            env_dir = tmp_root / "env-agents"
+            codex_home = tmp_root / "codex-home"
+            standard_dir = tmp_root / "standard-agents"
+            override_dir.mkdir()
+            env_dir.mkdir()
+            (codex_home / "agents").mkdir(parents=True)
+            standard_dir.mkdir()
+
+            with (
+                mock.patch.object(builder, "managed_agents_dir", return_value=standard_dir),
+                mock.patch.object(
+                    builder,
+                    "managed_agents_fixture_dir",
+                    return_value=FIXTURE_AGENTS_DIR,
+                ),
+            ):
+                resolved = builder.resolve_managed_agents_dir(
+                    override_dir,
+                    env={
+                        builder.MANAGED_AGENTS_DIR_ENV_VAR: str(env_dir),
+                        builder.CODEX_HOME_ENV_VAR: str(codex_home),
+                    },
+                )
+                self.assertEqual(resolved, override_dir.resolve())
+
+                resolved = builder.resolve_managed_agents_dir(
+                    env={
+                        builder.MANAGED_AGENTS_DIR_ENV_VAR: str(env_dir),
+                        builder.CODEX_HOME_ENV_VAR: str(codex_home),
+                    }
+                )
+                self.assertEqual(resolved, env_dir.resolve())
+
+                resolved = builder.resolve_managed_agents_dir(
+                    env={builder.CODEX_HOME_ENV_VAR: str(codex_home)}
+                )
+                self.assertEqual(resolved, (codex_home / "agents").resolve())
+
+    def test_managed_agents_dir_resolution_falls_back_to_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_standard = Path(tmp) / "missing-standard-agents"
+            with (
+                mock.patch.object(
+                    builder,
+                    "managed_agents_dir",
+                    return_value=missing_standard,
+                ),
+                mock.patch.object(
+                    builder,
+                    "managed_agents_fixture_dir",
+                    return_value=FIXTURE_AGENTS_DIR,
+                ),
+            ):
+                resolved = builder.resolve_managed_agents_dir(env={})
+                self.assertEqual(resolved, FIXTURE_AGENTS_DIR.resolve())
+                validated = builder.validate_managed_agent_registry(env={})
+                self.assertEqual(validated, FIXTURE_AGENTS_DIR.resolve())
+
+    def test_derive_spec_normalizes_packet_explorer_routing(self) -> None:
+        spec = builder.derive_spec(sample_spec())
+
+        self.assertEqual(spec["orchestrator_profile"], "standard")
+        self.assertTrue(spec["needs_validate"])
+        self.assertEqual(
+            spec["preferred_worker_families"]["context_findings"],
+            ["repo_mapper", "packet_explorer", "docs_verifier"],
+        )
+        self.assertEqual(
+            spec["packet_worker_map"],
+            {
+                "rules_packet": ["docs_verifier"],
+                "runtime_packet": ["packet_explorer"],
+            },
+        )
+        self.assertEqual(
+            spec["worker_selection_guidance"]["routing_authority"],
+            "packet_worker_map",
+        )
+        self.assertEqual(
+            builder.surfaced_optional_worker_list_for_docs(spec),
+            ["repo_mapper"],
+        )
+        self.assertEqual(spec["repo_profile"]["name"], "sample-repo")
+        self.assertEqual(
+            spec["repo_profile"]["profile_path"],
+            "profiles/sample-repo/profile.json",
+        )
+        self.assertEqual(spec["builder_versioning"], current_builder_versioning())
+        self.assertEqual(
+            spec["repo_profile"]["metadata"]["versioning"],
+            {
+                "builder_family": current_builder_versioning()["builder_family"],
+                "builder_semver": current_builder_versioning()["builder_semver"],
+                "compatibility_epoch": current_builder_versioning()["compatibility_epoch"],
+                "repo_profile_schema_version": current_builder_versioning()[
+                    "repo_profile_schema_version"
+                ],
+            },
+        )
+        self.assertEqual(
+            spec["repo_profile"]["bindings"]["settings_source_path"],
+            "src/Settings.cs",
+        )
+        self.assertEqual(
+            spec["repo_profile"]["extra"]["release_copy"]["maintaining_path"],
+            "MAINTAINING.md",
+        )
+        self.assertTrue(
+            spec["repo_profile"]["lint_rules"]["missing_review_docs_are_errors"]
+        )
+
+    def test_invalid_orchestrator_profile_is_rejected(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["orchestrator_profile"] = "everything"
+        with self.assertRaisesRegex(ValueError, "orchestrator_profile must be one of"):
+            builder.derive_spec(bad_spec)
+
+    def test_missing_builder_versioning_is_rejected(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec.pop("builder_versioning")
+        with self.assertRaisesRegex(
+            ValueError, "builder_versioning is required and must be a valid object"
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_repo_profile_rejects_unknown_packet_defaults(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["repo_profile"] = {
+            "packet_defaults": {
+                "review_docs": {
+                    "unknown-packet": ["README.md"],
+                }
+            }
+        }
+        with self.assertRaisesRegex(
+            ValueError, "repo_profile.packet_defaults.review_docs contains unknown packet name"
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_needs_apply_requires_needs_validate(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["needs_validate"] = False
+        with self.assertRaisesRegex(
+            ValueError, "needs_apply=true requires needs_validate=true"
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_weekly_update_like_retained_shape_generates_hierarchical_packets(self) -> None:
+        spec = builder.derive_spec(weekly_update_like_spec())
+
+        self.assertEqual(spec["archetype"], "plan-validate-apply")
+        self.assertTrue(spec["decision_ready_packets"])
+        self.assertEqual(spec["worker_return_contract"], "classification-oriented")
+        self.assertEqual(spec["worker_output_shape"], "hierarchical")
+        self.assertEqual(
+            spec["repo_profile"]["extra"]["weekly_update"]["state"]["namespace"],
+            "weekly-update",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            scripts_dir = skill_dir / "scripts"
+            for script in scripts_dir.glob("*.py"):
+                py_compile.compile(str(script), doraise=True)
+
+            context_path = Path(tmp) / "context.json"
+            packets_dir = Path(tmp) / "packets"
+            build_result_path = Path(tmp) / "build-result.json"
+
+            run_python(
+                scripts_dir / "collect_weekly_update_like_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(context_path),
+            )
+            run_python(
+                scripts_dir / "build_weekly_update_like_packets.py",
+                "--context",
+                str(context_path),
+                "--output-dir",
+                str(packets_dir),
+                "--result-output",
+                str(build_result_path),
+            )
+
+            context = json.loads(context_path.read_text(encoding="utf-8"))
+            orchestrator = json.loads(
+                (packets_dir / "orchestrator.json").read_text(encoding="utf-8")
+            )
+            global_packet = json.loads(
+                (packets_dir / "global_packet.json").read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(context["repo_profile_name"], "default")
+            self.assertEqual(context["builder_compatibility"]["status"], "current")
+            self.assertEqual(orchestrator["repo_profile_name"], "default")
+            self.assertTrue(orchestrator["decision_ready_packets"])
+            self.assertEqual(
+                orchestrator["worker_return_contract"], "classification-oriented"
+            )
+            self.assertEqual(orchestrator["worker_output_shape"], "hierarchical")
+            self.assertEqual(
+                global_packet["domain_overlay"]["proposal_enum_values"],
+                ["actual_incident", "blocker_or_risk", "artifact_only", "ignore"],
+            )
+            self.assertEqual(
+                global_packet["repo_profile"]["extra"]["weekly_update"]["state"][
+                    "namespace"
+                ],
+                "weekly-update",
+            )
+
+    def test_candidate_field_bundles_require_classification_oriented(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["candidate_field_bundles"] = [
+            {
+                "name": "candidate",
+                "description": "Candidate data.",
+                "required": True,
+                "fields": ["summary"],
+            }
+        ]
+        with self.assertRaisesRegex(
+            ValueError,
+            "candidate_field_bundles requires worker_return_contract=classification-oriented",
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_classification_oriented_requires_decision_ready_packets(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["worker_return_contract"] = "classification-oriented"
+        with self.assertRaisesRegex(
+            ValueError,
+            "worker_return_contract=classification-oriented requires decision_ready_packets=true",
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_worker_footer_fields_require_decision_ready_packets(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["worker_footer_fields"] = ["packet_ids", "primary_outcome"]
+        with self.assertRaisesRegex(
+            ValueError,
+            "worker_footer_fields requires decision_ready_packets=true",
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_worker_footer_fields_require_hierarchical_output(self) -> None:
+        bad_spec = weekly_update_like_spec()
+        bad_spec["worker_output_shape"] = "flat"
+        with self.assertRaisesRegex(
+            ValueError,
+            "worker_footer_fields requires worker_output_shape=hierarchical",
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_domain_overlay_requires_classification_oriented(self) -> None:
+        bad_spec = sample_spec()
+        bad_spec["domain_overlay"] = {
+            "proposal_enum_values": ["accept", "reject"],
+            "output_inclusion_rules": {"standalone": ["accept"], "excluded": ["reject"]},
+        }
+        with self.assertRaisesRegex(
+            ValueError,
+            "domain_overlay requires worker_return_contract=classification-oriented",
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_hierarchical_output_requires_usable_candidate_bundles(self) -> None:
+        bad_spec = weekly_update_like_spec()
+        bad_spec["candidate_field_bundles"] = []
+        with self.assertRaisesRegex(
+            ValueError,
+            "worker_output_shape=hierarchical requires candidate_field_bundles or required_candidate_fields",
+        ):
+            builder.derive_spec(bad_spec)
+
+    def test_worker_instruction_and_generated_docs_surface_packet_explorer(self) -> None:
+        spec = builder.derive_spec(sample_spec())
+        worker_instruction = builder.worker_instruction_map(spec)["packet_explorer"]
+
+        self.assertIn("Read global_packet.json first", worker_instruction)
+        self.assertIn("exactly one focused packet or one batch packet", worker_instruction)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            builder.generate_files(skill_dir, spec)
+
+            skill_md = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+            core_contract = (skill_dir / "references" / "core-contract.md").read_text(
+                encoding="utf-8"
+            )
+            agents_yaml = (skill_dir / "agents" / "openai.yaml").read_text(encoding="utf-8")
+            profile_json = json.loads(
+                (skill_dir / "profiles" / "sample-repo" / "profile.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+            self.assertIn("packet_explorer", skill_md)
+            self.assertIn("runtime_packet", skill_md)
+            self.assertIn("Orchestrator profile: `standard`.", skill_md)
+            self.assertIn("profiles/sample-repo/profile.json", skill_md)
+            self.assertIn(".codex/project/profiles/packet-explorer-smoke/profile.json", skill_md)
+            self.assertIn("references/core-contract.md", skill_md)
+            self.assertIn("data-only", skill_md)
+            self.assertIn(
+                ".codex/tmp/packet-workflow/packet-explorer-smoke/<run-id>/",
+                skill_md,
+            )
+            self.assertIn(
+                "~/.codex/tmp/evaluation_logs/packet-explorer-smoke/<run-id>.json",
+                skill_md,
+            )
+            self.assertIn(".codex/tmp/", skill_md)
+            self.assertIn("profiles/sample-repo/profile.json", core_contract)
+            self.assertIn(".codex/project/profiles/packet-explorer-smoke/profile.json", core_contract)
+            self.assertIn("data-only", core_contract)
+            self.assertIn('display_name: "Packet Explorer Smoke"', agents_yaml)
+            self.assertEqual(profile_json["name"], "sample-repo")
+            self.assertEqual(
+                profile_json["metadata"]["versioning"]["builder_semver"],
+                current_builder_versioning()["builder_semver"],
+            )
+            self.assertEqual(
+                profile_json["bindings"]["publish_config_path"],
+                "src/Properties/PublishConfiguration.xml",
+            )
+            assert_skill_md_execution_contract(self, skill_md, source=skill_dir / "SKILL.md")
+
+    def test_retained_skill_docs_use_python_bin_execution_contract(self) -> None:
+        retained_root = (
+            builder.foundry_root_dir()
+            / "builders"
+            / "packet-workflow"
+            / "retained-skills"
+        )
+        for skill_md_path in sorted(retained_root.glob("*/SKILL.md")):
+            with self.subTest(skill=skill_md_path.parent.name):
+                assert_skill_md_execution_contract(
+                    self,
+                    skill_md_path.read_text(encoding="utf-8"),
+                    source=skill_md_path,
+                )
+
+    def test_repo_operator_docs_do_not_prescribe_python_shims(self) -> None:
+        foundry_root = builder.foundry_root_dir()
+        violations: list[str] = []
+        for path in operator_doc_scan_targets(foundry_root):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for pattern in FORBIDDEN_OPERATOR_DOC_PATTERNS:
+                if pattern in text:
+                    violations.append(f"{path}: {pattern}")
+        self.assertEqual(violations, [])
+
+    def test_standard_scaffold_uses_validation_only_apply_contract(self) -> None:
+        spec = builder.derive_spec(sample_spec())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            scripts_dir = skill_dir / "scripts"
+            for script in scripts_dir.glob("*.py"):
+                py_compile.compile(str(script), doraise=True)
+
+            apply_script = (scripts_dir / "apply_builder_tests.py").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("--validation", apply_script)
+            self.assertNotIn("--plan", apply_script)
+            self.assertNotIn("--context", apply_script)
+
+            context_path = Path(tmp) / "context.json"
+            packets_dir = Path(tmp) / "packets"
+            build_result_path = Path(tmp) / "build-result.json"
+            plan_path = Path(tmp) / "plan.json"
+            validation_path = Path(tmp) / "validation.json"
+            apply_result_path = Path(tmp) / "apply-result.json"
+
+            run_python(
+                scripts_dir / "collect_builder_tests_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(context_path),
+            )
+            context = json.loads(context_path.read_text(encoding="utf-8"))
+            self.assertEqual(context["repo_profile_name"], "sample-repo")
+            self.assertEqual(
+                context["repo_profile"]["bindings"]["primary_readme_path"],
+                "README.md",
+            )
+            self.assertEqual(context["builder_compatibility"]["status"], "current")
+            self.assertEqual(
+                context["builder_compatibility"]["current_builder_semver"],
+                current_builder_versioning()["builder_semver"],
+            )
+            run_python(
+                scripts_dir / "build_builder_tests_packets.py",
+                "--context",
+                str(context_path),
+                "--output-dir",
+                str(packets_dir),
+                "--result-output",
+                str(build_result_path),
+            )
+
+            self.assertFalse((packets_dir / "synthesis_packet.json").exists())
+            self.assertFalse((packets_dir / "packet_metrics.json").exists())
+
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+            self.assertEqual(build_result["orchestrator_profile"], "standard")
+            self.assertEqual(build_result["repo_profile_name"], "sample-repo")
+
+            orchestrator = json.loads(
+                (packets_dir / "orchestrator.json").read_text(encoding="utf-8")
+            )
+            global_packet = json.loads(
+                (packets_dir / "global_packet.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(orchestrator["repo_profile_name"], "sample-repo")
+            self.assertEqual(
+                global_packet["repo_profile"]["packet_defaults"]["review_docs"][
+                    "rules_packet"
+                ],
+                ["README.md", "docs/rules.md"],
+            )
+
+            plan_path.write_text(
+                json.dumps(
+                    {
+                        "skill_name": spec["skill_name"],
+                        "context_id": context["context_id"],
+                        "selected_packets": ["rules_packet"],
+                        "actions": [],
+                        "stop_reasons": [],
+                        "overall_confidence": "medium",
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            run_python(
+                scripts_dir / "validate_builder_tests.py",
+                "--context",
+                str(context_path),
+                "--plan",
+                str(plan_path),
+                "--output",
+                str(validation_path),
+            )
+            validation = json.loads(validation_path.read_text(encoding="utf-8"))
+            self.assertTrue(validation["valid"])
+            self.assertTrue(validation["can_apply"])
+            self.assertIn("normalized_plan", validation)
+            self.assertIn("normalized_plan_fingerprint", validation)
+            self.assertIn("apply_gate_status", validation)
+
+            run_python(
+                scripts_dir / "apply_builder_tests.py",
+                "--validation",
+                str(validation_path),
+                "--dry-run",
+                "--result-output",
+                str(apply_result_path),
+            )
+            apply_result = json.loads(apply_result_path.read_text(encoding="utf-8"))
+            self.assertTrue(apply_result["validation_boundary_enforced"])
+            self.assertTrue(apply_result["dry_run"])
+
+    def test_generated_collector_warns_but_returns_context_for_stale_profile(self) -> None:
+        spec = builder.derive_spec(sample_spec())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            profile_path = skill_dir / "profiles" / "sample-repo" / "profile.json"
+            profile_payload = json.loads(profile_path.read_text(encoding="utf-8"))
+            profile_payload["metadata"]["versioning"]["repo_profile_schema_version"] = 0
+            profile_path.write_text(
+                json.dumps(profile_payload, indent=2, ensure_ascii=True) + "\n",
+                encoding="utf-8",
+            )
+
+            result = run_python(
+                skill_dir / "scripts" / "collect_builder_tests_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(Path(tmp) / "context.json"),
+                "--profile",
+                str(profile_path),
+            )
+            context = json.loads((Path(tmp) / "context.json").read_text(encoding="utf-8"))
+            self.assertEqual(context["builder_compatibility"]["status"], "stale-profile")
+            self.assertIn("status=stale-profile", result.stderr)
+
+    def test_generated_collector_warns_but_returns_context_for_invalid_profile_semver(self) -> None:
+        spec = builder.derive_spec(sample_spec())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            profile_path = skill_dir / "profiles" / "sample-repo" / "profile.json"
+            profile_payload = json.loads(profile_path.read_text(encoding="utf-8"))
+            profile_payload["metadata"]["versioning"]["builder_semver"] = "not-semver"
+            profile_path.write_text(
+                json.dumps(profile_payload, indent=2, ensure_ascii=True) + "\n",
+                encoding="utf-8",
+            )
+
+            result = run_python(
+                skill_dir / "scripts" / "collect_builder_tests_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(Path(tmp) / "context.json"),
+                "--profile",
+                str(profile_path),
+            )
+            context = json.loads((Path(tmp) / "context.json").read_text(encoding="utf-8"))
+            self.assertEqual(context["builder_compatibility"]["status"], "missing-profile-versioning")
+            self.assertIn("status=missing-profile-versioning", result.stderr)
+
+    def test_generated_collector_warns_but_returns_context_for_non_string_profile_semver(
+        self,
+    ) -> None:
+        spec = builder.derive_spec(sample_spec())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            profile_path = skill_dir / "profiles" / "sample-repo" / "profile.json"
+            profile_payload = json.loads(profile_path.read_text(encoding="utf-8"))
+            profile_payload["metadata"]["versioning"]["builder_semver"] = 1
+            profile_path.write_text(
+                json.dumps(profile_payload, indent=2, ensure_ascii=True) + "\n",
+                encoding="utf-8",
+            )
+
+            result = run_python(
+                skill_dir / "scripts" / "collect_builder_tests_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(Path(tmp) / "context.json"),
+                "--profile",
+                str(profile_path),
+            )
+            context = json.loads((Path(tmp) / "context.json").read_text(encoding="utf-8"))
+            self.assertEqual(context["builder_compatibility"]["status"], "missing-profile-versioning")
+            self.assertIn("status=missing-profile-versioning", result.stderr)
+
+    def test_generated_collector_prefers_project_local_skill_profile(self) -> None:
+        spec = builder.derive_spec(sample_spec())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            skill_profile = (
+                repo_root
+                / ".codex"
+                / "project"
+                / "profiles"
+                / str(spec["skill_name"])
+                / "profile.json"
+            )
+            default_profile = (
+                repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json"
+            )
+            retained_profile = skill_dir / "profiles" / "sample-repo" / "profile.json"
+            collector = load_module_from_path(
+                "collect_builder_tests_context_dynamic",
+                skill_dir / "scripts" / "collect_builder_tests_context.py",
+            )
+
+            skill_profile.parent.mkdir(parents=True, exist_ok=True)
+            skill_profile.write_text("{}", encoding="utf-8")
+            default_profile.parent.mkdir(parents=True, exist_ok=True)
+            default_profile.write_text("{}", encoding="utf-8")
+
+            self.assertEqual(
+                collector.default_repo_profile_path(repo_root),
+                skill_profile.resolve(),
+            )
+            self.assertEqual(
+                collector.resolve_profile_path(
+                    ".codex/project/profiles/default/profile.json",
+                    repo_root,
+                ),
+                default_profile.resolve(),
+            )
+            self.assertEqual(
+                collector.resolve_profile_path("profiles/sample-repo/profile.json", repo_root),
+                retained_profile.resolve(),
+            )
+
+            skill_profile.unlink()
+            self.assertEqual(
+                collector.default_repo_profile_path(repo_root),
+                default_profile.resolve(),
+            )
+
+            default_profile.unlink()
+            self.assertEqual(
+                collector.default_repo_profile_path(repo_root),
+                retained_profile.resolve(),
+            )
+
+    def test_packet_heavy_profile_emits_synthesis_and_metrics_sidecar(self) -> None:
+        raw_spec = sample_spec()
+        raw_spec["skill_name"] = "packet-heavy-smoke"
+        raw_spec["orchestrator_profile"] = "packet-heavy-orchestrator"
+        spec = builder.derive_spec(raw_spec)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = Path(tmp) / str(spec["skill_name"])
+            repo_root = Path(tmp) / "repo"
+            repo_root.mkdir()
+            builder.generate_files(skill_dir, spec)
+
+            scripts_dir = skill_dir / "scripts"
+            for script in scripts_dir.glob("*.py"):
+                py_compile.compile(str(script), doraise=True)
+
+            context_path = Path(tmp) / "context.json"
+            packets_dir = Path(tmp) / "packets"
+            build_result_path = Path(tmp) / "build-result.json"
+            eval_log_path = Path(tmp) / "eval-log.json"
+
+            run_python(
+                scripts_dir / "collect_builder_tests_context.py",
+                "--repo-root",
+                str(repo_root),
+                "--output",
+                str(context_path),
+            )
+            run_python(
+                scripts_dir / "build_builder_tests_packets.py",
+                "--context",
+                str(context_path),
+                "--output-dir",
+                str(packets_dir),
+                "--result-output",
+                str(build_result_path),
+            )
+
+            orchestrator = json.loads(
+                (packets_dir / "orchestrator.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                orchestrator["shared_local_packet"], "synthesis_packet.json"
+            )
+            self.assertIn("common_path_contract", orchestrator)
+            self.assertNotIn("estimated_local_only_tokens", orchestrator)
+            self.assertTrue((packets_dir / "synthesis_packet.json").exists())
+            self.assertTrue((packets_dir / "packet_metrics.json").exists())
+
+            packet_metrics = json.loads(
+                (packets_dir / "packet_metrics.json").read_text(encoding="utf-8")
+            )
+            self.assertIn("packet_count", packet_metrics)
+            self.assertIn("estimated_delegation_savings", packet_metrics)
+
+            build_result = json.loads(build_result_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                build_result["shared_local_packet"], "synthesis_packet.json"
+            )
+            self.assertIn("packet_metrics", build_result)
+            self.assertEqual(build_result["repo_profile_name"], "sample-repo")
+
+            run_python(
+                scripts_dir / "write_evaluation_log.py",
+                "init",
+                "--context",
+                str(context_path),
+                "--orchestrator",
+                str(packets_dir / "orchestrator.json"),
+                "--output",
+                str(eval_log_path),
+            )
+            run_python(
+                scripts_dir / "write_evaluation_log.py",
+                "phase",
+                "--log",
+                str(eval_log_path),
+                "--phase",
+                "build",
+                "--result",
+                str(build_result_path),
+            )
+            eval_log = json.loads(eval_log_path.read_text(encoding="utf-8"))
+            self.assertIn(
+                "packet_metrics",
+                eval_log["skill_specific"]["data"],
+            )
+            self.assertEqual(eval_log["measurement"]["token_source"], "estimated")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+

--- a/builders/packet-workflow/tests/test_packet_workflow_versioning.py
+++ b/builders/packet-workflow/tests/test_packet_workflow_versioning.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_skill_versions as check_versions
+import packet_workflow_versioning as versioning
+import stamp_skill_versions as stamp_versions
+
+
+def builder_version() -> dict[str, object]:
+    return dict(versioning.load_builder_versioning())
+
+
+def profile_version_block(
+    *,
+    semver: str | None = None,
+    compatibility_epoch: int | None = None,
+    repo_profile_schema_version: int | None = None,
+) -> dict[str, object]:
+    current = builder_version()
+    return {
+        "builder_family": current["builder_family"],
+        "builder_semver": semver or str(current["builder_semver"]),
+        "compatibility_epoch": (
+            int(current["compatibility_epoch"])
+            if compatibility_epoch is None
+            else compatibility_epoch
+        ),
+        "repo_profile_schema_version": (
+            int(current["repo_profile_schema_version"])
+            if repo_profile_schema_version is None
+            else repo_profile_schema_version
+        ),
+    }
+
+
+def skill_version_block(
+    *,
+    semver: str | None = None,
+    compatibility_epoch: int | None = None,
+    builder_spec_schema_version: int | None = None,
+    repo_profile_schema_version: int | None = None,
+) -> dict[str, object]:
+    current = builder_version()
+    return {
+        "builder_family": current["builder_family"],
+        "builder_semver": semver or str(current["builder_semver"]),
+        "compatibility_epoch": (
+            int(current["compatibility_epoch"])
+            if compatibility_epoch is None
+            else compatibility_epoch
+        ),
+        "builder_spec_schema_version": (
+            int(current["builder_spec_schema_version"])
+            if builder_spec_schema_version is None
+            else builder_spec_schema_version
+        ),
+        "repo_profile_schema_version": (
+            int(current["repo_profile_schema_version"])
+            if repo_profile_schema_version is None
+            else repo_profile_schema_version
+        ),
+    }
+
+
+def write_skill_fixture(
+    root: Path,
+    name: str,
+    *,
+    skill_versioning: dict[str, object] | None,
+    profile_versioning: dict[str, object] | None,
+) -> Path:
+    skill_dir = root / name
+    (skill_dir / "profiles" / "default").mkdir(parents=True, exist_ok=True)
+    spec_payload: dict[str, object] = {
+        "skill_name": name,
+        "description": "fixture",
+        "domain_slug": "fixture",
+        "workflow_family": "repo-audit",
+        "archetype": "audit-only",
+        "primary_goal": "fixture",
+        "trigger_phrases": ["fixture"],
+    }
+    if skill_versioning is not None:
+        spec_payload["builder_versioning"] = dict(skill_versioning)
+    (skill_dir / "builder-spec.json").write_text(
+        json.dumps(spec_payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    profile_payload: dict[str, object] = {
+        "name": "default",
+        "summary": "fixture",
+        "repo_match": {"root_markers": [], "remote_patterns": []},
+        "bindings": {
+            "primary_readme_path": "README.md",
+            "settings_source_path": None,
+            "publish_config_path": None,
+        },
+        "packet_defaults": {"review_docs": {}, "source_path_globs": {}},
+        "lint_rules": {
+            "require_readme_settings_table": False,
+            "missing_review_docs_are_errors": False,
+        },
+        "notes": [],
+        "profile_path": "profiles/default/profile.json",
+    }
+    if profile_versioning is not None:
+        profile_payload["metadata"] = {"versioning": dict(profile_versioning)}
+    (skill_dir / "profiles" / "default" / "profile.json").write_text(
+        json.dumps(profile_payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+class PacketWorkflowVersioningTests(unittest.TestCase):
+    def test_cli_defaults_use_canonical_retained_skills_root(self) -> None:
+        expected = str(versioning.canonical_retained_skills_root())
+        with mock.patch.object(sys, "argv", ["check_skill_versions.py"]):
+            self.assertEqual(check_versions.parse_args().skills_root, expected)
+        with mock.patch.object(sys, "argv", ["stamp_skill_versions.py"]):
+            self.assertEqual(stamp_versions.parse_args().skills_root, expected)
+
+    def test_evaluate_skill_dir_reports_current(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "current-skill",
+                skill_versioning=skill_version_block(),
+                profile_versioning=profile_version_block(),
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_CURRENT)
+            self.assertFalse(report["blocking"])
+
+    def test_evaluate_skill_dir_reports_semver_behind_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "semver-behind-skill",
+                skill_versioning=skill_version_block(semver="0.0.9"),
+                profile_versioning=profile_version_block(semver="0.0.9"),
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_SEMVER_BEHIND_COMPATIBLE)
+            self.assertFalse(report["blocking"])
+
+    def test_evaluate_skill_dir_reports_stale_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "stale-skill",
+                skill_versioning=skill_version_block(compatibility_epoch=0),
+                profile_versioning=profile_version_block(),
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_STALE_SKILL)
+            self.assertTrue(report["blocking"])
+
+    def test_evaluate_skill_dir_reports_stale_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "stale-profile",
+                skill_versioning=skill_version_block(),
+                profile_versioning=profile_version_block(repo_profile_schema_version=0),
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_STALE_PROFILE)
+            self.assertTrue(report["blocking"])
+
+    def test_evaluate_skill_dir_reports_missing_skill_versioning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "missing-skill-versioning",
+                skill_versioning=None,
+                profile_versioning=profile_version_block(),
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_MISSING_SKILL_VERSIONING)
+            self.assertTrue(report["blocking"])
+
+    def test_evaluate_skill_dir_reports_missing_profile_versioning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "missing-profile-versioning",
+                skill_versioning=skill_version_block(),
+                profile_versioning=None,
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_MISSING_PROFILE_VERSIONING)
+            self.assertTrue(report["blocking"])
+
+    def test_evaluate_skill_dir_reports_ahead_of_builder(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = write_skill_fixture(
+                Path(tmp),
+                "ahead-skill",
+                skill_versioning=skill_version_block(semver="9.9.9"),
+                profile_versioning=profile_version_block(),
+            )
+            report = versioning.evaluate_skill_dir(skill_dir)
+            self.assertEqual(report["status"], versioning.STATUS_AHEAD_OF_BUILDER)
+            self.assertTrue(report["blocking"])
+
+    def test_check_skill_versions_builds_json_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_skill_fixture(
+                root,
+                "current-skill",
+                skill_versioning=skill_version_block(),
+                profile_versioning=profile_version_block(),
+            )
+            write_skill_fixture(
+                root,
+                "missing-profile",
+                skill_versioning=skill_version_block(),
+                profile_versioning=None,
+            )
+            report = check_versions.build_report(root)
+            self.assertEqual(report["blocking_count"], 1)
+            self.assertEqual(report["summary"][versioning.STATUS_CURRENT], 1)
+            self.assertEqual(report["summary"][versioning.STATUS_MISSING_PROFILE_VERSIONING], 1)
+
+    def test_stamp_skill_versions_updates_semver_only_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = write_skill_fixture(
+                root,
+                "semver-behind",
+                skill_versioning=skill_version_block(semver="0.0.9"),
+                profile_versioning=profile_version_block(semver="0.0.9"),
+            )
+            result = stamp_versions.stamp_skill(skill_dir, builder_version=builder_version())
+            self.assertEqual(result["status_before"], versioning.STATUS_SEMVER_BEHIND_COMPATIBLE)
+
+            spec_payload = json.loads((skill_dir / "builder-spec.json").read_text(encoding="utf-8"))
+            profile_payload = json.loads(
+                (skill_dir / "profiles" / "default" / "profile.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(
+                spec_payload["builder_versioning"]["builder_semver"],
+                builder_version()["builder_semver"],
+            )
+            self.assertEqual(
+                profile_payload["metadata"]["versioning"]["builder_semver"],
+                builder_version()["builder_semver"],
+            )
+
+    def test_stamp_skill_versions_rejects_schema_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_dir = write_skill_fixture(
+                root,
+                "stale-skill",
+                skill_versioning=skill_version_block(compatibility_epoch=0),
+                profile_versioning=profile_version_block(),
+            )
+            with self.assertRaisesRegex(
+                SystemExit, "Refusing to stamp stale-skill: compatibility status is stale-skill"
+            ):
+                stamp_versions.stamp_skill(skill_dir, builder_version=builder_version())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/tests/test_project_local_profile_resolution.py
+++ b/builders/packet-workflow/tests/test_project_local_profile_resolution.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILL_SCRIPT_DIRS = [
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "draft-release-copy" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "gh-address-review-threads" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "gh-create-pr" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "gh-fix-pr-writeup" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "git-split-and-commit" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "public-docs-sync" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "reword-recent-commits" / "scripts",
+    REPO_ROOT / "builders" / "packet-workflow" / "retained-skills" / "weekly-update" / "scripts",
+]
+for script_dir in SKILL_SCRIPT_DIRS:
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))
+
+import collect_pr_context as gh_fix_pr_writeup_collect
+import collect_pr_create_context as gh_create_pr_collect
+import collect_public_docs_sync_context as public_docs_sync_collect
+import collect_recent_commits as reword_recent_commits_collect
+import collect_release_copy_context as draft_release_copy_collect
+import collect_review_threads as gh_address_review_threads_collect
+import collect_worktree_context as git_split_and_commit_collect
+import weekly_update_lib as weekly_update_lib
+
+
+MODULES = [
+    draft_release_copy_collect,
+    gh_address_review_threads_collect,
+    gh_create_pr_collect,
+    gh_fix_pr_writeup_collect,
+    git_split_and_commit_collect,
+    public_docs_sync_collect,
+    reword_recent_commits_collect,
+    weekly_update_lib,
+]
+
+
+class ProjectLocalProfileResolutionTests(unittest.TestCase):
+    def test_default_repo_profile_path_prefers_skill_specific_then_default_then_retained(self) -> None:
+        for module in MODULES:
+            with self.subTest(module=module.__name__):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    repo_root = Path(tmpdir)
+                    skill_profile = (
+                        repo_root
+                        / ".codex"
+                        / "project"
+                        / "profiles"
+                        / module.skill_root().name
+                        / "profile.json"
+                    )
+                    default_profile = (
+                        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json"
+                    )
+
+                    skill_profile.parent.mkdir(parents=True, exist_ok=True)
+                    skill_profile.write_text("{}", encoding="utf-8")
+                    self.assertEqual(
+                        module.default_repo_profile_path(repo_root),
+                        skill_profile.resolve(),
+                    )
+
+                    skill_profile.unlink()
+                    default_profile.parent.mkdir(parents=True, exist_ok=True)
+                    default_profile.write_text("{}", encoding="utf-8")
+                    self.assertEqual(
+                        module.default_repo_profile_path(repo_root),
+                        default_profile.resolve(),
+                    )
+
+                    default_profile.unlink()
+                    self.assertEqual(
+                        module.default_repo_profile_path(repo_root),
+                        module.retained_default_repo_profile_path(),
+                    )
+
+    def test_resolve_profile_path_prefers_repo_root_then_skill_root(self) -> None:
+        for module in MODULES:
+            with self.subTest(module=module.__name__):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    repo_root = Path(tmpdir)
+                    skill_profile_relative = (
+                        Path(".codex")
+                        / "project"
+                        / "profiles"
+                        / module.skill_root().name
+                        / "profile.json"
+                    )
+                    default_profile_relative = (
+                        Path(".codex") / "project" / "profiles" / "default" / "profile.json"
+                    )
+                    skill_profile = repo_root / skill_profile_relative
+                    default_profile = repo_root / default_profile_relative
+                    skill_profile.parent.mkdir(parents=True, exist_ok=True)
+                    default_profile.parent.mkdir(parents=True, exist_ok=True)
+                    skill_profile.write_text("{}", encoding="utf-8")
+                    default_profile.write_text("{}", encoding="utf-8")
+
+                    self.assertEqual(
+                        module.resolve_profile_path(skill_profile_relative.as_posix(), repo_root),
+                        skill_profile.resolve(),
+                    )
+                    self.assertEqual(
+                        module.resolve_profile_path(default_profile_relative.as_posix(), repo_root),
+                        default_profile.resolve(),
+                    )
+                    self.assertEqual(
+                        module.resolve_profile_path("profiles/default/profile.json", repo_root),
+                        module.retained_default_repo_profile_path(),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/builders/packet-workflow/version.json
+++ b/builders/packet-workflow/version.json
@@ -1,0 +1,7 @@
+{
+  "builder_family": "packet-workflow",
+  "builder_semver": "0.1.0",
+  "compatibility_epoch": 1,
+  "builder_spec_schema_version": 1,
+  "repo_profile_schema_version": 1
+}

--- a/builders/packet-workflow/versioning-policy.md
+++ b/builders/packet-workflow/versioning-policy.md
@@ -1,0 +1,70 @@
+﻿# Packet-Workflow Versioning Policy
+
+`packet-workflow` uses explicit builder-to-skill compatibility metadata.
+
+## Canonical Source
+
+- Canonical builder version metadata lives in `version.json`.
+- Machine-readable authority order:
+  1. `builders/packet-workflow/version.json`
+  2. `builders/packet-workflow/retained-skills/<skill>/builder-spec.json` `builder_versioning`
+  3. active `profiles/<name>/profile.json` `metadata.versioning`
+
+## Version Fields
+
+- `builder_semver`
+  - Human-facing release trace only.
+- `compatibility_epoch`
+  - Manual migration gate for structure or behavior-shape changes.
+- `builder_spec_schema_version`
+  - `builder-spec.json` shape version.
+- `repo_profile_schema_version`
+  - active profile JSON shape version.
+
+## Blocking Versus Non-Blocking
+
+Validation and CI block on:
+- stale skill epoch or schema
+- stale profile epoch or schema
+- missing or invalid skill version metadata
+- missing or invalid profile version metadata
+- skill or profile ahead of the current builder
+
+Validation and CI do not block on:
+- `builder_semver` drift only, when epoch and schema versions still match
+
+Runtime collectors should:
+- record a `builder_compatibility` block in context
+- warn on stderr when compatibility status is not `current`
+
+## When To Bump `compatibility_epoch`
+
+Bump the epoch when a retained skill or profile must be manually migrated because:
+- generated script expected contract shape changed
+- required or meaningful `builder-spec.json` shape changed
+- required `profile.json` shape changed
+- runtime contract keys consumed by generated skills changed
+- generated scaffold layout or required artifact set changed
+
+Do not bump the epoch for:
+- docs-only changes
+- tests-only changes
+- additive optional fields that leave existing skills and profiles structurally valid
+- bug fixes that do not require skill or profile rewrites
+
+## Upgrade Discipline
+
+- Silent auto-bumps across epoch or schema changes are forbidden.
+- If `compatibility_epoch`, `builder_spec_schema_version`, or `repo_profile_schema_version` changes, migration is manual.
+- Retained skills must record these upgrades under `Builder Compatibility History` in `migration-worksheet.md`.
+- Each compatibility-history entry should record:
+  - `from -> to`
+  - builder semver
+  - change reason
+  - manual migration scope
+
+## Semver-Only Stamp Helper
+
+- `scripts/stamp_skill_versions.py` may update `builder_semver` and `metadata.versioning.builder_semver`.
+- It must refuse to run when epoch or schema versions are stale, missing, invalid, or ahead of the builder.
+

--- a/codex.example.toml
+++ b/codex.example.toml
@@ -1,0 +1,25 @@
+# Example only.
+# This file is a repo convention example for PacketFlow Foundry.
+# It is not a Codex platform standard.
+
+[packetflow_foundry]
+foundry_root = ".codex/vendor/packetflow_foundry"
+default_profile = "baseline"
+optional_overlays = []
+builder_entrypoint = ".codex/vendor/packetflow_foundry/builders/packet-workflow/scripts/init_packet_skill.py"
+managed_agents_policy = "foundry default set bridged into .codex/agents plus additive project overrides"
+
+[packetflow_foundry.compose]
+profile_dirs = [
+  ".codex/vendor/packetflow_foundry/profiles",
+  ".codex/project/profiles",
+]
+skill_dirs = [
+  ".codex/vendor/packetflow_foundry/.agents/skills",
+  ".agents/skills",
+]
+agent_dirs = [
+  ".codex/vendor/packetflow_foundry/.codex/agents",
+  ".codex/agents",
+]
+precedence = "foundry baseline -> optional foundry overlay -> project-local profile -> root .agents/skills override surface -> root .codex/agents subagent discovery surface"

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,0 +1,23 @@
+# Core AGENTS
+
+This subtree is the authoritative home for shared PacketFlow Foundry semantics.
+
+Keep only cross-project behavior here:
+- contracts
+- templates
+- default semantic values
+
+Do not put these in `core/`:
+- repo-specific paths
+- one-project review doc ownership
+- project-only worker routing
+- consumer-specific prompt overlays
+
+Change rules:
+- define shared behavior changes in `core/` first
+- update `builders/packet-workflow/` in the same change so the builder keeps consuming the new authoritative core
+- update builder tests when contract, template, or default changes alter generated output
+
+Boundary rules:
+- `profile-boundary-contract.md` is authoritative for what can move into profiles
+- `packet-heavy-orchestrator` is an additive opt-in overlay, not the blanket default

--- a/core/contracts/packet-workflow/common-path-contract.md
+++ b/core/contracts/packet-workflow/common-path-contract.md
@@ -1,0 +1,14 @@
+# Common Path Contract
+
+This contract is used only when the `packet-heavy-orchestrator` overlay is selected.
+It is not the blanket default.
+
+Shared rules:
+- local synthesis should complete from `global_packet.json`, `synthesis_packet.json`, and at most one focused packet reread on the common path
+- raw rereads remain exception-only
+- packet insufficiency on the common path is a failure, not a reason to guess
+- runtime metadata stays in runtime packets
+- token-efficiency and packet-sizing metrics stay in evaluation artifacts such as `packet_metrics.json`
+
+Profiles may opt into this contract.
+They must not redefine its meaning.

--- a/core/contracts/packet-workflow/core-contract.md
+++ b/core/contracts/packet-workflow/core-contract.md
@@ -13,6 +13,15 @@ Optional runtime additions:
 - `batch-packet-01.json` when grouped work items are justified
 - `synthesis_packet.json` only when the `packet-heavy-orchestrator` overlay is selected
 
+## Shared Repo-Local Temporary File Policy
+
+- Use `.codex/tmp/` as the canonical gitignored repo-local scratch tree for
+  temporary, helper, runtime-artifact, and ad hoc operator-input files.
+- If a transient file must live inside the repo, place it under `.codex/tmp/`
+  rather than the repo root or another tracked directory.
+- Evaluation logs may default outside the repo under `~/.codex/tmp/`; if a
+  repo-local fallback is required, keep it under `.codex/tmp/` as well.
+
 ## Shared Review Modes
 
 The shared modes are:

--- a/core/contracts/packet-workflow/core-contract.md
+++ b/core/contracts/packet-workflow/core-contract.md
@@ -1,0 +1,45 @@
+# Packet Workflow Core Contract
+
+This directory is the authoritative home for shared packet-workflow semantics in PacketFlow Foundry.
+
+## Shared Runtime Surface
+
+Every packet-workflow scaffold uses:
+- `orchestrator.json`
+- `global_packet.json`
+- one or more focused packets
+
+Optional runtime additions:
+- `batch-packet-01.json` when grouped work items are justified
+- `synthesis_packet.json` only when the `packet-heavy-orchestrator` overlay is selected
+
+## Shared Review Modes
+
+The shared modes are:
+- `local-only`
+- `targeted-delegation`
+- `broad-delegation`
+
+Default review-mode support and default override signals live in `../../defaults/packet-workflow/review-modes.json`.
+
+## Shared Default Authority And Stops
+
+Default authority order lives in `../../defaults/packet-workflow/authority-order.json`.
+Default stop conditions live in `../../defaults/packet-workflow/stop-taxonomy.json`.
+
+Profiles may select or tighten behavior around these defaults, but they must not redefine their meaning.
+
+## Related Contracts
+
+- `validator-apply-contract.md`
+- `common-path-contract.md`
+- `worker-family-contract.md`
+- `profile-boundary-contract.md`
+- `evaluation-log-contract.md`
+- `pattern-catalog.md`
+
+## Composition Boundary
+
+Compose shared and local inputs in this order:
+
+`foundry baseline -> optional foundry overlay -> project-local profile -> project-local skill/agent overrides`

--- a/core/contracts/packet-workflow/evaluation-log-contract.md
+++ b/core/contracts/packet-workflow/evaluation-log-contract.md
@@ -1,0 +1,87 @@
+# Evaluation Log Contract
+
+Use this file for the authoritative shared evaluation-log envelope across packet-driven repo workflow skills.
+
+## Purpose
+
+Track three outcomes consistently across runs:
+- efficiency
+- quality
+- safety
+
+The log is a local operational artifact. It should default outside the repo at:
+
+`~/.codex/tmp/evaluation_logs/<skill-name>/<run-id>.json`
+
+An explicit override path is allowed, but the default must never point into the repo.
+
+## Top-Level Shape
+
+Every evaluation log should contain:
+
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep only truly common fields in the shared envelope.
+- Put workflow-specific counters and mutation details in `skill_specific.data`.
+- Record observed values first. Estimated values must be labeled in `measurement` or `baseline`.
+- If no baseline is available, leave savings fields null instead of inventing a comparison.
+- Scores must renormalize weights when inputs are missing.
+
+## Baseline
+
+- `baseline.method`: `none | heuristic_local_only | paired_run | historical_cohort`
+- default: `none`
+- include estimate fields only when they actually exist:
+  - `estimated_local_only_tokens`
+  - `estimated_token_savings`
+  - `estimated_delegation_savings`
+- keep `baseline.confidence` explicit when a heuristic or historical estimate is used
+
+## Measurement
+
+At minimum record:
+- `token_source`: `measured | estimated | unavailable`
+- `latency_source`: `measured | estimated | unavailable`
+- `quality_source`: `self_assessed | human_confirmed | mixed | unavailable`
+
+## Scoring
+
+- `scoring.formula_version` is required
+- `efficiency_score` should prefer observed signals:
+  - worker fit
+  - packet use
+  - raw reread
+  - reruns
+  - token share when available
+- `quality_score` should use first-pass usability, human post-edit needs, unsupported claims, evidence gaps, template violations, and final-output stability
+- `safety_score` should use validate/apply boundaries, fingerprint checks, ambiguous matches, marker conflicts, rollback, and apply-after-failed-validation violations
+- `overall_score` should weight safety highest, then quality, then efficiency
+
+## Lifecycle
+
+The common helper should support:
+- `init`
+  - build a base log from `context`, `orchestrator`, and optional `lint`
+- `phase`
+  - merge deterministic phase outputs such as lint, validate, and apply results
+- `finalize`
+  - merge agent-only observations such as token usage, actual worker mix, final usability, outputs, and notes

--- a/core/contracts/packet-workflow/pattern-catalog.md
+++ b/core/contracts/packet-workflow/pattern-catalog.md
@@ -1,0 +1,255 @@
+# Pattern Catalog
+
+Read this file when a new workflow needs to be mapped onto the packet-driven repo pattern.
+This file is a shared core reference, not a project-local profile surface.
+
+## Core Shape
+
+The repeated family in this environment follows:
+
+1. deterministic context collection
+2. optional deterministic lint or normalization
+3. packet building
+4. local synthesis from `orchestrator.json` and `global_packet.json`
+5. optional validate or apply
+6. local evaluation-log updates for efficiency, quality, and safety tracking
+
+Keep the generated skill lean. Put the workflow in `SKILL.md`, detailed contracts in `references/`, and deterministic logic in `scripts/`.
+
+## Common Reference-Grade Baseline
+
+Promote these as the common default for new reference-grade scaffolds:
+- authoritative contract source in code and references
+- validator/apply separation for mutating workflows
+- apply consumes validator-normalized output only
+- stale-context recheck and dry-run parity
+- explicit stop taxonomy and fixed warning/error codes
+- smoke or end-to-end dry-run validation
+- runtime contract metadata separated from evaluation/regression metadata
+
+## Archetypes
+
+### `audit-only`
+
+Use for read-only tasks that compare rules, docs, repo state, or GitHub state and report a decision.
+
+### `audit-and-apply`
+
+Use for tasks that audit first and then apply a small, direct mutation path after local synthesis.
+
+### `plan-validate-apply`
+
+Use when the skill must create a structured action plan and refuse mutation until that plan is validated.
+
+## Packet Defaults
+
+Every generated skill should keep these contracts:
+- `orchestrator.json`
+  - review mode
+  - worker budget
+  - shared packet name
+  - local responsibilities
+  - recommended workers
+- `global_packet.json`
+  - authoritative context shared by all workers
+  - stop conditions
+  - review mode overrides
+  - non-authoritative helper notes when relevant
+
+Focused packets should be named for the workflow, for example:
+- `rules_packet.json`
+- `changes_packet.json`
+- `thread-01.json`
+- `commit-01.json`
+
+Use batch packets only when a grouped unit saves worker count or preserves context better than singleton packets.
+
+## Packet-Heavy Orchestrator Profile
+
+Use `orchestrator_profile=packet-heavy-orchestrator` only when the workflow is both packet-heavy and local-synthesis-heavy.
+
+Profile-specific additions:
+- `synthesis_packet.json`
+  - shared local drafting packet for the common path
+- `common_path_contract`
+  - runtime rule that common-path drafting should finish from `global_packet.json`, `synthesis_packet.json`, and at most one focused packet reread
+- `packet_metrics.json`
+  - evaluation/regression sidecar for packet sizing and byte/token proxies
+
+Do not make this the blanket default.
+- Narrow mutation skills usually need the common baseline only.
+- Packet-efficiency counters usually belong in evaluation artifacts, not runtime packets.
+
+## Hierarchical Adjudication Workflow
+
+Use this pattern when the local orchestrator must make the final decision from packetized evidence rather than from broad raw rereads.
+
+Shared generic structure:
+- `decision_ready_packets=true`
+- `worker_return_contract=classification-oriented`
+- `worker_output_shape=hierarchical`
+- worker outputs use:
+  - `candidates[]`
+  - `footer`
+- candidate-level factual summaries stay inside `candidates[]`
+- worker batch summary stays in `footer.primary_outcome` only
+- worker classifications remain proposal-only
+- final adjudication stays local
+- final plan confidence is recomputed locally
+- raw rereads remain exception-only
+
+Generic candidate semantics:
+- `fact_summary`
+- `proposal_classification`
+- `classification_rationale`
+- `supporting_references`
+- `ambiguity`
+- `confidence`
+- `reread_control`
+
+Generic footer semantics:
+- `packet_ids`
+- `candidate_ids`
+- `primary_outcome`
+- `overall_confidence`
+- `coverage_gaps`
+- `overall_risk`
+
+Shared reread discipline:
+- do not reopen raw evidence by default after packet generation
+- reread only when reread control points to an allowed reason such as:
+  - `conflicting_signals`
+  - `missing_required_evidence`
+  - `schema_mismatch`
+  - `insufficient_excerpt_quality`
+
+Required retained-shape guards:
+- do not combine `classification-oriented` with `decision_ready_packets=false`
+- do not declare explicit `candidate_field_bundles` for `generic` worker return
+  contracts
+- do not declare explicit `worker_footer_fields` outside decision-ready
+  hierarchical flows
+
+## Worker Family Pattern
+
+Use named worker families when the workflow benefits from reusable specialists without collapsing every workflow into one downstream-specific contract.
+
+Context/findings workers:
+- `repo_mapper`
+  - execution path
+  - touched surfaces
+  - packet membership hints
+  - assumptions and unknowns
+- `packet_explorer`
+  - one focused packet or batch packet
+  - explicitly referenced file slices only when needed
+  - packet-scoped code, behavior, or workflow findings
+- `docs_verifier`
+  - verified vs inferred vs unknown claims
+  - exact refs
+  - narrow verifier-only checks
+
+Candidate-producing workers:
+- `evidence_summarizer`
+  - long narrative evidence -> decision-ready candidate records
+- `large_diff_auditor`
+  - risk hotspots -> candidate-ready change findings
+- `log_triager`
+  - failure signals -> candidate-ready root-cause or incident findings
+
+Routing rules:
+- `worker_selection_guidance` explains when each family is useful
+- `packet_worker_map` is the only concrete routing authority
+- the builder should not infer packet-to-agent routing from packet names alone
+
+Optional worker surface:
+- family membership may overlap
+- surfaced `optional_workers` is still a deduped list
+- when explicit packet routing exists, delegation docs should surface the delegated-mode optional list after removing mapped recommended worker types
+- the same worker type may still appear on multiple packet assignments in `recommended_workers`
+
+## Domain Overlay Pattern
+
+Use a `domain_overlay` when the workflow needs domain semantics without changing the shared structure.
+
+Typical overlay responsibilities:
+- define proposal enum values
+- map generic candidate semantics to domain field names
+- mark some proposal values as reference-only
+- declare output inclusion and exclusion rules
+- adjust candidate bundles for the domain
+
+The overlay should never rename shared structural keys like `candidates` or `footer`.
+
+Precedence model:
+1. shared structure stays fixed
+2. generic candidate bundles establish semantic slots
+3. overlay bundle overrides adjust those bundles
+4. overlay aliases rename the resolved semantic slots
+
+## Weekly-Update As One Example
+
+`weekly-update` is a strong example overlay, not the universal template.
+
+It specializes the shared structure by:
+- defining proposal enum values such as incident, blocker/risk, reference-only artifact, and ignore
+- mapping generic candidate semantics to names like `summary`, `proposed_classification`, `source_refs`, `open_ambiguity`, and `raw_reread_reason`
+- mapping packets to reusable worker types such as:
+  - `mapping_packet -> repo_mapper`
+  - `changes_packet -> large_diff_auditor`
+  - `incidents_packet -> log_triager`
+  - `risks_packet -> evidence_summarizer`
+- marking one proposal value as reference-only
+- defining final section inclusion rules for its reporting output
+- keeping repo-specific review markers, release-title patterns, and similar
+  conventions in `repo_profile.extra.weekly_update` rather than in a separate
+  builder family
+
+That same structure can support other adjudication-heavy workflows such as:
+- release gating
+- incident-vs-risk adjudication
+- review triage
+- operational summaries
+
+## Delegation Defaults
+
+- `local-only`
+  - no workers
+- `targeted-delegation`
+  - 1-2 narrow packet workers
+- `broad-delegation`
+  - 3-4 narrow packet workers
+  - add QA only when findings conflict or mutation risk is broad
+
+Workers should read:
+1. `global_packet.json`
+2. one narrow packet or one batch packet
+3. one file slice only when necessary
+
+Worker return modes:
+- `generic`
+  - flat outcome-oriented response
+- `classification-oriented`
+  - proposal-grade candidate records for local adjudication
+  - prefer hierarchical `candidates[] + footer`
+
+## Safety Defaults
+
+Generated skills should inherit these assumptions unless the target workflow clearly needs something else:
+- keep final synthesis local
+- keep final adjudication local
+- keep mutation local
+- stop on `low confidence`
+- stop on stale snapshots or stale structured context
+- refresh smoke expectations from a fresh snapshot instead of hardcoding them
+- use deterministic markers or fingerprints for reruns
+- treat optional local helpers as local-only and non-authoritative
+- emit local evaluation logs outside the repo by default
+
+## Non-Goals
+
+Do not generate:
+- shared runtime Python libraries used by multiple skills
+- long generic READMEs
+- exhaustive domain semantics without repo evidence
+- migration helpers for older generic skills unless the user explicitly asks for a separate migration tool

--- a/core/contracts/packet-workflow/profile-boundary-contract.md
+++ b/core/contracts/packet-workflow/profile-boundary-contract.md
@@ -1,0 +1,35 @@
+# Profile Boundary Contract
+
+Profiles are data-only overlays.
+
+## Allowed In Profiles
+
+- repo markers
+- path bindings
+- globs
+- review-doc lists
+- lint and review defaults
+- worker selection defaults
+- `metadata.versioning` compatibility metadata
+- notes
+
+## Must Stay In Core
+
+- validator/apply semantics
+- stop taxonomy meaning
+- common-path semantics
+- worker-family semantics
+- packet schema semantics
+- shared default authority order
+
+## Forbidden In Profiles
+
+- executable hooks
+- prompt fragments that define behavior
+- packet routing authority
+- validator/apply behavior
+- stop taxonomy redefinition
+- token-budget semantics
+
+Foundry reusable overlays belong in `profiles/`.
+Repo-specific profiles belong in `.codex/project/profiles/`.

--- a/core/contracts/packet-workflow/validator-apply-contract.md
+++ b/core/contracts/packet-workflow/validator-apply-contract.md
@@ -1,0 +1,10 @@
+# Validator Apply Contract
+
+Shared mutating workflow rules:
+- validator and apply are separate phases
+- apply consumes validator-normalized output only
+- apply must not consume raw plan input directly
+- `--dry-run` must use the same validator-normalized input path as real apply
+- stale-context, fingerprint, and apply-gate checks belong on the validate/apply boundary
+
+Profiles may select defaults around these phases, but they must not redefine this contract.

--- a/core/contracts/packet-workflow/worker-family-contract.md
+++ b/core/contracts/packet-workflow/worker-family-contract.md
@@ -1,0 +1,22 @@
+# Worker Family Contract
+
+Shared worker families:
+- `context_findings`
+  - `repo_mapper`
+  - `packet_explorer`
+  - `docs_verifier`
+- `candidate_producers`
+  - `evidence_summarizer`
+  - `large_diff_auditor`
+  - `log_triager`
+- `verifiers`
+  - `docs_verifier`
+
+Routing rules:
+- `worker_selection_guidance` is explanatory only
+- `packet_worker_map` is the routing authority when present
+- family overlap is allowed
+- surfaced optional workers are deduped after family composition
+
+Projects may adjust worker selection defaults locally.
+They should not redefine shared worker behavior semantics in profiles.

--- a/core/defaults/packet-workflow/authority-order.json
+++ b/core/defaults/packet-workflow/authority-order.json
@@ -1,0 +1,5 @@
+[
+  "tracked repo materials",
+  "structured workflow packets",
+  "optional local helper"
+]

--- a/core/defaults/packet-workflow/review-modes.json
+++ b/core/defaults/packet-workflow/review-modes.json
@@ -1,0 +1,12 @@
+{
+  "supported_modes": [
+    "local-only",
+    "targeted-delegation",
+    "broad-delegation"
+  ],
+  "default_override_signals": [
+    "diff churn exceeds a configured threshold",
+    "core runtime, config, or process files span multiple groups",
+    "generated files are present but are not the majority of the change"
+  ]
+}

--- a/core/defaults/packet-workflow/stop-taxonomy.json
+++ b/core/defaults/packet-workflow/stop-taxonomy.json
@@ -1,0 +1,10 @@
+{
+  "default_stop_conditions": [
+    "low confidence",
+    "stale snapshot or stale context",
+    "ambiguous packet or ownership match"
+  ],
+  "notes": [
+    "Profiles may tighten thresholds around stop handling but must not redefine these meanings."
+  ]
+}

--- a/core/templates/packet-workflow/apply.py.tmpl
+++ b/core/templates/packet-workflow/apply.py.tmpl
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Dry-run or apply a validated action file for __SKILL_NAME__."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--validation",
+        required=True,
+        help="Validator output JSON with normalized_plan and apply_gate_status.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the apply plan without mutating.",
+    )
+    parser.add_argument(
+        "--result-output",
+        help="Optional machine-readable apply result JSON.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def fingerprint_plan(plan: dict) -> str:
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def build_result(
+    validation: dict,
+    *,
+    dry_run: bool,
+    apply_succeeded: bool,
+    stop_reasons: list[str],
+    message: str,
+) -> dict:
+    normalized_plan = validation.get("normalized_plan") or {}
+    return {
+        "skill_name": normalized_plan.get("skill_name"),
+        "context_id": normalized_plan.get("context_id"),
+        "dry_run": dry_run,
+        "apply_succeeded": apply_succeeded,
+        "validation_boundary_enforced": True,
+        "normalized_plan_fingerprint": validation.get("normalized_plan_fingerprint"),
+        "mutation_type": "none",
+        "message": message,
+        "action_count": len(normalized_plan.get("actions", [])),
+        "mutations": [],
+        "primary_artifact": None,
+        "secondary_artifacts": [],
+        "stop_reasons": stop_reasons,
+        "rollback_needed": False,
+        "requires_implementation": True,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    validation = load_json(Path(args.validation).resolve())
+    normalized_plan = validation.get("normalized_plan")
+    expected_fingerprint = validation.get("normalized_plan_fingerprint")
+    stop_reasons = [str(item) for item in validation.get("stop_reasons", []) if str(item).strip()]
+
+    if not isinstance(normalized_plan, dict):
+        result = build_result(
+            validation,
+            dry_run=args.dry_run,
+            apply_succeeded=False,
+            stop_reasons=sorted(set(stop_reasons + ["validator_mismatch"])),
+            message="Validator output is missing normalized_plan.",
+        )
+        if args.result_output:
+            write_json(Path(args.result_output).resolve(), result)
+        print(json.dumps(result, indent=2))
+        return 1
+
+    actual_fingerprint = fingerprint_plan(normalized_plan)
+    if not expected_fingerprint or actual_fingerprint != expected_fingerprint:
+        result = build_result(
+            validation,
+            dry_run=args.dry_run,
+            apply_succeeded=False,
+            stop_reasons=sorted(set(stop_reasons + ["validator_mismatch"])),
+            message="Validator fingerprint mismatch blocked apply.",
+        )
+        if args.result_output:
+            write_json(Path(args.result_output).resolve(), result)
+        print(json.dumps(result, indent=2))
+        return 1
+
+    if not validation.get("valid") or not validation.get("can_apply"):
+        result = build_result(
+            validation,
+            dry_run=args.dry_run,
+            apply_succeeded=False,
+            stop_reasons=sorted(set(stop_reasons or ["unresolved_stop_reason"])),
+            message="Validation did not clear apply gates.",
+        )
+        if args.result_output:
+            write_json(Path(args.result_output).resolve(), result)
+        print(json.dumps(result, indent=2))
+        return 1
+
+    result = build_result(
+        validation,
+        dry_run=args.dry_run,
+        apply_succeeded=True,
+        stop_reasons=sorted(set(stop_reasons)),
+        message=(
+            "Skeleton apply script confirmed the validator boundary and dry-run parity. "
+            "Replace the placeholder mutation block with domain-specific logic."
+        ),
+    )
+
+    if args.result_output:
+        write_json(Path(args.result_output).resolve(), result)
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/templates/packet-workflow/build_packets.py.tmpl
+++ b/core/templates/packet-workflow/build_packets.py.tmpl
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Build focused packets for __SKILL_NAME__ from collected context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SPEC_METADATA = __SPEC_METADATA_JSON__
+PACKET_NAMES = __TASK_PACKET_NAMES_JSON__
+USES_BATCH_PACKETS = __USES_BATCH_PACKETS__
+REVIEW_MODE_OVERRIDES = __REVIEW_MODE_OVERRIDES_JSON__
+WORKER_INSTRUCTION_MAP = __WORKER_INSTRUCTION_MAP_JSON__
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+__LINT_ARG_BLOCK__
+    parser.add_argument("--output-dir", required=True, help="Packet output directory.")
+    parser.add_argument(
+        "--result-output",
+        help="Optional machine-readable build result JSON.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def next_mode(mode: str) -> str:
+    order = ["local-only", "targeted-delegation", "broad-delegation"]
+    index = min(order.index(mode) + 1, len(order) - 1)
+    return order[index]
+
+
+def has_override_signal(context: dict, lint: dict) -> bool:
+    merged = {}
+    merged.update(context.get("override_signals", {}))
+    merged.update(lint.get("override_signals", {}))
+    return any(bool(value) for value in merged.values())
+
+
+def compute_review_mode(context: dict, lint: dict) -> tuple[str, bool]:
+    counts = context.get("counts", {})
+    task_packet_count = max(int(counts.get("task_packet_count", 0)), len(PACKET_NAMES))
+    changed_files = int(counts.get("changed_files", task_packet_count))
+    batch_count = int(counts.get("batch_count", 0))
+
+    mode = "local-only"
+    if task_packet_count >= 5 or changed_files > 20 or batch_count >= 3:
+        mode = "broad-delegation"
+    elif task_packet_count >= 3 or batch_count >= 2:
+        mode = "targeted-delegation"
+
+    override = has_override_signal(context, lint)
+    if override:
+        mode = next_mode(mode)
+    return mode, override
+
+
+def recommended_worker_count(review_mode: str) -> int:
+    return {
+        "local-only": 0,
+        "targeted-delegation": 2,
+        "broad-delegation": 4,
+    }[review_mode]
+
+
+def active_worker_family_order() -> list[str]:
+    if SPEC_METADATA["worker_return_contract"] == "classification-oriented":
+        return ["context_findings", "candidate_producers", "verifiers"]
+    return ["context_findings", "verifiers"]
+
+
+def surfaced_optional_workers(recommended_workers: list[dict]) -> list[str]:
+    ordered: list[str] = []
+    for family_name in active_worker_family_order():
+        ordered.extend(SPEC_METADATA["preferred_worker_families"].get(family_name, []))
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for agent_type in ordered:
+        if agent_type not in seen:
+            seen.add(agent_type)
+            deduped.append(agent_type)
+    recommended_agent_types = {worker["agent_type"] for worker in recommended_workers}
+    return [
+        agent_type
+        for agent_type in deduped
+        if agent_type not in recommended_agent_types
+    ]
+
+
+def recommended_workers(review_mode: str) -> list[dict]:
+    if review_mode == "local-only" or not SPEC_METADATA["packet_worker_map"]:
+        return []
+    budget = recommended_worker_count(review_mode)
+    workers: list[dict] = []
+    seen_assignments: set[tuple[str, str]] = set()
+    ordered_packets: list[str] = []
+    if USES_BATCH_PACKETS:
+        ordered_packets.append("batch-packet-01")
+    ordered_packets.extend(PACKET_NAMES)
+    for packet_name in ordered_packets:
+        for agent_type in SPEC_METADATA["packet_worker_map"].get(packet_name, []):
+            assignment = (agent_type, packet_name)
+            if assignment in seen_assignments:
+                continue
+            workers.append(
+                {
+                    "agent_type": agent_type,
+                    "packet": f"{packet_name}.json",
+                    "instruction": WORKER_INSTRUCTION_MAP[agent_type],
+                }
+            )
+            seen_assignments.add(assignment)
+            if len(workers) >= budget:
+                return workers
+    return workers
+
+
+def packet_order() -> list[str]:
+    order = ["global_packet.json"]
+    if SPEC_METADATA.get("shared_local_packet"):
+        order.append(SPEC_METADATA["shared_local_packet"])
+    if USES_BATCH_PACKETS:
+        order.append("batch-packet-01.json")
+    order.extend(f"{packet_name}.json" for packet_name in PACKET_NAMES)
+    return order
+
+
+def orchestrator_payload(
+    context: dict,
+    review_mode: str,
+    override: bool,
+    concrete_workers: list[dict],
+    ordered_packets: list[str],
+) -> dict:
+    payload = {
+        "skill_name": SPEC_METADATA["skill_name"],
+        "workflow_family": SPEC_METADATA["workflow_family"],
+        "archetype": SPEC_METADATA["archetype"],
+        "orchestrator_profile": SPEC_METADATA["orchestrator_profile"],
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "recommended_worker_count": recommended_worker_count(review_mode),
+        "recommended_workers": concrete_workers,
+        "optional_workers": surfaced_optional_workers(concrete_workers),
+        "local_responsibilities": [
+            "final adjudication",
+            "final synthesis",
+            "final plan confidence recomputation",
+            "final mutation",
+            "conflict resolution",
+        ],
+        "shared_packet": "global_packet.json",
+        "packet_order": ordered_packets,
+        "review_mode_overrides": REVIEW_MODE_OVERRIDES,
+        "override_applied": override,
+        "preferred_worker_families": SPEC_METADATA["preferred_worker_families"],
+        "packet_worker_map": SPEC_METADATA["packet_worker_map"],
+        "worker_selection_guidance": SPEC_METADATA["worker_selection_guidance"],
+        "decision_ready_packets": SPEC_METADATA["decision_ready_packets"],
+        "worker_return_contract": SPEC_METADATA["worker_return_contract"],
+        "worker_output_shape": SPEC_METADATA["worker_output_shape"],
+        "xhigh_reread_policy": SPEC_METADATA["xhigh_reread_policy"],
+        "candidate_field_bundles": SPEC_METADATA["resolved_candidate_field_bundles"],
+        "worker_footer_fields": SPEC_METADATA["worker_footer_fields"],
+        "reread_reason_values": SPEC_METADATA["reread_reason_values"],
+        "domain_overlay": SPEC_METADATA["domain_overlay"],
+    }
+    if SPEC_METADATA.get("shared_local_packet"):
+        payload["shared_local_packet"] = SPEC_METADATA["shared_local_packet"]
+        payload["common_path_contract"] = SPEC_METADATA["common_path_contract"]
+    return payload
+
+
+def global_packet_payload(context: dict) -> dict:
+    payload = {
+        "skill_name": SPEC_METADATA["skill_name"],
+        "workflow_family": SPEC_METADATA["workflow_family"],
+        "primary_goal": SPEC_METADATA["primary_goal"],
+        "authority_order": SPEC_METADATA["authority_order"],
+        "stop_conditions": SPEC_METADATA["stop_conditions"],
+        "review_mode_overrides": REVIEW_MODE_OVERRIDES,
+        "context_id": context.get("context_id"),
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile": context.get("repo_profile"),
+        "optional_local_helper": context.get("optional_local_helper"),
+        "preferred_worker_families": SPEC_METADATA["preferred_worker_families"],
+        "packet_worker_map": SPEC_METADATA["packet_worker_map"],
+        "worker_selection_guidance": SPEC_METADATA["worker_selection_guidance"],
+        "decision_ready_packets": SPEC_METADATA["decision_ready_packets"],
+        "worker_return_contract": SPEC_METADATA["worker_return_contract"],
+        "worker_output_shape": SPEC_METADATA["worker_output_shape"],
+        "xhigh_reread_policy": SPEC_METADATA["xhigh_reread_policy"],
+        "candidate_field_bundles": SPEC_METADATA["resolved_candidate_field_bundles"],
+        "worker_footer_fields": SPEC_METADATA["worker_footer_fields"],
+        "reread_reason_values": SPEC_METADATA["reread_reason_values"],
+        "domain_overlay": SPEC_METADATA["domain_overlay"],
+        "orchestrator_profile": SPEC_METADATA["orchestrator_profile"],
+    }
+    if SPEC_METADATA.get("shared_local_packet"):
+        payload["shared_local_packet"] = SPEC_METADATA["shared_local_packet"]
+    return payload
+
+
+def synthesis_packet_payload(context: dict, review_mode: str) -> dict:
+    return {
+        "packet_id": "synthesis_packet",
+        "packet_kind": "local-synthesis",
+        "context_id": context.get("context_id"),
+        "repo_profile_name": context.get("repo_profile_name"),
+        "review_mode": review_mode,
+        "shared_packet": "global_packet.json",
+        "focused_packets": [f"{packet_name}.json" for packet_name in PACKET_NAMES],
+        "common_path_contract": SPEC_METADATA["common_path_contract"],
+        "drafting_authority_order": SPEC_METADATA["authority_order"],
+        "required_final_checks": [
+            "recompute final plan confidence locally",
+            "treat raw rereads as exceptional rather than compensatory",
+            "stop if packet insufficiency blocks local drafting",
+        ],
+        "todo": "Replace this scaffold packet with the common-path decision set needed for local final drafting.",
+    }
+
+
+def dump_json_bytes(payload: dict) -> int:
+    return len(json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")) + 1
+
+
+def estimate_tokens(byte_count: int) -> int:
+    return max(1, (byte_count + 3) // 4)
+
+
+def packet_metrics_payload(context: dict, lint: dict, packet_payloads: dict[str, dict]) -> dict:
+    packet_sizes = {
+        name: dump_json_bytes(payload)
+        for name, payload in packet_payloads.items()
+    }
+    ordered_sizes = sorted(packet_sizes.values(), reverse=True)
+    worker_facing_packets = {
+        name: size
+        for name, size in packet_sizes.items()
+        if name != "synthesis_packet.json"
+    }
+    worker_facing_bytes = sum(worker_facing_packets.values())
+    local_only_bytes = dump_json_bytes(context)
+    if lint:
+        local_only_bytes += dump_json_bytes(lint)
+    estimated_local_only_tokens = estimate_tokens(local_only_bytes)
+    estimated_packet_tokens = estimate_tokens(worker_facing_bytes)
+    return {
+        "packet_count": len(packet_sizes),
+        "packet_size_bytes": packet_sizes,
+        "largest_packet_bytes": ordered_sizes[0] if ordered_sizes else 0,
+        "largest_two_packets_bytes": sum(ordered_sizes[:2]),
+        "estimated_local_only_tokens": estimated_local_only_tokens,
+        "estimated_packet_tokens": estimated_packet_tokens,
+        "estimated_delegation_savings": max(
+            0, estimated_local_only_tokens - estimated_packet_tokens
+        ),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+__LINT_LOAD_BLOCK__
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    review_mode, override = compute_review_mode(context, lint)
+    ordered_packets = packet_order()
+    concrete_workers = recommended_workers(review_mode)
+
+    packet_payloads: dict[str, dict] = {
+        "orchestrator.json": orchestrator_payload(
+            context,
+            review_mode,
+            override,
+            concrete_workers,
+            ordered_packets,
+        ),
+        "global_packet.json": global_packet_payload(context),
+    }
+    if SPEC_METADATA.get("shared_local_packet"):
+        packet_payloads[SPEC_METADATA["shared_local_packet"]] = synthesis_packet_payload(
+            context,
+            review_mode,
+        )
+
+    for packet_name in PACKET_NAMES:
+        packet_payloads[f"{packet_name}.json"] = __FOCUSED_PACKET_TEMPLATE__
+
+    if USES_BATCH_PACKETS:
+        packet_payloads["batch-packet-01.json"] = {
+            "packet_id": "batch-packet-01",
+            "packet_kind": "batch",
+            "packet_targets": PACKET_NAMES,
+            "context_id": context.get("context_id"),
+            "todo": "Group related singleton packets here when the workflow benefits from clustering.",
+        }
+
+    for file_name, payload in packet_payloads.items():
+        write_json(output_dir / file_name, payload)
+
+    packet_metrics = None
+    if SPEC_METADATA["orchestrator_profile"] == "packet-heavy-orchestrator":
+        packet_metrics = packet_metrics_payload(context, lint, packet_payloads)
+        write_json(output_dir / "packet_metrics.json", packet_metrics)
+
+    result = {
+        "skill_name": SPEC_METADATA["skill_name"],
+        "workflow_family": SPEC_METADATA["workflow_family"],
+        "orchestrator_profile": SPEC_METADATA["orchestrator_profile"],
+        "repo_profile_name": context.get("repo_profile_name"),
+        "repo_profile_path": context.get("repo_profile_path"),
+        "repo_profile_summary": context.get("repo_profile_summary"),
+        "review_mode": review_mode,
+        "recommended_worker_count": recommended_worker_count(review_mode),
+        "packet_files": ordered_packets,
+    }
+    if SPEC_METADATA.get("shared_local_packet"):
+        result["shared_local_packet"] = SPEC_METADATA["shared_local_packet"]
+        result["common_path_contract"] = SPEC_METADATA["common_path_contract"]
+    if packet_metrics is not None:
+        result["packet_metrics"] = packet_metrics
+
+    if args.result_output:
+        write_json(Path(args.result_output).resolve(), result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/templates/packet-workflow/collect_context.py.tmpl
+++ b/core/templates/packet-workflow/collect_context.py.tmpl
@@ -1,0 +1,357 @@
+﻿#!/usr/bin/env python3
+"""Collect structured workflow context for __SKILL_NAME__."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SPEC_METADATA = __SPEC_METADATA_JSON__
+DEFAULT_AUTHORITY_ORDER = __AUTHORITY_ORDER_JSON__
+DEFAULT_STOP_CONDITIONS = __STOP_CONDITIONS_JSON__
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True, help="Repository root to inspect.")
+    parser.add_argument("--output", required=True, help="Output JSON path.")
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help=(
+            "Optional path to the active repo profile JSON. Relative paths resolve from the "
+            "repo root first, then the skill root. When omitted, the collector prefers "
+            "`.codex/project/profiles/<skill-name>/profile.json`, then "
+            "`.codex/project/profiles/default/profile.json`, then the retained default scaffold."
+        ),
+    )
+__HELPER_COLLECT_ARG_BLOCK__
+    return parser.parse_args()
+
+
+def resolve_repo_root(repo_root: str) -> Path:
+    path = Path(repo_root).resolve()
+    if not path.exists():
+        raise SystemExit(f"[ERROR] Missing repo root: {path}")
+    return path
+
+
+def skill_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def retained_default_repo_profile_path() -> Path:
+    return skill_root() / "profiles" / SPEC_METADATA["repo_profile"]["name"] / "profile.json"
+
+
+def project_local_profile_candidates(repo_root: Path) -> list[Path]:
+    repo_root = repo_root.resolve()
+    return [
+        repo_root / ".codex" / "project" / "profiles" / skill_root().name / "profile.json",
+        repo_root / ".codex" / "project" / "profiles" / "default" / "profile.json",
+    ]
+
+
+def default_repo_profile_path(repo_root: Path | None = None) -> Path:
+    if repo_root is not None:
+        for candidate in project_local_profile_candidates(repo_root):
+            if candidate.exists():
+                return candidate.resolve()
+    return retained_default_repo_profile_path()
+
+
+def resolve_profile_path(profile_path: str | None, repo_root: Path | None = None) -> Path:
+    if not profile_path:
+        return default_repo_profile_path(repo_root)
+
+    candidate = Path(profile_path)
+    if candidate.is_absolute():
+        resolved_candidates = [candidate.resolve()]
+    else:
+        resolved_candidates: list[Path] = []
+        if repo_root is not None:
+            resolved_candidates.append((repo_root / candidate).resolve())
+        resolved_candidates.append((skill_root() / candidate).resolve())
+    for resolved in resolved_candidates:
+        if resolved.exists():
+            return resolved
+    searched = ", ".join(path.as_posix() for path in resolved_candidates)
+    raise SystemExit(f"[ERROR] Missing repo profile: {searched}")
+
+
+def load_repo_profile(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(payload, dict):
+        raise SystemExit("[ERROR] Repo profile must be a JSON object.")
+    return payload
+
+
+def canonical_builder_version_path() -> Path | None:
+    seen: set[Path] = set()
+    for base in skill_root().parents:
+        for candidate in (
+            base / "builders" / "packet-workflow" / "version.json",
+            base / ".codex" / "vendor" / "packetflow_foundry" / "builders" / "packet-workflow" / "version.json",
+        ):
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            if resolved.is_file():
+                return resolved
+    return None
+
+
+def normalize_versioning_block(
+    value: object,
+    *,
+    require_builder_spec_schema_version: bool,
+) -> dict | None:
+    if not isinstance(value, dict):
+        return None
+    builder_family = value.get("builder_family")
+    builder_semver = value.get("builder_semver")
+    compatibility_epoch = value.get("compatibility_epoch")
+    repo_profile_schema_version = value.get("repo_profile_schema_version")
+    if not isinstance(builder_family, str) or not builder_family.strip():
+        return None
+    if parse_semver(builder_semver) is None:
+        return None
+    if not isinstance(compatibility_epoch, int):
+        return None
+    if not isinstance(repo_profile_schema_version, int):
+        return None
+    normalized = {
+        "builder_family": builder_family.strip(),
+        "builder_semver": str(builder_semver).strip(),
+        "compatibility_epoch": compatibility_epoch,
+        "repo_profile_schema_version": repo_profile_schema_version,
+    }
+    if require_builder_spec_schema_version:
+        builder_spec_schema_version = value.get("builder_spec_schema_version")
+        if not isinstance(builder_spec_schema_version, int):
+            return None
+        normalized["builder_spec_schema_version"] = builder_spec_schema_version
+    return normalized
+
+
+def parse_semver(value: object) -> tuple[int, int, int] | None:
+    text = str(value or "").strip()
+    parts = text.split(".")
+    if len(parts) != 3:
+        return None
+    if any(not part.isdigit() for part in parts):
+        return None
+    return tuple(int(part) for part in parts)
+
+
+def compare_semver(left: str, right: str) -> int:
+    left_semver = parse_semver(left)
+    right_semver = parse_semver(right)
+    if left_semver is None or right_semver is None:
+        raise SystemExit("[ERROR] Invalid builder semver metadata.")
+    if left_semver < right_semver:
+        return -1
+    if left_semver > right_semver:
+        return 1
+    return 0
+
+
+def load_current_builder_versioning() -> tuple[dict, list[str]]:
+    warnings: list[str] = []
+    version_path = canonical_builder_version_path()
+    if version_path is not None and version_path.is_file():
+        payload = json.loads(version_path.read_text(encoding="utf-8-sig"))
+        normalized = normalize_versioning_block(
+            payload,
+            require_builder_spec_schema_version=True,
+        )
+        if normalized is not None:
+            return normalized, warnings
+        warnings.append(
+            "Canonical builder version metadata is invalid; falling back to skill metadata."
+        )
+    else:
+        warnings.append(
+            "Canonical builder version metadata is missing; falling back to skill metadata."
+        )
+    fallback = normalize_versioning_block(
+        SPEC_METADATA.get("builder_versioning"),
+        require_builder_spec_schema_version=True,
+    )
+    if fallback is None:
+        raise SystemExit("[ERROR] Missing skill builder_versioning metadata.")
+    return fallback, warnings
+
+
+def build_builder_compatibility(repo_profile: dict) -> dict:
+    warnings: list[str] = []
+    current_builder, builder_warnings = load_current_builder_versioning()
+    warnings.extend(builder_warnings)
+    skill_versioning = normalize_versioning_block(
+        SPEC_METADATA.get("builder_versioning"),
+        require_builder_spec_schema_version=True,
+    )
+    metadata = repo_profile.get("metadata")
+    profile_versioning = normalize_versioning_block(
+        metadata.get("versioning") if isinstance(metadata, dict) else None,
+        require_builder_spec_schema_version=False,
+    )
+    status = "current"
+    if skill_versioning is None:
+        status = "missing-skill-versioning"
+        warnings.append("Skill builder_versioning is missing or invalid.")
+    elif skill_versioning["builder_family"] != current_builder["builder_family"]:
+        status = "missing-skill-versioning"
+        warnings.append(
+            "Skill builder_versioning.builder_family does not match the current builder family."
+        )
+    elif profile_versioning is None:
+        status = "missing-profile-versioning"
+        warnings.append("Profile metadata.versioning is missing or invalid.")
+    elif profile_versioning["builder_family"] != current_builder["builder_family"]:
+        status = "missing-profile-versioning"
+        warnings.append(
+            "Profile metadata.versioning.builder_family does not match the current builder family."
+        )
+    else:
+        skill_semver_cmp = compare_semver(
+            skill_versioning["builder_semver"],
+            current_builder["builder_semver"],
+        )
+        profile_semver_cmp = compare_semver(
+            profile_versioning["builder_semver"],
+            current_builder["builder_semver"],
+        )
+        if (
+            skill_versioning["compatibility_epoch"] > current_builder["compatibility_epoch"]
+            or skill_versioning["builder_spec_schema_version"]
+            > current_builder["builder_spec_schema_version"]
+            or skill_versioning["repo_profile_schema_version"]
+            > current_builder["repo_profile_schema_version"]
+            or profile_versioning["compatibility_epoch"]
+            > current_builder["compatibility_epoch"]
+            or profile_versioning["repo_profile_schema_version"]
+            > current_builder["repo_profile_schema_version"]
+            or skill_semver_cmp > 0
+            or profile_semver_cmp > 0
+        ):
+            status = "ahead-of-builder"
+        elif (
+            skill_versioning["compatibility_epoch"] < current_builder["compatibility_epoch"]
+            or skill_versioning["builder_spec_schema_version"]
+            < current_builder["builder_spec_schema_version"]
+            or skill_versioning["repo_profile_schema_version"]
+            < current_builder["repo_profile_schema_version"]
+        ):
+            status = "stale-skill"
+        elif (
+            profile_versioning["compatibility_epoch"] < current_builder["compatibility_epoch"]
+            or profile_versioning["repo_profile_schema_version"]
+            < current_builder["repo_profile_schema_version"]
+        ):
+            status = "stale-profile"
+        elif skill_semver_cmp < 0 or profile_semver_cmp < 0:
+            status = "semver-behind-compatible"
+            if skill_semver_cmp < 0:
+                warnings.append(
+                    f"Skill builder_semver {skill_versioning['builder_semver']} trails current builder {current_builder['builder_semver']}."
+                )
+            if profile_semver_cmp < 0:
+                warnings.append(
+                    f"Active profile builder_semver {profile_versioning['builder_semver']} trails current builder {current_builder['builder_semver']}."
+                )
+        if (
+            status in {"current", "semver-behind-compatible"}
+            and compare_semver(
+                skill_versioning["builder_semver"],
+                profile_versioning["builder_semver"],
+            )
+            != 0
+        ):
+            warnings.append(
+                "Skill and active profile semver differ while remaining compatibility-safe."
+            )
+    return {
+        "status": status,
+        "current_builder_semver": current_builder["builder_semver"],
+        "current_compatibility_epoch": current_builder["compatibility_epoch"],
+        "current_builder_spec_schema_version": current_builder["builder_spec_schema_version"],
+        "current_repo_profile_schema_version": current_builder["repo_profile_schema_version"],
+        "skill_builder_semver": None if skill_versioning is None else skill_versioning["builder_semver"],
+        "skill_compatibility_epoch": None if skill_versioning is None else skill_versioning["compatibility_epoch"],
+        "skill_builder_spec_schema_version": None if skill_versioning is None else skill_versioning["builder_spec_schema_version"],
+        "active_profile_builder_semver": None if profile_versioning is None else profile_versioning["builder_semver"],
+        "active_profile_repo_profile_schema_version": None if profile_versioning is None else profile_versioning["repo_profile_schema_version"],
+        "warnings": warnings,
+    }
+
+
+def emit_builder_compatibility_warning(compatibility: dict) -> None:
+    if compatibility.get("status") == "current":
+        return
+    warning_text = "; ".join(str(item) for item in compatibility.get("warnings") or [])
+    suffix = f" {warning_text}" if warning_text else ""
+    print(
+        "[WARN] packet-workflow builder compatibility "
+        f"status={compatibility.get('status')}.{suffix}".strip(),
+        file=sys.stderr,
+    )
+
+
+__HELPER_COLLECT_FUNCTIONS__
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = resolve_repo_root(args.repo_root)
+    profile_path = resolve_profile_path(args.profile, repo_root)
+    repo_profile = load_repo_profile(profile_path)
+    builder_compatibility = build_builder_compatibility(repo_profile)
+
+    context = {
+        "skill_name": SPEC_METADATA["skill_name"],
+        "workflow_family": SPEC_METADATA["workflow_family"],
+        "archetype": SPEC_METADATA["archetype"],
+        "context_id": f"{SPEC_METADATA['skill_name']}:{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+        "repo_root": repo_root.as_posix(),
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "repo_profile_name": repo_profile.get("name"),
+        "repo_profile_path": profile_path.as_posix(),
+        "repo_profile_summary": repo_profile.get("summary"),
+        "repo_profile": repo_profile,
+        "builder_compatibility": builder_compatibility,
+        "authority_order": DEFAULT_AUTHORITY_ORDER,
+        "stop_conditions": DEFAULT_STOP_CONDITIONS,
+        "counts": {
+            "changed_files": 0,
+            "task_packet_count": len(SPEC_METADATA["task_packet_names"]),
+            "batch_count": 0,
+        },
+        "override_signals": {
+            "high_churn": False,
+            "multi_group_core_files": False,
+            "generated_not_majority": False,
+        },
+        "notes": [
+            f"Loaded repo profile from {profile_path.as_posix()}.",
+            "TODO: replace this skeleton collector with domain-specific structured context gathering."
+        ],
+    }
+__HELPER_COLLECT_CONTEXT_LINE__
+    emit_builder_compatibility_warning(builder_compatibility)
+    write_json(Path(args.output).resolve(), context)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/core/templates/packet-workflow/core_contract.tmpl
+++ b/core/templates/packet-workflow/core_contract.tmpl
@@ -22,6 +22,15 @@ Consumer repos should prefer `.codex/project/profiles/__SKILL_NAME__/profile.jso
 __TASK_PACKET_BULLETS__
 __PROFILE_RUNTIME_ARTIFACTS__
 
+## Shared Repo-Local Temporary File Policy
+
+- Use `.codex/tmp/` as the canonical gitignored repo-local scratch tree for
+  temporary, helper, runtime-artifact, and ad hoc operator-input files.
+- If a transient file must live inside the repo, place it under `.codex/tmp/`
+  rather than the repo root or another tracked directory.
+- Evaluation logs may default outside the repo under `~/.codex/tmp/`; if a
+  repo-local fallback is required, keep it under `.codex/tmp/` as well.
+
 Review mode overrides inherited by default:
 __REVIEW_MODE_OVERRIDES_BULLETS__
 

--- a/core/templates/packet-workflow/core_contract.tmpl
+++ b/core/templates/packet-workflow/core_contract.tmpl
@@ -1,0 +1,62 @@
+# __SKILL_TITLE__ Core Contract
+
+This file captures the reusable packet-workflow core for the generated `__SKILL_NAME__` scaffold.
+Keep repo-specific paths, review-doc lists, and lint toggles in `__REPO_PROFILE_FILE__`.
+Repo profiles are data-only inputs. Do not place executable hooks, prompt text, or worker-routing behavior in them.
+Consumer repos should prefer `.codex/project/profiles/__SKILL_NAME__/profile.json` over editing the retained default directly.
+
+## Core Metadata
+
+- `workflow_family`: `__WORKFLOW_FAMILY__`
+- `archetype`: `__ARCHETYPE__`
+- `orchestrator_profile`: `__ORCHESTRATOR_PROFILE__`
+- `decision_ready_packets`: `__DECISION_READY_PACKETS__`
+- `worker_return_contract`: `__WORKER_RETURN_CONTRACT__`
+- `worker_output_shape`: `__WORKER_OUTPUT_SHAPE__`
+
+## Shared Runtime Surface
+
+- Required packet outputs:
+- `orchestrator.json`
+- `global_packet.json`
+__TASK_PACKET_BULLETS__
+__PROFILE_RUNTIME_ARTIFACTS__
+
+Review mode overrides inherited by default:
+__REVIEW_MODE_OVERRIDES_BULLETS__
+
+Authority order:
+__AUTHORITY_ORDER_BULLETS__
+
+Stop conditions:
+__STOP_CONDITIONS_BULLETS__
+
+## Generic Worker Contract
+
+__GENERIC_ADJUDICATION_SECTION__
+
+__WORKER_FAMILY_SECTION__
+
+## Repo Profile Boundary
+
+- Default generated profile: `__REPO_PROFILE_FILE__`
+- Preferred project-local override path: `.codex/project/profiles/__SKILL_NAME__/profile.json`
+- Summary: __REPO_PROFILE_SUMMARY__
+- Default bindings:
+__REPO_PROFILE_BINDINGS_MARKDOWN__
+- Default packet defaults:
+__REPO_PROFILE_PACKET_DEFAULTS_MARKDOWN__
+- Default lint rules:
+__REPO_PROFILE_LINT_RULES_MARKDOWN__
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime routing, authority, stop conditions, and adjudication support in `orchestrator.json` and `global_packet.json`.
+- Keep packet sizing, byte proxies, and delegation-efficiency metrics in evaluation logs or `packet_metrics.json`, not in the core runtime packets.
+- Keep repo-specific file layout and doc ownership in the repo profile instead of hardcoding them into this core contract.
+- Keep the repo profile declarative. Scripts may consume its data, but the profile itself should not define executable behavior.
+
+## Notes
+
+- Optional local helpers remain non-authoritative even when collected.
+- __CONFIDENCE_LAYERING_NOTE__

--- a/core/templates/packet-workflow/delegation_playbook.tmpl
+++ b/core/templates/packet-workflow/delegation_playbook.tmpl
@@ -1,0 +1,86 @@
+# Delegation Playbook
+
+Read this file only when `orchestrator.json` sets `review_mode` to `targeted-delegation` or `broad-delegation`.
+
+## Worker Budget
+
+- `local-only`: no workers
+- `targeted-delegation`: 1-2 analysis workers
+- `broad-delegation`: 3-4 analysis workers
+- Optional QA worker: only when packet findings conflict or broad mutation needs a final coverage pass
+
+## Packet Order
+
+- Every worker reads `global_packet.json` first.
+- Prefer `batch-packet-*.json` when it exists and the orchestrator points to grouped work.
+- Read singleton focused packets only for work not covered by a batch.
+- Keep each worker on one small packet slice.
+
+## Shared Context
+
+`global_packet.json` keeps all workers aligned on:
+- workflow family
+- primary goal
+- authority order
+- stop conditions
+- review mode overrides
+- preferred worker families
+- packet worker map when configured
+- worker selection guidance
+- worker return contract
+- worker output shape
+- xHigh reread policy
+- candidate field bundles when decision-ready packets are enabled
+- worker footer fields when hierarchical output is enabled
+- reread reason values when decision-ready packets are enabled
+- domain overlay semantics when configured
+- optional local helper policy
+
+## Worker Return Modes
+
+- `generic`
+  - Use for simple workflows where the local orchestrator mainly needs a narrow outcome and evidence pointers.
+- `classification-oriented`
+  - Use for adjudication-heavy workflows where final adjudication stays local but workers must return proposal-grade candidate records.
+  - Prefer hierarchical `candidates[] + footer` output.
+
+## Worker Families
+
+- Preferred worker families for this scaffold:
+__WORKER_FAMILY_MARKDOWN__
+- Surfaced optional worker list below is the delegated-mode exposed list after stable dedupe and after subtracting explicitly mapped recommended worker types:
+__SURFACED_OPTIONAL_WORKERS_BULLETS__
+__PACKET_WORKER_MAP_MARKDOWN__
+__WORKER_SELECTION_GUIDANCE_MARKDOWN__
+
+## Analysis Worker Contract
+
+Prefer the named worker families above before falling back to an unspecified narrow `gpt-5.4-mini` worker.
+
+__ACTIVE_WORKER_CONTRACT_NOTE__
+
+Do not draft the final user-facing response in worker output. The main agent owns final synthesis.
+__CONFIDENCE_LAYERING_NOTE__
+
+## Mutation Guardrails
+
+- Keep final mutation local unless the generated skill explicitly narrows a safe worker-owned edit slice.
+- If the skill handles repo or remote mutations, do not ask a worker to own the whole mutation path from scratch.
+- If findings conflict, keep the result local and add QA instead of widening worker scope.
+
+## Prompt Skeleton
+
+Use a prompt shaped like this:
+
+```text
+Use $__SKILL_NAME__ to analyze packet-driven workflow inputs.
+
+Read only:
+- <global-packet>
+- <focused-packet-or-batch-packet>
+- <specific file slice if needed>
+
+__WORKER_PROMPT_RETURN_BLOCK__
+```
+
+Keep each worker narrow. Do not ask a worker to rediscover the whole repo state from scratch.

--- a/core/templates/packet-workflow/domain_contract.tmpl
+++ b/core/templates/packet-workflow/domain_contract.tmpl
@@ -1,0 +1,105 @@
+# __SKILL_TITLE__ Contract
+
+This file captures the default domain contract for the generated `__SKILL_NAME__` scaffold.
+
+The generic packet-workflow core lives in `references/__CORE_CONTRACT_FILE__`.
+Repo-specific bindings live in `__REPO_PROFILE_FILE__`.
+Repo profiles are data-only overlays. Keep executable behavior in scripts and contracts, not in profile JSON.
+
+## Builder Metadata
+
+- `workflow_family`: `__WORKFLOW_FAMILY__`
+- `archetype`: `__ARCHETYPE__`
+- `orchestrator_profile`: `__ORCHESTRATOR_PROFILE__`
+- `decision_ready_packets`: `__DECISION_READY_PACKETS__`
+- `worker_return_contract`: `__WORKER_RETURN_CONTRACT__`
+- `worker_output_shape`: `__WORKER_OUTPUT_SHAPE__`
+- trigger phrases:
+__TRIGGER_PHRASES_BULLETS__
+
+## Required Packet Outputs
+
+- `orchestrator.json`
+- `global_packet.json`
+__TASK_PACKET_BULLETS__
+__PROFILE_RUNTIME_ARTIFACTS__
+
+Review mode overrides inherited by default:
+__REVIEW_MODE_OVERRIDES_BULLETS__
+
+Evaluation-only sidecars:
+__PROFILE_EVALUATION_ARTIFACTS__
+
+## Default Repo Profile Scaffold
+
+- Active generated profile: `__REPO_PROFILE_FILE__`
+- Summary: __REPO_PROFILE_SUMMARY__
+- Profile boundary: keep only declarative bindings, globs, review-doc lists, booleans, and notes here.
+- Default bindings:
+__REPO_PROFILE_BINDINGS_MARKDOWN__
+- Default packet defaults:
+__REPO_PROFILE_PACKET_DEFAULTS_MARKDOWN__
+- Default lint rules:
+__REPO_PROFILE_LINT_RULES_MARKDOWN__
+- Profile notes:
+__REPO_PROFILE_NOTES_MARKDOWN__
+
+## Shared Packet Contract
+
+`global_packet.json` should keep:
+- workflow family
+- primary goal
+- authority order
+- stop conditions
+- review mode overrides
+- preferred worker families
+- packet worker map when configured
+- worker selection guidance
+- worker return contract
+- worker output shape
+- xHigh reread policy
+- candidate field bundles when decision-ready packets are enabled
+- worker footer fields when hierarchical worker output is enabled
+- reread reason values when decision-ready packets are enabled
+- domain overlay metadata when configured
+- optional local helper policy when present
+
+Runtime profile note:
+__PROFILE_RUNTIME_NOTE__
+
+Authority order:
+__AUTHORITY_ORDER_BULLETS__
+
+Stop conditions:
+__STOP_CONDITIONS_BULLETS__
+
+## Focused Packet Guidance
+
+__BATCH_PACKET_NOTE__
+- Focused packets should stay narrow enough for one local synthesis step or one `gpt-5.4-mini` worker.
+- Prefer packet names that describe one concern or grouped work item.
+
+__GENERIC_ADJUDICATION_SECTION__
+
+__WORKER_FAMILY_SECTION__
+
+__DOMAIN_OVERLAY_SECTION__
+
+## Plan Guidance
+
+__DOMAIN_CONTRACT_PLAN_NOTE__
+
+__VALIDATE_PLAN_CONTRACT__
+__APPLY_PLAN_CONTRACT__
+
+## Runtime vs Evaluation Metadata
+
+- Keep runtime contract metadata in `orchestrator.json` and `global_packet.json` only when the orchestrator or local drafter needs it to operate safely.
+- Keep packet sizing, byte proxies, delegation-efficiency estimates, and other regression metrics out of runtime packets by default.
+- When `orchestrator_profile=packet-heavy-orchestrator`, write packet-efficiency metrics to `packet_metrics.json` and merge them into evaluation logs instead of expanding `orchestrator.json`.
+
+## Notes
+
+- The generated scripts are placeholders and must be filled with domain-specific logic.
+- Optional local helpers remain non-authoritative even when included in collected context.
+- __CONFIDENCE_LAYERING_NOTE__

--- a/core/templates/packet-workflow/domain_evaluation_contract.tmpl
+++ b/core/templates/packet-workflow/domain_evaluation_contract.tmpl
@@ -1,0 +1,19 @@
+# __SKILL_TITLE__ Evaluation Contract
+
+Use the shared envelope in `references/evaluation-log-contract.md` and keep workflow-specific metrics under `skill_specific.data`.
+
+Recommended domain fields for this scaffold:
+
+- `primary_outcomes`
+- `domain_quality_findings`
+- `domain_safety_findings`
+- `apply_artifacts`
+__PROFILE_EVALUATION_ARTIFACTS__
+
+Expected behavior:
+
+- Add only domain metrics that cannot live cleanly in the shared envelope.
+- Prefer observed counts and booleans over free-form summaries.
+- If the workflow later gains deterministic validators or apply scripts, surface their domain-specific boundary signals here rather than expanding the common schema.
+- Keep the contract aligned with `__ARCHETYPE__` expectations and the packets defined for `__DOMAIN_SLUG__`.
+- Keep runtime contract metadata out of evaluation fields; packet-efficiency metrics belong here only when they are regression or smoke signals rather than live routing inputs.

--- a/core/templates/packet-workflow/evaluation_log_contract.tmpl
+++ b/core/templates/packet-workflow/evaluation_log_contract.tmpl
@@ -1,0 +1,60 @@
+# Evaluation Log Contract
+
+Use this file for the shared evaluation-log envelope in `__SKILL_NAME__`.
+
+## Purpose
+
+Track three outcomes consistently:
+- efficiency
+- quality
+- safety
+
+Default log path:
+
+`~/.codex/tmp/evaluation_logs/__SKILL_NAME__/<run-id>.json`
+
+The default path must stay outside the repo. An explicit override path is allowed.
+
+## Common Envelope
+
+Use this top-level shape:
+- `schema_version`
+- `run_id`
+- `timestamp_utc`
+- `skill`
+- `repo`
+- `request`
+- `input_size`
+- `orchestration`
+- `baseline`
+- `measurement`
+- `tokens`
+- `latency`
+- `quality`
+- `safety`
+- `outputs`
+- `scoring`
+- `notes`
+- `skill_specific`
+
+## Common Rules
+
+- Keep truly common fields in the shared envelope only.
+- Put workflow-specific counters or mutation details in `skill_specific.data`.
+- Keep runtime contract metadata out of the evaluation log unless the workflow explicitly mirrors it for regression analysis.
+- Default `baseline.method` to `none`.
+- Leave savings fields null when no baseline exists.
+- Label estimated or unavailable data explicitly in `measurement`.
+- Renormalize scoring weights when a signal is missing.
+
+## Helper Workflow
+
+Use `scripts/write_evaluation_log.py` in three modes:
+- `init`
+  - `--context <json> --orchestrator <json> [--lint <json>] [--output <json>]`
+- `phase`
+  - `--log <json> --phase build|lint|validate|apply --result <json> [--duration-seconds <float>]`
+- `finalize`
+  - `--log <json> --final <json>`
+
+When a packet-heavy orchestrator profile emits `packet_metrics.json`, merge those counters through the build-phase result instead of copying them into runtime packets.

--- a/core/templates/packet-workflow/lint.py.tmpl
+++ b/core/templates/packet-workflow/lint.py.tmpl
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run deterministic lint checks for __SKILL_NAME__."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+EXPECTS_LOCAL_HELPER = __EXPECTS_LOCAL_HELPER__
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--output", required=True, help="Output lint JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    findings = {
+        "errors": [],
+        "warnings": [],
+        "infos": [
+            "TODO: replace skeleton lint logic with domain-specific deterministic checks."
+        ],
+        "override_signals": {
+            "high_churn": False,
+            "multi_group_core_files": False,
+            "generated_not_majority": False,
+        },
+        "can_proceed": True,
+    }
+
+    if not context.get("authority_order"):
+        findings["warnings"].append("Authority order is missing from collected context.")
+
+__LINT_WARNING_BLOCK__
+    write_json(Path(args.output).resolve(), findings)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/templates/packet-workflow/openai_yaml.tmpl
+++ b/core/templates/packet-workflow/openai_yaml.tmpl
@@ -1,0 +1,4 @@
+interface:
+  display_name: "__SKILL_TITLE__"
+  short_description: "__SHORT_DESCRIPTION__"
+  default_prompt: "__DEFAULT_PROMPT__"

--- a/core/templates/packet-workflow/repo_profile_json.tmpl
+++ b/core/templates/packet-workflow/repo_profile_json.tmpl
@@ -1,0 +1,1 @@
+__REPO_PROFILE_JSON__

--- a/core/templates/packet-workflow/skill_md.tmpl
+++ b/core/templates/packet-workflow/skill_md.tmpl
@@ -30,6 +30,7 @@ __REPO_PROFILE_NOTE__
 - Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/__SKILL_NAME__/<run-id>/` and keep `.codex/tmp/` gitignored.
 - Set `<packet-dir>` to `<runtime-root>/packets`.
 - Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/__SKILL_NAME__/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/__SKILL_NAME__/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+- Keep any repo-local temporary, helper, scratch, or ad hoc operator-input file under `<repo-root>/.codex/tmp/` rather than the repo root or another tracked directory.
 
 ## Workflow
 
@@ -85,7 +86,7 @@ __PROFILE_EVALUATION_ARTIFACTS__
 - Use `phase` updates for deterministic lint, validate, and apply results when those outputs exist.
 - Use `finalize` after the run to merge token usage, actual worker mix, final usability, outputs, and notes.
 - Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
-- Keep packet artifacts and other helper temp files under the fixed gitignored `.codex/tmp/packet-workflow/` root.
+- Keep any repo-local temporary, helper, scratch, or ad hoc input file under the fixed gitignored `.codex/tmp/` tree; packet artifacts stay under `.codex/tmp/packet-workflow/`.
 - Read `references/evaluation-log-contract.md` for the shared envelope and `references/__DOMAIN_SLUG__-evaluation-contract.md` for workflow-specific fields.
 
 ## Scripts

--- a/core/templates/packet-workflow/skill_md.tmpl
+++ b/core/templates/packet-workflow/skill_md.tmpl
@@ -1,0 +1,109 @@
+---
+name: __SKILL_NAME__
+description: __DESCRIPTION__
+---
+
+# __SKILL_TITLE__
+
+Use this skill to __PRIMARY_GOAL__.
+
+This is a packet-driven repo workflow skill:
+- keep orchestration, final synthesis, and mutation local
+- use deterministic scripts to collect context before reading raw artifacts broadly
+- use `gpt-5.4-mini` workers only for narrow packet analysis
+- stop on low confidence, stale snapshots, or ambiguous ownership instead of guessing
+- keep generic packet rules in `references/__CORE_CONTRACT_FILE__` and repo-specific layout assumptions in `__REPO_PROFILE_FILE__`
+- keep repo profiles data-only: paths, globs, doc lists, booleans, and notes only; executable logic stays in scripts and contracts
+- prefer a project-local override at `.codex/project/profiles/__SKILL_NAME__/profile.json` when the repo carries skill-specific bindings or review docs
+__PROFILE_RUNTIME_NOTE__
+__REPO_PROFILE_NOTE__
+
+## Execution Roots
+
+- Resolve `<skill-dir>` as the directory containing this `SKILL.md`.
+- Resolve `<python-bin>` as a concrete interpreter path before running any helper script.
+- On Windows, prefer a non-`WindowsApps` interpreter from `Get-Command python -All | Where-Object { $_.Source -notlike '*Microsoft\WindowsApps*' } | Select-Object -ExpandProperty Source -First 1`.
+- If that probe returns nothing, scan `%LOCALAPPDATA%\Python\pythoncore-*\python.exe` and `%LOCALAPPDATA%\Programs\Python\Python*\python.exe`, then reuse the first concrete path you find.
+- If you already resolved a concrete interpreter path outside the sandbox, reuse that exact path inside the sandbox instead of calling `py` or bare `python`.
+- Run helper scripts as `<python-bin> -B <skill-dir>/scripts/...`.
+- Stop and report the blocker if you cannot resolve a concrete interpreter path.
+- Resolve `<runtime-root>` to `<repo-root>/.codex/tmp/packet-workflow/__SKILL_NAME__/<run-id>/` and keep `.codex/tmp/` gitignored.
+- Set `<packet-dir>` to `<runtime-root>/packets`.
+- Set `<eval-log-json>` to `~/.codex/tmp/evaluation_logs/__SKILL_NAME__/<run-id>.json` by default. If the sandbox blocks that path, use `<repo-root>/.codex/tmp/evaluation_logs/__SKILL_NAME__/<run-id>.json` as an explicit override and keep `.codex/tmp/` gitignored.
+
+## Workflow
+
+1. Collect structured context.
+- Review `references/__CORE_CONTRACT_FILE__` before changing shared packet semantics.
+- Review the active repo profile before trusting repo-specific path bindings, review-doc lists, or deterministic lint toggles.
+- Run `<python-bin> -B <skill-dir>/scripts/collect___DOMAIN_SLUG___context.py --repo-root <repo-root> --output <context-json>`.
+__LINT_STEP__
+- Run `<python-bin> -B <skill-dir>/scripts/build___DOMAIN_SLUG___packets.py --context <context-json>__BUILD_LINT_ARG__ --output-dir <packet-dir>`.
+- __BUILD_RESULT_NOTE__
+- Read `<packet-dir>/orchestrator.json` first.
+- Keep `<packet-dir>/global_packet.json` in view before reading any focused packet.
+__COMMON_PATH_NOTE__
+
+2. Follow the review mode.
+- `local-only`: keep the work local.
+- `targeted-delegation`: use 1-2 `gpt-5.4-mini` workers on narrow packets.
+- `broad-delegation`: use 3-4 `gpt-5.4-mini` workers and add QA only when findings conflict.
+- Escalate to the next larger mode when churn is high, core runtime/config/process files span groups, or generated files are not the majority.
+
+3. Keep packet analysis narrow.
+- Treat `references/__CORE_CONTRACT_FILE__` as the generic workflow contract and the active repo profile as the repo-specific overlay.
+- Read `references/__DOMAIN_CONTRACT_FILE__` before drafting domain outputs.
+- Read `references/delegation-playbook.md` only when `review_mode` is not `local-only`.
+- Worker return contract for this skill: `__WORKER_RETURN_CONTRACT__`.
+- Worker output shape for this skill: `__WORKER_OUTPUT_SHAPE__`.
+- Decision-ready packets enabled: `__DECISION_READY_PACKETS__`.
+- XHigh reread policy: __XHIGH_REREAD_POLICY__
+__WORKER_OUTPUT_GUIDANCE__
+- Preferred worker families for this skill:
+__WORKER_FAMILY_MARKDOWN__
+- Use `worker_selection_guidance` as explanatory family guidance only. When configured, `packet_worker_map` owns concrete packet routing.
+- Focus packet set for this skill:
+__TASK_PACKET_BULLETS__
+__PROFILE_RUNTIME_ARTIFACTS__
+__BATCH_PACKET_NOTE__
+
+4. Respect authority and stop conditions.
+- Authority order for this skill:
+__AUTHORITY_ORDER_BULLETS__
+__OPTIONAL_LOCAL_HELPER_NOTE__
+- Packet-first adjudication guidance:
+__DECISION_READY_SKILL_GUIDANCE__
+- Stop and report instead of mutating when:
+__STOP_CONDITIONS_BULLETS__
+
+__WORKFLOW_TAIL__
+
+## Evaluation
+
+- Use `<python-bin> -B <skill-dir>/scripts/write_evaluation_log.py init --context <context-json> --orchestrator <packet-dir>/orchestrator.json --output <eval-log-json>` after packet generation.
+__PROFILE_EVALUATION_ARTIFACTS__
+- Use `phase` updates for deterministic lint, validate, and apply results when those outputs exist.
+- Use `finalize` after the run to merge token usage, actual worker mix, final usability, outputs, and notes.
+- Keep the evaluation log at the contract-default outside-repo path unless you intentionally need the gitignored `.codex/tmp/` fallback.
+- Keep packet artifacts and other helper temp files under the fixed gitignored `.codex/tmp/packet-workflow/` root.
+- Read `references/evaluation-log-contract.md` for the shared envelope and `references/__DOMAIN_SLUG__-evaluation-contract.md` for workflow-specific fields.
+
+## Scripts
+
+- `scripts/collect___DOMAIN_SLUG___context.py`
+  - Collect the structured inputs and repo artifacts for this workflow, including the active repo profile.
+__LINT_SCRIPT_SECTION__
+- `scripts/build___DOMAIN_SLUG___packets.py`
+  - Build `orchestrator.json`, `global_packet.json`, and focused packets for local synthesis and optional mini-worker analysis.
+- `scripts/write_evaluation_log.py`
+  - Emit and update the shared evaluation log for efficiency, quality, and safety tracking.
+__VALIDATE_SCRIPT_SECTION__
+__APPLY_SCRIPT_SECTION__
+
+## Output
+
+- Tell the user which packets drove the decision.
+- Tell the user whether the run stayed local or used mini workers.
+- Tell the user which repo profile was active when repo-specific bindings mattered.
+- Tell the user whether final plan confidence was recomputed locally or a reread exception blocked that conclusion.
+__MUTATION_OUTPUT_NOTE__

--- a/core/templates/packet-workflow/skill_wrapper_md.tmpl
+++ b/core/templates/packet-workflow/skill_wrapper_md.tmpl
@@ -1,0 +1,20 @@
+---
+name: __SKILL_NAME__
+description: __DESCRIPTION__
+---
+
+# __SKILL_TITLE__
+
+Thin entrypoint for the foundry retained `__SKILL_NAME__` kernel.
+
+This subtree is intentionally minimal:
+- keep only `SKILL.md` and `agents/openai.yaml` here
+- keep authoritative retained workflow assets in `__RETAINED_SKILL_DIR__/`
+- do not reintroduce local copies of builder specs, profiles, references, scripts, tests, or migration worksheets under this wrapper
+
+Use this skill by reading and following the retained kernel instructions at `__RETAINED_SKILL_MD__`.
+
+When working on this skill:
+- treat `__RETAINED_SKILL_DIR__/` as the source of truth
+- apply reusable fixes in the retained kernel, not in this wrapper
+- keep consumer-local overrides outside the vendor subtree

--- a/core/templates/packet-workflow/validate.py.tmpl
+++ b/core/templates/packet-workflow/validate.py.tmpl
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Validate a planned action file against collected context for __SKILL_NAME__."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+PLAN_FIELD_POLICY = {
+    "required": [
+        "skill_name",
+        "context_id",
+        "selected_packets",
+        "actions",
+        "stop_reasons",
+    ],
+    "allowed": [
+        "skill_name",
+        "context_id",
+        "selected_packets",
+        "actions",
+        "stop_reasons",
+        "overall_confidence",
+        "review_mode",
+        "notes",
+        "draft_basis",
+    ],
+    "ignored": ["metadata"],
+}
+VALIDATION_ERROR_CODES = {
+    "missing_required_plan_fields": "missing_required_plan_fields",
+    "skill_name_mismatch": "skill_name_mismatch",
+    "context_id_mismatch": "context_id_mismatch",
+    "selected_packets_duplicate": "selected_packets_duplicate",
+    "selected_packets_invalid": "selected_packets_invalid",
+    "actions_invalid": "actions_invalid",
+}
+VALIDATION_WARNING_CODES = {
+    "unknown_plan_fields_ignored": "unknown_plan_fields_ignored",
+    "ignored_plan_fields_removed": "ignored_plan_fields_removed",
+    "overall_confidence_low": "overall_confidence_low",
+}
+CORE_STOP_CATEGORIES = [
+    "stale_context",
+    "ambiguous_routing",
+    "missing_required_evidence",
+    "validator_mismatch",
+    "missing_auth",
+    "unresolved_stop_reason",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Collected context JSON.")
+    parser.add_argument("--plan", required=True, help="Planned action JSON.")
+    parser.add_argument("--output", required=True, help="Validation output JSON.")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def issue(code: str, message: str, **extra: object) -> dict:
+    payload = {"code": code, "message": message}
+    payload.update(extra)
+    return payload
+
+
+def fingerprint_plan(plan: dict) -> str:
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def normalize_plan(plan: dict) -> tuple[dict, list[dict], list[dict]]:
+    errors: list[dict] = []
+    warnings: list[dict] = []
+    normalized: dict = {}
+
+    allowed = set(PLAN_FIELD_POLICY["allowed"])
+    required = set(PLAN_FIELD_POLICY["required"])
+    ignored = set(PLAN_FIELD_POLICY["ignored"])
+    plan_keys = set(plan)
+
+    missing = sorted(required - plan_keys)
+    if missing:
+        errors.append(
+            issue(
+                VALIDATION_ERROR_CODES["missing_required_plan_fields"],
+                "Plan is missing required fields.",
+                fields=missing,
+            )
+        )
+
+    ignored_fields = sorted(plan_keys & ignored)
+    if ignored_fields:
+        warnings.append(
+            issue(
+                VALIDATION_WARNING_CODES["ignored_plan_fields_removed"],
+                "Ignored plan fields were removed from the normalized plan.",
+                fields=ignored_fields,
+            )
+        )
+
+    unknown_fields = sorted(plan_keys - allowed - ignored)
+    if unknown_fields:
+        warnings.append(
+            issue(
+                VALIDATION_WARNING_CODES["unknown_plan_fields_ignored"],
+                "Unknown plan fields were ignored during normalization.",
+                fields=unknown_fields,
+            )
+        )
+
+    for key in PLAN_FIELD_POLICY["allowed"]:
+        if key not in plan:
+            continue
+        value = plan[key]
+        if key == "selected_packets":
+            if not isinstance(value, list) or any(
+                not isinstance(item, str) or not item.strip() for item in value
+            ):
+                errors.append(
+                    issue(
+                        VALIDATION_ERROR_CODES["selected_packets_invalid"],
+                        "selected_packets must be an array of non-empty strings.",
+                    )
+                )
+                normalized[key] = []
+            else:
+                normalized[key] = [item.strip() for item in value]
+                if len(normalized[key]) != len(set(normalized[key])):
+                    errors.append(
+                        issue(
+                            VALIDATION_ERROR_CODES["selected_packets_duplicate"],
+                            "selected_packets contains duplicate values.",
+                        )
+                    )
+        elif key == "actions":
+            if not isinstance(value, list):
+                errors.append(
+                    issue(
+                        VALIDATION_ERROR_CODES["actions_invalid"],
+                        "actions must be an array.",
+                    )
+                )
+                normalized[key] = []
+            else:
+                normalized[key] = value
+        elif key == "stop_reasons":
+            if not isinstance(value, list):
+                normalized[key] = []
+            else:
+                normalized[key] = [str(item) for item in value if str(item).strip()]
+        else:
+            normalized[key] = value
+
+    return normalized, errors, warnings
+
+
+def main() -> int:
+    args = parse_args()
+    context = load_json(Path(args.context).resolve())
+    plan = load_json(Path(args.plan).resolve())
+
+    normalized_plan, errors, warnings = normalize_plan(plan)
+    stop_reasons: list[str] = []
+
+    context_skill_name = context.get("skill_name")
+    normalized_skill_name = normalized_plan.get("skill_name")
+    if normalized_skill_name not in (None, context_skill_name):
+        errors.append(
+            issue(
+                VALIDATION_ERROR_CODES["skill_name_mismatch"],
+                "plan.skill_name does not match context.skill_name",
+            )
+        )
+        stop_reasons.append("validator_mismatch")
+
+    context_id = context.get("context_id")
+    plan_context_id = normalized_plan.get("context_id")
+    if context_id and plan_context_id and plan_context_id != context_id:
+        errors.append(
+            issue(
+                VALIDATION_ERROR_CODES["context_id_mismatch"],
+                "plan.context_id does not match context.context_id",
+            )
+        )
+        stop_reasons.append("stale_context")
+
+    confidence = str(normalized_plan.get("overall_confidence") or "").strip().lower()
+    if confidence in {"", "low"}:
+        warnings.append(
+            issue(
+                VALIDATION_WARNING_CODES["overall_confidence_low"],
+                "overall_confidence is missing or low",
+            )
+        )
+        stop_reasons.append("missing_required_evidence")
+
+    valid = not errors
+    blocking_stop_categories = {
+        "stale_context",
+        "missing_required_evidence",
+        "validator_mismatch",
+        "unresolved_stop_reason",
+    }
+    can_apply = valid and not any(
+        reason in blocking_stop_categories for reason in stop_reasons
+    )
+    normalized_fingerprint = fingerprint_plan(normalized_plan)
+
+    payload = {
+        "valid": valid,
+        "can_apply": can_apply,
+        "errors": errors,
+        "warnings": warnings,
+        "stop_reasons": sorted(set(stop_reasons)),
+        "validation_commands": [
+            "Replace skeleton field policy with domain-specific constraints.",
+            "Replace placeholder stop-category coverage with domain-specific gate checks.",
+        ],
+        "normalized_plan": normalized_plan,
+        "normalized_plan_fingerprint": normalized_fingerprint,
+        "apply_gate_status": {
+            "status": "pass" if can_apply else "fail",
+            "applicable_stop_categories": [
+                "stale_context",
+                "missing_required_evidence",
+                "validator_mismatch",
+                "unresolved_stop_reason",
+            ],
+            "covered_stop_categories": sorted(set(stop_reasons)),
+            "uncovered_stop_categories": [
+                category
+                for category in ["ambiguous_routing", "missing_auth", "unresolved_stop_reason"]
+                if category not in stop_reasons
+            ],
+            "not_applicable_stop_categories": [
+                category
+                for category in CORE_STOP_CATEGORIES
+                if category not in {
+                    "stale_context",
+                    "missing_required_evidence",
+                    "validator_mismatch",
+                    "unresolved_stop_reason",
+                }
+            ],
+        },
+        "field_policy": PLAN_FIELD_POLICY,
+    }
+    write_json(Path(args.output).resolve(), payload)
+    return 0 if can_apply else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/templates/packet-workflow/write_evaluation_log.py.tmpl
+++ b/core/templates/packet-workflow/write_evaluation_log.py.tmpl
@@ -1,0 +1,1010 @@
+#!/usr/bin/env python3
+"""Emit and update local evaluation logs for packet-driven skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0"
+SKILL_FAMILY = "repo-packet-workflow"
+SKILL_VERSION = "unversioned"
+DEFAULT_FORMULA_VERSION = "1.0"
+DEFAULT_BASELINE_METHOD = "none"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def isoformat_utc(value: datetime | None = None) -> str:
+    return (value or now_utc()).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def slugify(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "unknown"
+
+
+def safe_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip()
+    if re.fullmatch(r"-?\d+", text):
+        return int(text)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    text = str(value).strip()
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes"}:
+        return True
+    if text in {"false", "0", "no"}:
+        return False
+    return None
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    return [str(value)]
+
+
+def deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    for key, value in incoming.items():
+        if key == "notes" and isinstance(value, list):
+            base.setdefault("notes", [])
+            base["notes"].extend(str(item) for item in value if str(item).strip())
+            continue
+        if key == "skill_specific" and isinstance(value, dict):
+            target = base.setdefault("skill_specific", {"schema_name": "", "schema_version": "1.0", "data": {}})
+            if "schema_name" in value:
+                target["schema_name"] = value["schema_name"]
+            if "schema_version" in value:
+                target["schema_version"] = value["schema_version"]
+            data_value = value.get("data")
+            if isinstance(data_value, dict):
+                target.setdefault("data", {})
+                deep_merge(target["data"], data_value)
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def parse_frontmatter(skill_root: Path) -> dict[str, str]:
+    skill_md = skill_root / "SKILL.md"
+    if not skill_md.is_file():
+        return {"name": skill_root.name, "description": ""}
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return {"name": skill_root.name, "description": ""}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {"name": skill_root.name, "description": ""}
+    metadata: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        metadata[key.strip()] = value.strip()
+    metadata.setdefault("name", skill_root.name)
+    metadata.setdefault("description", "")
+    return metadata
+
+
+def infer_archetype(skill_root: Path) -> str:
+    script_dir = skill_root / "scripts"
+    names = {path.name for path in script_dir.glob("*.py")}
+    has_validate = any(name.startswith("validate_") for name in names)
+    has_apply = any(name.startswith("apply_") for name in names) or "create_release_issue.py" in names
+    if has_validate and has_apply:
+        return "plan-validate-apply"
+    if has_apply:
+        return "audit-and-apply"
+    return "audit-only"
+
+
+def skill_identity(script_path: Path) -> dict[str, str]:
+    skill_root = script_path.resolve().parents[1]
+    frontmatter = parse_frontmatter(skill_root)
+    return {
+        "name": frontmatter.get("name", skill_root.name),
+        "family": SKILL_FAMILY,
+        "archetype": infer_archetype(skill_root),
+        "skill_version": SKILL_VERSION,
+        "skill_root": str(skill_root),
+    }
+
+
+def find_repo_name(context: dict[str, Any]) -> str | None:
+    for key in ("repo_slug", "repo_name"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    url = str(pr.get("url") or "")
+    match = re.search(r"github\.com/(?P<slug>[^/]+/[^/]+)/pull/\d+", url)
+    return match.group("slug") if match else None
+
+
+def find_branch(context: dict[str, Any]) -> str | None:
+    branch = str(context.get("branch") or "").strip()
+    if branch:
+        return branch
+    branch_state = context.get("branch_state") or {}
+    branch = str(branch_state.get("branch") or "").strip()
+    if branch:
+        return branch
+    pr = context.get("pr", {})
+    return str(pr.get("headRefName") or "").strip() or None
+
+
+def find_head_sha(context: dict[str, Any]) -> str | None:
+    for key in ("head_sha", "head_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("headRefOid") or "").strip() or None
+
+
+def find_base_ref(context: dict[str, Any]) -> str | None:
+    for key in ("base_ref", "base_tag", "base_commit"):
+        value = str(context.get(key) or "").strip()
+        if value:
+            return value
+    pr = context.get("pr", {})
+    return str(pr.get("baseRefName") or "").strip() or None
+
+
+def packet_files(orchestrator: dict[str, Any]) -> list[str]:
+    return [str(item) for item in orchestrator.get("packet_files", []) if str(item).strip()]
+
+
+def item_packet_count(orchestrator: dict[str, Any]) -> int:
+    shared = {"global_packet.json", "rules_packet.json", "orchestrator.json"}
+    count = 0
+    for name in packet_files(orchestrator):
+        lowered = name.lower()
+        if lowered in shared or "batch-packet" in lowered or lowered.startswith("batch-"):
+            continue
+        count += 1
+    return count
+
+
+def batch_packet_count(orchestrator: dict[str, Any]) -> int:
+    return sum(
+        1
+        for name in packet_files(orchestrator)
+        if "batch-packet" in name.lower() or name.lower().startswith("batch-")
+    )
+
+
+def active_area_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    for key in ("active_areas", "active_groups"):
+        value = orchestrator.get(key)
+        if isinstance(value, list):
+            return len(value)
+    counts = context.get("counts", {})
+    detected = safe_int(counts.get("active_areas"))
+    return detected or 0
+
+
+def changed_file_count(context: dict[str, Any], orchestrator: dict[str, Any]) -> int:
+    if isinstance(context.get("changed_files"), list):
+        return len(context["changed_files"])
+    if isinstance(context.get("files"), list):
+        return len(context["files"])
+    counts = context.get("counts", {})
+    if safe_int(counts.get("changed_files")) is not None:
+        return int(counts["changed_files"])
+    diff_summary = orchestrator.get("diff_summary", {})
+    return safe_int(diff_summary.get("changed_file_count")) or 0
+
+
+def untracked_file_count(context: dict[str, Any]) -> int:
+    if isinstance(context.get("files"), list):
+        return sum(1 for entry in context["files"] if str(entry.get("change_kind") or "") == "untracked")
+    return safe_int(context.get("untracked_files")) or 0
+
+
+def diff_churn(orchestrator: dict[str, Any], context: dict[str, Any]) -> int:
+    diff_summary = orchestrator.get("diff_summary", {})
+    totals = diff_summary.get("diff_stat_totals") or {}
+    if safe_int(totals.get("churn")) is not None:
+        return int(totals["churn"])
+    totals = context.get("diff_stat_totals") or {}
+    return safe_int(totals.get("churn")) or 0
+
+
+def normalize_override_signals(orchestrator: dict[str, Any]) -> list[str]:
+    signals = []
+    for item in orchestrator.get("review_overrides", []):
+        if isinstance(item, dict):
+            reason = str(item.get("reason") or "").strip()
+            if reason:
+                signals.append(reason)
+        else:
+            text = str(item).strip()
+            if text:
+                signals.append(text)
+    return signals
+
+
+def worker_roles(orchestrator: dict[str, Any]) -> list[str]:
+    roles = []
+    for item in orchestrator.get("recommended_workers", []):
+        if not isinstance(item, dict):
+            continue
+        role = str(item.get("agent_type") or item.get("role") or item.get("name") or "").strip()
+        if role:
+            roles.append(role)
+    return roles
+
+
+def count_messages(findings: dict[str, Any], *keys: str) -> list[str]:
+    messages: list[str] = []
+    for key in keys:
+        value = findings.get(key)
+        if isinstance(value, list):
+            messages.extend(str(item) for item in value if str(item).strip())
+    return messages
+
+
+def summarize_findings(lint_report: dict[str, Any] | None) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings", "info")
+    unsupported = [message for message in messages if "unsupported claim" in message.lower()]
+    evidence = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("evidence", "tested", "testing", "verification", "command"))
+    ]
+    template = [
+        message
+        for message in messages
+        if any(token in message.lower() for token in ("template", "section", "placeholder", "blank bullet", "body contains"))
+    ]
+    return {
+        "messages": messages,
+        "unsupported_claims_found": len(unsupported),
+        "evidence_gaps_found": len(evidence),
+        "template_violations_found": len(template),
+    }
+
+
+def skill_specific_data(
+    skill_name: str,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    findings = (lint_report or {}).get("findings", {})
+    messages = count_messages(findings, "errors", "warnings")
+    if skill_name == "gh-fix-pr-writeup":
+        expected = list(context.get("expected_template_sections") or [])
+        actual = list(context.get("current_body_sections") or [])
+        return {
+            "title_changed": None,
+            "body_changed": None,
+            "template_sections_required": len(expected),
+            "template_sections_filled": len([section for section in expected if section in actual]),
+            "unsupported_claim_categories": sorted({message for message in messages if "unsupported claim" in message.lower()}),
+            "evidence_gap_categories": sorted({message for message in messages if "testing" in message.lower() or "evidence" in message.lower()}),
+        }
+    if skill_name == "gh-address-review-threads":
+        counts = orchestrator.get("thread_counts", {})
+        return {
+            "threads_seen": safe_int(counts.get("unresolved")) or 0,
+            "threads_accepted": None,
+            "threads_rejected": None,
+            "threads_deferred": None,
+            "threads_defer_outdated": None,
+            "threads_resolved": None,
+            "outdated_threads_seen": safe_int(counts.get("unresolved_outdated")) or 0,
+            "marker_conflicts": len(orchestrator.get("marker_conflicts", [])),
+        }
+    if skill_name == "reword-recent-commits":
+        commits = context.get("commits", [])
+        return {
+            "commits_in_scope": len(commits) if isinstance(commits, list) else safe_int(context.get("count")) or 0,
+            "commits_rewritten": None,
+            "rewrite_strategy": None,
+            "force_push_needed": None,
+        }
+    if skill_name == "prepare-release-copy":
+        checks = (lint_report or {}).get("checks", {})
+        return {
+            "base_tag": context.get("base_tag"),
+            "evidence_gate_status": "complete" if checks.get("evidence_complete") else "incomplete",
+            "publish_fields_changed": [],
+            "readme_sections_changed": [],
+            "release_issue_created": None,
+        }
+    if skill_name == "git-split-and-commit":
+        return {
+            "commit_buckets_planned": None,
+            "commit_buckets_applied": None,
+            "hunk_splits_attempted": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "hunk_splits_blocked": None,
+            "targeted_checks_failed": 0,
+        }
+    if skill_name == "packet-workflow-skill-builder":
+        spec = context.get("spec") or {}
+        generated = context.get("generated_files") or []
+        return {
+            "requested_archetype": spec.get("archetype"),
+            "requested_domain_slug": spec.get("domain_slug"),
+            "generated_file_count": len(generated) if isinstance(generated, list) else 0,
+            "includes_optional_local_helper": bool(spec.get("optional_local_helper")),
+            "template_validation_passed": None,
+        }
+    return {"custom_metrics": {}}
+
+
+def derive_run_id(skill_name: str, context: dict[str, Any]) -> tuple[str, str]:
+    timestamp = isoformat_utc()
+    ref = find_head_sha(context) or context.get("context_id") or context.get("run_id") or "nohead"
+    return f"{timestamp}__{skill_name}__{slugify(str(ref))[:16]}", timestamp
+
+
+def safe_filename(value: str) -> str:
+    sanitized = re.sub(r'[<>:"/\\\\|?*]+', "-", value).strip(" .")
+    return sanitized or "evaluation-log"
+
+
+def default_output_path(skill_name: str, run_id: str) -> Path:
+    return Path.home() / ".codex" / "tmp" / "evaluation_logs" / skill_name / f"{safe_filename(run_id)}.json"
+
+
+def build_base_log(
+    script_path: Path,
+    context: dict[str, Any],
+    orchestrator: dict[str, Any],
+    lint_report: dict[str, Any] | None,
+) -> dict[str, Any]:
+    identity = skill_identity(script_path)
+    skill_name = identity["name"]
+    run_id, timestamp = derive_run_id(skill_name, context)
+    lint_summary = summarize_findings(lint_report)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "timestamp_utc": timestamp,
+        "skill": {
+            "name": skill_name,
+            "family": identity["family"],
+            "archetype": identity["archetype"],
+            "skill_version": identity["skill_version"],
+        },
+        "repo": {
+            "repo_name": find_repo_name(context),
+            "repo_root": context.get("repo_root"),
+            "branch": find_branch(context),
+            "head_sha": find_head_sha(context),
+            "base_ref": find_base_ref(context),
+        },
+        "request": {
+            "mode_requested": "default",
+            "mutation_allowed": identity["archetype"] != "audit-only",
+            "dry_run_requested": False,
+            "user_intent_summary": None,
+            "input_scope": "all-default",
+        },
+        "input_size": {
+            "changed_files": changed_file_count(context, orchestrator),
+            "untracked_files": untracked_file_count(context),
+            "candidate_batches": safe_int((orchestrator.get("analysis_targets") or {}).get("batch_count")) or 0,
+            "split_file_packets": sum(1 for name in packet_files(orchestrator) if "split-file" in name.lower()),
+            "active_areas": active_area_count(context, orchestrator),
+            "diff_churn_lines": diff_churn(orchestrator, context),
+        },
+        "orchestration": {
+            "review_mode": orchestrator.get("review_mode"),
+            "override_signals": normalize_override_signals(orchestrator),
+            "worker_count": safe_int(orchestrator.get("recommended_worker_count")) or len(worker_roles(orchestrator)),
+            "worker_roles": worker_roles(orchestrator),
+            "batch_packets_used": batch_packet_count(orchestrator),
+            "item_packets_used": item_packet_count(orchestrator),
+            "global_packet_used": "global_packet.json" in packet_files(orchestrator) or orchestrator.get("shared_packet") == "global_packet.json",
+            "rules_packet_used": "rules_packet.json" in packet_files(orchestrator),
+            "raw_reread_required": False,
+            "raw_reread_reason": None,
+            "low_confidence_stop": False,
+            "stop_reasons": [],
+        },
+        "baseline": {
+            "method": DEFAULT_BASELINE_METHOD,
+            "confidence": "unavailable",
+            "paired_run_available": False,
+            "baseline_skill_version": None,
+            "estimated_local_only_tokens": None,
+            "estimated_token_savings": None,
+            "estimated_delegation_savings": None,
+        },
+        "measurement": {
+            "token_source": "unavailable",
+            "latency_source": "unavailable",
+            "quality_source": "unavailable",
+        },
+        "tokens": {
+            "main_model": {
+                "model": None,
+                "reasoning_effort": None,
+                "input_tokens": None,
+                "output_tokens": None,
+                "reasoning_tokens": None,
+            },
+            "subagents": [],
+            "total_input_tokens": None,
+            "total_output_tokens": None,
+            "total_reasoning_tokens": None,
+            "main_model_token_share": None,
+        },
+        "latency": {
+            "collector_seconds": None,
+            "linter_seconds": None,
+            "packet_builder_seconds": None,
+            "model_seconds": None,
+            "validator_seconds": None,
+            "apply_seconds": None,
+            "total_seconds": None,
+        },
+        "quality": {
+            "result_status": "initialized",
+            "first_pass_usable": None,
+            "human_post_edit_required": None,
+            "human_post_edit_severity": "unknown",
+            "rerun_count": 0,
+            "unsupported_claims_found": lint_summary["unsupported_claims_found"],
+            "evidence_gaps_found": lint_summary["evidence_gaps_found"],
+            "template_violations_found": lint_summary["template_violations_found"],
+            "final_output_changed_after_review": None,
+        },
+        "safety": {
+            "validation_run": False,
+            "validation_passed": None,
+            "apply_attempted": False,
+            "apply_succeeded": None,
+            "mutation_type": None,
+            "rollback_needed": False,
+            "active_git_operation_detected": context.get("active_operation") is not None,
+            "fingerprint_match": None,
+            "ambiguous_hunk_match": False,
+            "marker_conflict_detected": len(orchestrator.get("marker_conflicts", [])) > 0,
+        },
+        "outputs": {
+            "primary_artifact": None,
+            "secondary_artifacts": [],
+            "mutations": [],
+        },
+        "scoring": {
+            "formula_version": DEFAULT_FORMULA_VERSION,
+            "efficiency_score": None,
+            "quality_score": None,
+            "safety_score": None,
+            "overall_score": None,
+        },
+        "notes": [],
+        "skill_specific": {
+            "schema_name": skill_name,
+            "schema_version": "1.0",
+            "data": skill_specific_data(skill_name, context, orchestrator, lint_report),
+        },
+    }
+
+
+def update_latency(log: dict[str, Any], phase: str, duration: float | None) -> None:
+    if duration is None:
+        return
+    mapping = {
+        "build": "packet_builder_seconds",
+        "lint": "linter_seconds",
+        "validate": "validator_seconds",
+        "apply": "apply_seconds",
+    }
+    key = mapping.get(phase)
+    if key:
+        log.setdefault("latency", {})[key] = round(duration, 3)
+        log.setdefault("measurement", {})["latency_source"] = "measured"
+
+
+def bool_score(value: bool | None, true_score: float = 1.0, false_score: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return true_score if value else false_score
+
+
+def linear_penalty(count: int | None, penalty: float, floor: float = 0.0) -> float | None:
+    if count is None:
+        return None
+    return max(floor, 1.0 - penalty * max(count, 0))
+
+
+def weighted_average(items: list[tuple[float | None, float]]) -> float | None:
+    filtered = [(value, weight) for value, weight in items if value is not None]
+    if not filtered:
+        return None
+    total_weight = sum(weight for _value, weight in filtered)
+    return round(sum(value * weight for value, weight in filtered) / total_weight, 3)
+
+
+def score_worker_fit(review_mode: Any, worker_count: Any) -> float | None:
+    mode = str(review_mode or "").strip()
+    count = safe_int(worker_count)
+    if not mode or count is None:
+        return None
+    if mode == "local-only":
+        return 1.0 if count == 0 else max(0.0, 1.0 - 0.25 * count)
+    if mode == "targeted-delegation":
+        if 1 <= count <= 2:
+            return 1.0
+        if count in {0, 3}:
+            return 0.6
+        return 0.3
+    if mode == "broad-delegation":
+        if 3 <= count <= 4:
+            return 1.0
+        if count == 2:
+            return 0.7
+        if count in {1, 5}:
+            return 0.4
+        return 0.2
+    return None
+
+
+def score_token_share(value: Any) -> float | None:
+    share = safe_float(value)
+    if share is None:
+        return None
+    if share <= 0.8:
+        return 1.0
+    if share <= 0.9:
+        return 0.8
+    if share <= 0.95:
+        return 0.6
+    return 0.4
+
+
+def score_baseline_savings(baseline: dict[str, Any]) -> float | None:
+    savings = safe_float(baseline.get("estimated_token_savings"))
+    reference = safe_float(baseline.get("estimated_local_only_tokens"))
+    if savings is None or reference is None or reference <= 0:
+        return None
+    return round(max(0.0, min(1.0, savings / reference)), 3)
+
+
+def compute_scores(log: dict[str, Any]) -> None:
+    orchestration = log.get("orchestration", {})
+    quality = log.get("quality", {})
+    safety = log.get("safety", {})
+    baseline = log.get("baseline", {})
+    tokens = log.get("tokens", {})
+
+    efficiency = weighted_average(
+        [
+            (score_worker_fit(orchestration.get("review_mode"), orchestration.get("worker_count")), 0.25),
+            (bool_score(to_bool(orchestration.get("global_packet_used")), 1.0, 0.0), 0.1),
+            (bool_score(not bool(orchestration.get("raw_reread_required")), 1.0, 0.4), 0.2),
+            (linear_penalty(safe_int(quality.get("rerun_count")), 0.25, floor=0.25), 0.2),
+            (score_token_share(tokens.get("main_model_token_share")), 0.15),
+            (score_baseline_savings(baseline), 0.1),
+        ]
+    )
+
+    severity = str(quality.get("human_post_edit_severity") or "unknown").lower()
+    severity_scores = {"none": 1.0, "low": 0.75, "medium": 0.5, "high": 0.25, "unknown": 0.6}
+    human_edit_required = to_bool(quality.get("human_post_edit_required"))
+    human_edit_score = None
+    if human_edit_required is not None:
+        human_edit_score = 1.0 if not human_edit_required else severity_scores.get(severity, 0.6)
+
+    result_status = str(quality.get("result_status") or "").lower()
+    status_scores = {"completed": 1.0, "dry-run": 0.8, "stopped": 0.5, "failed": 0.2}
+    quality_score = weighted_average(
+        [
+            (status_scores.get(result_status), 0.1),
+            (bool_score(to_bool(quality.get("first_pass_usable")), 1.0, 0.0), 0.3),
+            (human_edit_score, 0.15),
+            (linear_penalty(safe_int(quality.get("unsupported_claims_found")), 0.2), 0.15),
+            (linear_penalty(safe_int(quality.get("evidence_gaps_found")), 0.15), 0.1),
+            (linear_penalty(safe_int(quality.get("template_violations_found")), 0.25), 0.1),
+            (bool_score(not bool(quality.get("final_output_changed_after_review")), 1.0, 0.65), 0.1),
+        ]
+    )
+
+    validation_run = to_bool(safety.get("validation_run"))
+    validation_passed = to_bool(safety.get("validation_passed"))
+    apply_attempted = to_bool(safety.get("apply_attempted"))
+    if apply_attempted and validation_passed is False:
+        validation_boundary_score = 0.0
+    elif validation_run and validation_passed is True:
+        validation_boundary_score = 1.0
+    elif validation_run and validation_passed is False:
+        validation_boundary_score = 0.3
+    elif apply_attempted:
+        validation_boundary_score = 0.2
+    else:
+        validation_boundary_score = None
+
+    safety_score = weighted_average(
+        [
+            (validation_boundary_score, 0.3),
+            (bool_score(to_bool(safety.get("fingerprint_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("ambiguous_hunk_match")), 1.0, 0.0), 0.15),
+            (bool_score(not bool(safety.get("marker_conflict_detected")), 1.0, 0.4), 0.1),
+            (bool_score(not bool(safety.get("rollback_needed")), 1.0, 0.2), 0.1),
+            (bool_score(not bool(safety.get("active_git_operation_detected")), 1.0, 0.0), 0.1),
+            (bool_score(to_bool(safety.get("apply_succeeded")), 1.0, 0.2) if apply_attempted else None, 0.1),
+        ]
+    )
+
+    overall = weighted_average([(efficiency, 0.2), (quality_score, 0.35), (safety_score, 0.45)])
+
+    log.setdefault("scoring", {})
+    log["scoring"]["formula_version"] = DEFAULT_FORMULA_VERSION
+    log["scoring"]["efficiency_score"] = efficiency
+    log["scoring"]["quality_score"] = quality_score
+    log["scoring"]["safety_score"] = safety_score
+    log["scoring"]["overall_score"] = overall
+
+
+def apply_phase_update(log: dict[str, Any], phase: str, result: dict[str, Any], duration: float | None) -> None:
+    update_latency(log, phase, duration)
+    if phase == "build":
+        orchestration = log.setdefault("orchestration", {})
+        if result.get("review_mode"):
+            orchestration["review_mode"] = result.get("review_mode")
+        worker_count = safe_int(result.get("recommended_worker_count"))
+        if worker_count is not None:
+            orchestration["worker_count"] = worker_count
+        packet_metrics = result.get("packet_metrics")
+        if isinstance(packet_metrics, dict):
+            skill_specific = log.setdefault(
+                "skill_specific",
+                {"schema_name": log.get("skill", {}).get("name"), "schema_version": "1.0", "data": {}},
+            )
+            data = skill_specific.setdefault("data", {})
+            data["packet_metrics"] = packet_metrics
+            baseline = log.setdefault("baseline", {})
+            estimated_local_only_tokens = safe_int(
+                packet_metrics.get("estimated_local_only_tokens")
+            )
+            estimated_packet_tokens = safe_int(
+                packet_metrics.get("estimated_packet_tokens")
+            )
+            estimated_delegation_savings = safe_int(
+                packet_metrics.get("estimated_delegation_savings")
+            )
+            if estimated_local_only_tokens is not None:
+                baseline["estimated_local_only_tokens"] = estimated_local_only_tokens
+            if (
+                estimated_local_only_tokens is not None
+                and estimated_packet_tokens is not None
+            ):
+                baseline["estimated_token_savings"] = max(
+                    0, estimated_local_only_tokens - estimated_packet_tokens
+                )
+            if estimated_delegation_savings is not None:
+                baseline["estimated_delegation_savings"] = estimated_delegation_savings
+            baseline["method"] = "heuristic_local_only"
+            baseline["confidence"] = "estimated"
+            log.setdefault("measurement", {})["token_source"] = "estimated"
+        return
+
+    if phase == "lint":
+        lint_like = result.get("findings", result)
+        lint_summary = summarize_findings({"findings": lint_like})
+        quality = log.setdefault("quality", {})
+        quality["unsupported_claims_found"] = lint_summary["unsupported_claims_found"]
+        quality["evidence_gaps_found"] = lint_summary["evidence_gaps_found"]
+        quality["template_violations_found"] = lint_summary["template_violations_found"]
+        log.setdefault("measurement", {})["quality_source"] = "estimated"
+        return
+
+    if phase == "validate":
+        safety = log.setdefault("safety", {})
+        orchestration = log.setdefault("orchestration", {})
+        safety["validation_run"] = True
+
+        validation_passed = None
+        if "validation_passed" in result:
+            validation_passed = to_bool(result.get("validation_passed"))
+        elif "valid" in result:
+            validation_passed = to_bool(result.get("valid"))
+        elif "ok" in result:
+            validation_passed = to_bool(result.get("ok"))
+        elif "can_apply" in result and "errors" in result:
+            validation_passed = to_bool(result.get("can_apply")) and not bool(result.get("errors"))
+        safety["validation_passed"] = validation_passed
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+        return
+
+    if phase == "apply":
+        safety = log.setdefault("safety", {})
+        quality = log.setdefault("quality", {})
+        outputs = log.setdefault("outputs", {})
+        orchestration = log.setdefault("orchestration", {})
+        dry_run = to_bool(result.get("dry_run"))
+        apply_attempted = not bool(dry_run)
+        safety["apply_attempted"] = apply_attempted
+
+        apply_succeeded = None
+        for key in ("apply_succeeded", "success", "ok", "applied"):
+            if key in result:
+                apply_succeeded = to_bool(result.get(key))
+                break
+        if apply_attempted:
+            safety["apply_succeeded"] = apply_succeeded
+
+        fingerprint_match = result.get("fingerprint_match")
+        if fingerprint_match is not None:
+            safety["fingerprint_match"] = to_bool(fingerprint_match)
+        ambiguous_match = result.get("ambiguous_hunk_match")
+        if ambiguous_match is not None:
+            safety["ambiguous_hunk_match"] = to_bool(ambiguous_match)
+        rollback_needed = result.get("rollback_needed")
+        if rollback_needed is not None:
+            safety["rollback_needed"] = to_bool(rollback_needed)
+
+        mutation_type = result.get("mutation_type")
+        mutations = result.get("mutations")
+        if not mutation_type and isinstance(mutations, list) and mutations:
+            first = mutations[0]
+            if isinstance(first, dict):
+                mutation_type = first.get("kind")
+        if mutation_type:
+            safety["mutation_type"] = mutation_type
+
+        if isinstance(mutations, list):
+            outputs["mutations"] = mutations
+        if result.get("primary_artifact"):
+            outputs["primary_artifact"] = result.get("primary_artifact")
+        secondary = result.get("secondary_artifacts")
+        if isinstance(secondary, list):
+            outputs["secondary_artifacts"] = secondary
+
+        stop_reasons = result.get("stop_reasons") or []
+        if isinstance(stop_reasons, list) and stop_reasons:
+            existing = list(orchestration.get("stop_reasons") or [])
+            for reason in stop_reasons:
+                if isinstance(reason, str) and reason not in existing:
+                    existing.append(reason)
+            orchestration["stop_reasons"] = existing
+            orchestration["low_confidence_stop"] = orchestration.get("low_confidence_stop") or any(
+                "low confidence" in str(reason).lower() for reason in existing
+            )
+
+        if dry_run:
+            quality["result_status"] = "dry-run"
+        elif apply_succeeded is True:
+            quality["result_status"] = "completed"
+        elif stop_reasons:
+            quality["result_status"] = "stopped"
+        elif apply_attempted:
+            quality["result_status"] = "failed"
+        return
+
+
+def normalize_tokens(log: dict[str, Any]) -> None:
+    tokens = log.setdefault("tokens", {})
+    main_model = tokens.setdefault("main_model", {})
+    subagents = tokens.get("subagents")
+    if not isinstance(subagents, list):
+        subagents = []
+        tokens["subagents"] = subagents
+
+    def token_value(section: dict[str, Any], key: str) -> int:
+        return safe_int(section.get(key)) or 0
+
+    main_input = token_value(main_model, "input_tokens")
+    main_output = token_value(main_model, "output_tokens")
+    main_reasoning = token_value(main_model, "reasoning_tokens")
+    sub_input = 0
+    sub_output = 0
+    sub_reasoning = 0
+    for agent in subagents:
+        if not isinstance(agent, dict):
+            continue
+        sub_input += token_value(agent, "input_tokens")
+        sub_output += token_value(agent, "output_tokens")
+        sub_reasoning += token_value(agent, "reasoning_tokens")
+
+    total_input = main_input + sub_input
+    total_output = main_output + sub_output
+    total_reasoning = main_reasoning + sub_reasoning
+    if total_input:
+        tokens["total_input_tokens"] = total_input
+    if total_output:
+        tokens["total_output_tokens"] = total_output
+    if total_reasoning:
+        tokens["total_reasoning_tokens"] = total_reasoning
+    if total_input:
+        tokens["main_model_token_share"] = round(main_input / total_input, 3)
+
+    if total_input or total_output or total_reasoning:
+        log.setdefault("measurement", {})["token_source"] = "measured"
+
+
+def finalize_log(log: dict[str, Any], final_payload: dict[str, Any]) -> None:
+    deep_merge(log, final_payload)
+
+    notes = log.get("notes")
+    if not isinstance(notes, list):
+        log["notes"] = []
+    else:
+        deduped: list[str] = []
+        for note in notes:
+            if isinstance(note, str) and note not in deduped:
+                deduped.append(note)
+        log["notes"] = deduped
+
+    measurement = log.setdefault("measurement", {})
+    if log.get("tokens", {}).get("main_model", {}).get("model") or log.get("tokens", {}).get("subagents"):
+        measurement["token_source"] = "measured"
+    if log.get("quality", {}).get("first_pass_usable") is not None and measurement.get("quality_source") == "unavailable":
+        measurement["quality_source"] = "self_assessed"
+
+    latency = log.setdefault("latency", {})
+    component_keys = [
+        "collector_seconds",
+        "linter_seconds",
+        "packet_builder_seconds",
+        "model_seconds",
+        "validator_seconds",
+        "apply_seconds",
+    ]
+    if latency.get("total_seconds") is None:
+        total = sum(safe_float(latency.get(key)) or 0.0 for key in component_keys)
+        if total > 0:
+            latency["total_seconds"] = round(total, 3)
+            if measurement.get("latency_source") == "unavailable":
+                measurement["latency_source"] = "estimated"
+
+    normalize_tokens(log)
+    compute_scores(log)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a base evaluation log.")
+    init_parser.add_argument("--context", required=True, help="Path to the structured context JSON.")
+    init_parser.add_argument("--orchestrator", required=True, help="Path to orchestrator.json.")
+    init_parser.add_argument("--lint", help="Optional lint findings JSON.")
+    init_parser.add_argument("--output", help="Optional log output path.")
+
+    phase_parser = subparsers.add_parser("phase", help="Merge a deterministic phase result.")
+    phase_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    phase_parser.add_argument(
+        "--phase",
+        required=True,
+        choices=["build", "lint", "validate", "apply"],
+        help="Workflow phase being merged.",
+    )
+    phase_parser.add_argument("--result", required=True, help="Path to the phase result JSON.")
+    phase_parser.add_argument("--duration-seconds", type=float, help="Optional measured duration.")
+
+    finalize_parser = subparsers.add_parser("finalize", help="Merge final agent observations and score the log.")
+    finalize_parser.add_argument("--log", required=True, help="Path to the existing evaluation log.")
+    finalize_parser.add_argument("--final", required=True, help="Path to the final observations JSON.")
+
+    return parser.parse_args()
+
+
+def print_summary(path: Path, payload: dict[str, Any]) -> None:
+    print(
+        json.dumps(
+            {
+                "log_path": str(path),
+                "run_id": payload.get("run_id"),
+                "result_status": (payload.get("quality") or {}).get("result_status"),
+                "overall_score": (payload.get("scoring") or {}).get("overall_score"),
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+
+    if args.command == "init":
+        context = load_json(Path(args.context))
+        orchestrator = load_json(Path(args.orchestrator))
+        lint_report = load_json(Path(args.lint)) if args.lint else None
+        payload = build_base_log(script_path, context, orchestrator, lint_report)
+        output = Path(args.output).resolve() if args.output else default_output_path(payload["skill"]["name"], payload["run_id"])
+        write_json(output, payload)
+        print_summary(output, payload)
+        return 0
+
+    if args.command == "phase":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        result = load_json(Path(args.result))
+        apply_phase_update(payload, args.phase, result, args.duration_seconds)
+        compute_scores(payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    if args.command == "finalize":
+        log_path = Path(args.log).resolve()
+        payload = load_json(log_path)
+        final_payload = load_json(Path(args.final))
+        finalize_log(payload, final_payload)
+        write_json(log_path, payload)
+        print_summary(log_path, payload)
+        return 0
+
+    raise SystemExit(f"Unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/kernel-wrapper-migration-tracker.md
+++ b/docs/kernel-wrapper-migration-tracker.md
@@ -1,0 +1,38 @@
+# Kernel / Wrapper Migration Tracker
+
+This tracker records the split status for legacy source imports that are being
+decomposed into:
+
+- retained foundry kernels
+- consumer-local wrappers
+- profile-only data
+- cannot-migrate items
+
+## Foundry Boundary
+
+Current foundry ownership:
+- authoritative retained kernels live under `builders/packet-workflow/retained-skills/`
+- thin discovery wrappers live under `.agents/skills/`
+- wrappers may contain only `SKILL.md` and `agents/openai.yaml`
+
+Drift origin:
+- thin-entrypoint intent existed in repo prose from bootstrap
+- the original generator and retained-skill tests still treated `.agents/skills/` as a bundled output root
+- this migration closes that gap by moving authoritative retained assets and enforcing wrapper thinness in generator output and tests
+
+## Status Key
+
+- `source-import`: restored legacy copy is still the working source
+- `retained-in-progress`: retained skill scaffold exists and is being filled
+- `wrapper-in-progress`: consumer-local wrapper exists and is being trimmed
+- `ready-to-remove`: retained and wrapper characterization tests are green, the
+  worksheet ledger is complete, and the legacy source copy may be removed from
+  foundry
+- `removed`: legacy source copy has been removed from foundry
+
+## Skills
+
+| Legacy Source Skill | Retained Kernel | Consumer-Local Wrapper | Profile Split | Characterization Tests | Legacy Source Removal |
+| --- | --- | --- | --- | --- | --- |
+| `prepare-release-copy` | `draft-release-copy` | `prepare-release-copy` | retained profile complete; wrapper out-of-repo | retained green; wrapper out-of-repo | removed |
+| `repo-public-docs-sync` | `public-docs-sync` | `repo-public-docs-sync` | retained profile complete; wrapper out-of-repo | retained green; wrapper out-of-repo | removed |

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -1,0 +1,87 @@
+# Vendoring PacketFlow Foundry
+
+Use `packetflow_foundry` as a vendor subtree at `.codex/vendor/packetflow_foundry`.
+
+## Compose Model
+
+Compose in this order:
+
+`foundry baseline -> optional foundry overlay -> project-local profile -> root .agents/skills wrapper/override surface`
+
+Meaning:
+- start from `profiles/baseline/profile.json`
+- optionally add `profiles/packet-heavy-orchestrator/profile.json`
+- add repo-specific profile data from `.codex/project/profiles/`
+  - keep repo-wide defaults in `.codex/project/profiles/default/profile.json`
+  - keep skill-specific overrides in `.codex/project/profiles/<skill-name>/profile.json`
+- bridge reusable foundry default agent TOMLs from `.codex/vendor/packetflow_foundry/.codex/agents/` into repo-root `.codex/agents/`
+- expose repo-scoped skills from repo-root `.agents/skills/`
+- bridge reusable foundry thin wrappers from `.codex/vendor/packetflow_foundry/.agents/skills/` into the root discovery surface
+- keep authoritative retained kernels in `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+
+## Recommended Consumer Layout
+
+```text
+project-root/
+  .agents/
+    skills/
+  .codex/
+    AGENTS.md
+    agents/
+    vendor/
+      packetflow_foundry/
+    project/
+      profiles/
+```
+
+Bootstrap the local overlay after vendoring:
+
+```text
+git subtree add --prefix=.codex/vendor/packetflow_foundry packetflow_foundry master --squash
+python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+```
+
+Bootstrap notes:
+- root `AGENTS.md` and `.codex/AGENTS.md` are append-only targets
+- repo-root `.codex/agents/` is the canonical consumer subagent location
+- `.codex/project/profiles/default/profile.json` is a project-local scaffold, not a reusable foundry overlay
+- skill-specific project-local overrides belong in `.codex/project/profiles/<skill-name>/profile.json`
+- vendored foundry default agent TOMLs are bridged into repo-root `.codex/agents/` unless a root entry already exists
+- repo-root `.agents/skills/` is the canonical consumer skill location
+- vendored foundry thin wrappers are bridged into root `.agents/skills/` unless a root entry already exists
+- bridged wrappers resolve authoritative retained kernels from `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- legacy `.codex/project/agents/` is deprecated and bridged only for migration
+- legacy `.codex/project/skills/` is deprecated and bridged only for migration
+- if any tracked non-`AGENTS.md` bootstrap output already exists, the helper aborts without writing files
+- if symlink creation fails, the helper aborts with environment guidance instead of copying skills
+
+## What Stays In The Vendor
+
+Keep these in the foundry vendor subtree:
+- shared contracts and templates
+- reusable overlay profiles
+- reusable builder logic
+- reusable default managed agent registry under `.codex/vendor/packetflow_foundry/.codex/agents/`
+- reusable foundry thin skill entrypoints under `.codex/vendor/packetflow_foundry/.agents/skills/`
+- reusable foundry retained kernels under `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+
+## What Stays Outside The Vendor
+
+Keep these in the consumer repo root or `.codex/project/`:
+- repo-specific profile data in `.codex/project/profiles/`
+  - repo-wide scaffold defaults in `.codex/project/profiles/default/profile.json`
+  - skill-specific overrides in `.codex/project/profiles/<skill-name>/profile.json`
+- repo-specific agents in `.codex/agents/`
+- repo-specific skills in `.agents/skills/`
+- legacy `.codex/project/agents/` only as a migration shim
+- project-only overrides that should not be upstreamed
+
+## No Direct Vendor Edits For Local Needs
+
+Do not edit `.codex/vendor/packetflow_foundry` to satisfy one project's local layout.
+Make those changes in repo-root `.agents/skills/`, repo-root `.codex/agents/`, or `.codex/project/` instead.
+
+Edit the vendor subtree directly only when:
+- fixing a reusable foundry bug
+- adding a reusable foundry capability
+- changing shared contracts or templates that should be kept upstream

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -14,9 +14,9 @@ Meaning:
 - add repo-specific profile data from `.codex/project/profiles/`
   - keep repo-wide defaults in `.codex/project/profiles/default/profile.json`
   - keep skill-specific overrides in `.codex/project/profiles/<skill-name>/profile.json`
-- bridge reusable foundry default agent TOMLs from `.codex/vendor/packetflow_foundry/.codex/agents/` into repo-root `.codex/agents/`
+- copy reusable foundry default agent TOMLs from `.codex/vendor/packetflow_foundry/.codex/agents/` into repo-root `.codex/agents/` as managed bootstrap artifacts
 - expose repo-scoped skills from repo-root `.agents/skills/`
-- bridge reusable foundry thin wrappers from `.codex/vendor/packetflow_foundry/.agents/skills/` into the root discovery surface
+- copy reusable foundry thin wrappers from `.codex/vendor/packetflow_foundry/.agents/skills/` into the root discovery surface as managed bootstrap artifacts
 - keep authoritative retained kernels in `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
 
 ## Recommended Consumer Layout
@@ -41,19 +41,27 @@ git subtree add --prefix=.codex/vendor/packetflow_foundry packetflow_foundry mas
 python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py
 ```
 
+Bootstrap now writes managed copies into repo-root `.codex/agents/` and `.agents/skills/`.
+After updating `.codex/vendor/packetflow_foundry`, rerun the same bootstrap command to
+refresh those managed copies while leaving locally modified copies untouched.
+
 Bootstrap notes:
+- repo-root `.gitignore` is created or appended so `.codex/tmp/` stays ignored
+- repo-local temporary, helper, scratch, and ad hoc operator-input files belong under `.codex/tmp/`, not at repo root or in tracked source directories
 - root `AGENTS.md` and `.codex/AGENTS.md` are append-only targets
 - repo-root `.codex/agents/` is the canonical consumer subagent location
 - `.codex/project/profiles/default/profile.json` is a project-local scaffold, not a reusable foundry overlay
 - skill-specific project-local overrides belong in `.codex/project/profiles/<skill-name>/profile.json`
-- vendored foundry default agent TOMLs are bridged into repo-root `.codex/agents/` unless a root entry already exists
+- vendored foundry default agent TOMLs are copied into repo-root `.codex/agents/` unless a root entry already exists
 - repo-root `.agents/skills/` is the canonical consumer skill location
-- vendored foundry thin wrappers are bridged into root `.agents/skills/` unless a root entry already exists
-- bridged wrappers resolve authoritative retained kernels from `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- vendored foundry thin wrappers are copied into root `.agents/skills/` unless a root entry already exists
+- copied skill wrappers keep resolving authoritative retained kernels from `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
+- rerunning bootstrap refreshes managed copies that still match the last managed state
+- `--bridge-mode copy-on-fail` is retained only as a deprecated compatibility alias for `copy`
 - legacy `.codex/project/agents/` is deprecated and bridged only for migration
 - legacy `.codex/project/skills/` is deprecated and bridged only for migration
-- if any tracked non-`AGENTS.md` bootstrap output already exists, the helper aborts without writing files
-- if symlink creation fails, the helper aborts with environment guidance instead of copying skills
+- a compatible existing `.codex/project/profiles/default/profile.json` is left unchanged on rerun
+- conflicting non-`AGENTS.md` bootstrap outputs still cause the helper to abort before creating or overwriting those managed artifacts, although append-only targets like `AGENTS.md` and `.gitignore` may already have been updated
 
 ## What Stays In The Vendor
 

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -42,8 +42,21 @@ python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init
 ```
 
 Bootstrap now writes managed copies into repo-root `.codex/agents/` and `.agents/skills/`.
+Those bootstrap-copied entries are managed artifacts only when they came from the
+vendor subtree; do not patch those copied artifacts in place. Update the vendor source
+or replace the entry with a project-local one, then rerun bootstrap.
 After updating `.codex/vendor/packetflow_foundry`, rerun the same bootstrap command to
 refresh those managed copies while leaving locally modified copies untouched.
+
+Recommended update flow:
+
+```text
+git subtree pull --prefix=.codex/vendor/packetflow_foundry packetflow_foundry <upstream-branch> --squash
+python .codex/vendor/packetflow_foundry/builders/consumer-bootstrap/scripts/init_consumer_codex.py
+<run the relevant consumer smoke test(s)>
+git diff
+git commit
+```
 
 Bootstrap notes:
 - repo-root `.gitignore` is created or appended so `.codex/tmp/` stays ignored
@@ -57,6 +70,7 @@ Bootstrap notes:
 - vendored foundry thin wrappers are copied into root `.agents/skills/` unless a root entry already exists
 - copied skill wrappers keep resolving authoritative retained kernels from `.codex/vendor/packetflow_foundry/builders/packet-workflow/retained-skills/`
 - rerunning bootstrap refreshes managed copies that still match the last managed state
+- `bridge-state.json` stores both raw and LF-normalized hashes so CRLF/LF-only drift does not trigger a refresh or local-modification warning
 - `--bridge-mode copy-on-fail` is retained only as a deprecated compatibility alias for `copy`
 - legacy `.codex/project/agents/` is deprecated and bridged only for migration
 - legacy `.codex/project/skills/` is deprecated and bridged only for migration

--- a/profiles/AGENTS.md
+++ b/profiles/AGENTS.md
@@ -1,0 +1,21 @@
+# Profiles AGENTS
+
+This subtree contains reusable foundry overlay profiles only.
+
+Default model:
+- `baseline` is the default overlay
+- `packet-heavy-orchestrator` is an opt-in upper overlay
+
+Profiles here must stay:
+- reusable across multiple repos
+- data-only
+- limited to selection defaults, bindings, review defaults, and notes
+
+Do not place these in foundry profiles:
+- repo-specific path bindings for one consumer repo
+- project-only review docs
+- executable hooks
+- behavior semantics
+- packet routing authority
+
+If a profile is only useful to one consumer repo, put it in `.codex/project/profiles/` instead of here.

--- a/profiles/baseline/profile.json
+++ b/profiles/baseline/profile.json
@@ -1,0 +1,46 @@
+{
+  "name": "baseline",
+  "kind": "foundry-overlay-profile",
+  "summary": "Default reusable PacketFlow Foundry overlay for standard packet-workflow scaffolds.",
+  "extends": [],
+  "packet_workflow": {
+    "orchestrator_profile": "standard",
+    "review_mode_defaults": {
+      "supported_modes": [
+        "local-only",
+        "targeted-delegation",
+        "broad-delegation"
+      ],
+      "default_override_signals": [
+        "diff churn exceeds a configured threshold",
+        "core runtime, config, or process files span multiple groups",
+        "generated files are present but are not the majority of the change"
+      ]
+    },
+    "lint_defaults": {
+      "require_readme_settings_table": false,
+      "missing_review_docs_are_errors": false
+    },
+    "worker_selection_defaults": {
+      "preferred_worker_families": {
+        "context_findings": [
+          "repo_mapper",
+          "packet_explorer",
+          "docs_verifier"
+        ],
+        "candidate_producers": [
+          "evidence_summarizer",
+          "large_diff_auditor",
+          "log_triager"
+        ],
+        "verifiers": [
+          "docs_verifier"
+        ]
+      }
+    }
+  },
+  "notes": [
+    "This is a reusable overlay, not a repo-specific profile.",
+    "Project-specific paths, docs, and bindings belong in .codex/project/profiles/."
+  ]
+}

--- a/profiles/packet-heavy-orchestrator/profile.json
+++ b/profiles/packet-heavy-orchestrator/profile.json
@@ -1,0 +1,22 @@
+{
+  "name": "packet-heavy-orchestrator",
+  "kind": "foundry-overlay-profile",
+  "summary": "Opt-in reusable overlay for packet-heavy workflows that need the common-path local synthesis pattern.",
+  "extends": [
+    "baseline"
+  ],
+  "packet_workflow": {
+    "orchestrator_profile": "packet-heavy-orchestrator",
+    "common_path_contract": "packet-heavy",
+    "evaluation_sidecars": [
+      "packet_metrics.json"
+    ],
+    "worker_selection_defaults": {
+      "prefer_shared_local_packet": true
+    }
+  },
+  "notes": [
+    "This overlay selects the packet-heavy common path defined by core contracts.",
+    "It does not redefine validator/apply semantics, stop taxonomy, or common-path meaning."
+  ]
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,105 @@
+{
+  "include": [
+    "builders",
+    "core",
+    ".agents"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    ".pytest_cache"
+  ],
+  "executionEnvironments": [
+    {
+      "root": "builders/consumer-bootstrap/scripts"
+    },
+    {
+      "root": "builders/consumer-bootstrap/tests",
+      "extraPaths": [
+        "builders/consumer-bootstrap/scripts",
+        "builders/packet-workflow/retained-skills/reword-recent-commits/scripts",
+        "builders/packet-workflow/retained-skills/git-split-and-commit/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/tests",
+      "extraPaths": [
+        "builders/packet-workflow/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/draft-release-copy/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/draft-release-copy/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/draft-release-copy/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/gh-address-review-threads/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/gh-address-review-threads/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/gh-address-review-threads/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/gh-create-pr/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/gh-create-pr/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/gh-create-pr/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/git-split-and-commit/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/git-split-and-commit/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/git-split-and-commit/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/public-docs-sync/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/public-docs-sync/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/public-docs-sync/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/reword-recent-commits/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/reword-recent-commits/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/reword-recent-commits/scripts"
+      ]
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/weekly-update/scripts"
+    },
+    {
+      "root": "builders/packet-workflow/retained-skills/weekly-update/tests",
+      "extraPaths": [
+        "builders/packet-workflow/retained-skills/weekly-update/scripts"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed
- Vendor `packetflow_foundry` into `.codex/vendor/packetflow_foundry`, including the builder, retained-skill kernels, templates, defaults, and supporting docs.
- Add repo-local wrapper skills under `.agents/skills/*` for the retained workflows, including `gh-create-pr`, `gh-fix-pr-writeup`, `gh-address-review-threads`, and related packet workflow skills.
- Add Codex agent configs plus `.codex/project` profile and bootstrap state so the repository can resolve and use the vendored workflow assets.
- Ignore Codex temp artifacts via `.gitignore`.

## Why
- Add the vendored packet workflow foundation and repo-local wiring needed to bootstrap these Codex workflows from this repository without depending on a separate external checkout.

## How
- Import the foundry snapshot under `.codex/vendor/packetflow_foundry` and keep consumer-local overrides in repo-owned `.agents` and `.codex/project` paths.
- Wire the thin wrapper skills to the retained kernel paths and register repo-local profiles and agent definitions that point at the vendored assets.
- Repo-local automation defaults are introduced through `.codex/project/profiles/*`; gameplay/runtime application defaults are unchanged.
- Save compatibility / migration impact:
  - No game-save or runtime data migration is involved; impact is limited to Codex workflow metadata and repo automation configuration.

## Testing
- Build / validation:
  - Not run. I did not execute the vendored Python test or smoke suites before opening this PR.
- Manual verification:
  - `git diff --stat origin/develop..origin/packetflow_foundry_vendoring -- .agents .codex .gitignore`
  - `git show origin/packetflow_foundry_vendoring:.agents/skills/gh-create-pr/SKILL.md`
- Settings touched:
  - [ ] No settings changed
  - [x] Defaults changed
  - [ ] Reload required
  - [ ] Restart required
- The changed defaults are limited to Codex/project profile configuration, not runtime application settings.

## Risk / Rollback
- Risk areas:
  - Wrapper and profile paths can drift from the vendored foundry layout and break retained skill resolution.
  - Large vendor imports are easy to merge with a stale upstream snapshot if `packetflow_foundry` moves independently.
- Rollback / mitigation:
  - Revert the vendor import together with the repo-local `.agents`, `.codex/project`, and `.gitignore` updates as one change set; no persistent runtime data migration needs to be unwound.

## Reviewer Checklist
- [ ] Linked issue, investigation, or release item when applicable
- [ ] README or docs updated if behavior or defaults changed
- [x] Save compatibility impact called out
- [x] Verification steps are specific enough to reproduce
- [x] Risk and rollback are concrete for shipped behavior

## PR Classification (optional)
- [x] Feature

Justification:
Adds a new repo-local packet workflow capability by vendoring the foundry assets and wiring wrappers, profiles, and agent definitions that let this repository consume them.
