### PR TITLE
fix(systems): track software fulfillment latency and demand recovery

### DIFF
--- a/.github/scripts/raw_log_automation.py
+++ b/.github/scripts/raw_log_automation.py
@@ -1741,6 +1741,9 @@ def compact_office_snapshot(observation: dict[str, Any] | None) -> str:
                 "selectedNoResourceBuyer",
                 "selectedNoBuyerShortGap",
                 "selectedNoBuyerPersistent",
+                "selectedNoBuyerMissedVanillaPass",
+                "selectedNoBuyerMissedMultipleVanillaPasses",
+                "selectedNoBuyerMaxMissedVanillaPasses",
                 "selectedRequestNoPath",
                 "selectedRequestNoPathShortGap",
                 "selectedRequestNoPathPersistent",
@@ -2429,6 +2432,28 @@ def build_llm_semantic_facts(parsed_log: dict[str, Any]) -> list[str]:
             f"Latest counters: softwareConsumerBuyerState.selectedNoBuyerPersistent={selected_no_buyer_persistent} marks selected software consumers whose buyerless state persisted across multiple windows."
         )
 
+    selected_no_buyer_missed_vanilla_pass = safe_int(buyer_state.get("selectedNoBuyerMissedVanillaPass"))
+    if selected_no_buyer_missed_vanilla_pass > 0:
+        facts.append(
+            f"Latest counters: softwareConsumerBuyerState.selectedNoBuyerMissedVanillaPass={selected_no_buyer_missed_vanilla_pass} marks selected software consumers whose buyerless state already spanned at least one estimated vanilla buyer pass."
+        )
+
+    selected_no_buyer_missed_multiple_vanilla_passes = safe_int(
+        buyer_state.get("selectedNoBuyerMissedMultipleVanillaPasses")
+    )
+    if selected_no_buyer_missed_multiple_vanilla_passes > 0:
+        facts.append(
+            f"Latest counters: softwareConsumerBuyerState.selectedNoBuyerMissedMultipleVanillaPasses={selected_no_buyer_missed_multiple_vanilla_passes} marks selected software consumers whose buyerless state spanned multiple estimated vanilla buyer passes."
+        )
+
+    selected_no_buyer_max_missed_vanilla_passes = safe_int(
+        buyer_state.get("selectedNoBuyerMaxMissedVanillaPasses")
+    )
+    if selected_no_buyer_max_missed_vanilla_passes > 0:
+        facts.append(
+            f"Latest counters: softwareConsumerBuyerState.selectedNoBuyerMaxMissedVanillaPasses={selected_no_buyer_max_missed_vanilla_passes} is the maximum estimated vanilla buyer passes crossed by a still-buyerless selected software consumer."
+        )
+
     selected_request_no_path_short_gap = safe_int(buyer_state.get("selectedRequestNoPathShortGap"))
     if selected_request_no_path_short_gap > 0:
         facts.append(
@@ -2531,6 +2556,7 @@ def build_llm_request_payload(context: dict[str, Any], model: str | None = None)
         - If `softwareConsumerBuyerState.correctiveBuyerPresent` or `softwareConsumerBuyerState.vanillaBuyerPresent` is nonzero, mention corrective or vanilla buyer coverage when buyer-state fields are central to the run.
         - If `softwareConsumerBuyerState.selectedRequestNoPath` or `softwareConsumerBuyerState.pathPending` is nonzero, prefer path-stage wording such as buyer-present / no-path / pending-path rather than buyer-shortage wording.
         - If `softwareConsumerBuyerState.selectedNoBuyerPersistent` or `softwareConsumerBuyerState.selectedRequestNoPathPersistent` is nonzero, use persistence wording rather than generic shortage wording.
+        - If `softwareConsumerBuyerState.selectedNoBuyerMissedVanillaPass` or `softwareConsumerBuyerState.selectedNoBuyerMissedMultipleVanillaPasses` is nonzero, describe that as buyerless state persisting past estimated vanilla buyer passes rather than as a simple next-tick wait.
         - If `softwareConsumerBuyerState.selectedNoBuyerShortGap` or `softwareConsumerBuyerState.selectedRequestNoPathShortGap` is nonzero, use short-gap wording rather than persistent-stall wording.
         - If `softwareConsumerBuyerState.resolvedVirtualNoTrackingExpected` or `softwareConsumerBuyerState.virtualResolvedThisWindow` is nonzero, include that actual in-window virtual resolution was observed.
         - Do not use legacy wording such as `noBuyerDespiteNeed` unless that exact field is present in the provided facts.
@@ -2617,6 +2643,7 @@ def build_summary_refinement_request_payload(context: dict[str, Any], model: str
         - If `softwareConsumerBuyerState.resourceBuyerPresent` equals `softwareConsumerBuyerState.needSelected`, describe that literally as buyer coverage rather than shortage.
         - If `softwareConsumerBuyerState.correctiveBuyerPresent` or `softwareConsumerBuyerState.vanillaBuyerPresent` is nonzero, mention corrective or vanilla buyer coverage when buyer-state fields are central to the run.
         - If `softwareConsumerBuyerState.selectedNoBuyerPersistent` or `softwareConsumerBuyerState.selectedRequestNoPathPersistent` is nonzero, prefer persistence wording rather than generic shortage wording.
+        - If `softwareConsumerBuyerState.selectedNoBuyerMissedVanillaPass` or `softwareConsumerBuyerState.selectedNoBuyerMissedMultipleVanillaPasses` is nonzero, prefer wording that the buyerless state extended past estimated vanilla buyer passes.
         - If `softwareConsumerBuyerState.selectedNoBuyerShortGap` or `softwareConsumerBuyerState.selectedRequestNoPathShortGap` is nonzero, prefer short-gap wording rather than persistent-stall wording.
         - If `softwareConsumerBuyerState.resolvedVirtualNoTrackingExpected` or `softwareConsumerBuyerState.virtualResolvedThisWindow` is nonzero, include that actual in-window virtual resolution was observed.
         - Avoid subjective intensifiers like "significantly".

--- a/.github/scripts/tests/test_raw_log_automation.py
+++ b/.github/scripts/tests/test_raw_log_automation.py
@@ -549,6 +549,9 @@ class RawLogAutomationTests(unittest.TestCase):
                         "correctiveBuyerPresent": 2,
                         "vanillaBuyerPresent": 2,
                         "selectedNoBuyerPersistent": 1,
+                        "selectedNoBuyerMissedVanillaPass": 1,
+                        "selectedNoBuyerMissedMultipleVanillaPasses": 1,
+                        "selectedNoBuyerMaxMissedVanillaPasses": 5,
                         "selectedRequestNoPathShortGap": 3,
                         "virtualResolvedThisWindow": 2,
                         "virtualResolvedAmount": 96,
@@ -559,6 +562,9 @@ class RawLogAutomationTests(unittest.TestCase):
         self.assertIn("correctiveBuyerPresent=2", snapshot)
         self.assertIn("vanillaBuyerPresent=2", snapshot)
         self.assertIn("selectedNoBuyerPersistent=1", snapshot)
+        self.assertIn("selectedNoBuyerMissedVanillaPass=1", snapshot)
+        self.assertIn("selectedNoBuyerMissedMultipleVanillaPasses=1", snapshot)
+        self.assertIn("selectedNoBuyerMaxMissedVanillaPasses=5", snapshot)
         self.assertIn("selectedRequestNoPathShortGap=3", snapshot)
         self.assertIn("virtualResolvedThisWindow=2", snapshot)
         self.assertIn("virtualResolvedAmount=96", snapshot)
@@ -630,6 +636,7 @@ class RawLogAutomationTests(unittest.TestCase):
             "correctiveBuyerPresent": 4,
             "vanillaBuyerPresent": 0,
             "selectedNoResourceBuyer": 0,
+            "selectedNoBuyerMissedVanillaPass": 2,
             "virtualResolvedThisWindow": 2,
             "virtualResolvedAmount": 64,
         }
@@ -652,6 +659,10 @@ class RawLogAutomationTests(unittest.TestCase):
         )
         self.assertTrue(
             any("virtualResolvedThisWindow=2" in fact for fact in context["semantic_facts"]),
+            context["semantic_facts"],
+        )
+        self.assertTrue(
+            any("selectedNoBuyerMissedVanillaPass=2" in fact for fact in context["semantic_facts"]),
             context["semantic_facts"],
         )
 

--- a/.github/software-evidence-schema.md
+++ b/.github/software-evidence-schema.md
@@ -62,7 +62,7 @@ Observation fields describe the actual evidence collected.
 Required:
 
 - `symptom_classification`: the main observed symptom, using a stable label
-- `diagnostic_counters`: the relevant counter groups captured during the observation window; include all groups needed for the hypothesis under test, such as `software(...)`, `electronics(...)`, `softwareProducerOffices(...)`, `softwareConsumerOffices(...)`, and `softwareConsumerBuyerState(...)` when present. If the claim is about office-demand response, preserve `officeDemand(...)` instead of paraphrasing it away. When buyer-lifecycle or zero-weight virtual-resolution behavior is part of the claim, preserve any emitted `softwareConsumerBuyerState(...)` subfields that separate corrective versus vanilla buyers, short-gap versus persistent buyerless states, and virtual-resolution summaries instead of collapsing them into prose
+- `diagnostic_counters`: the relevant counter groups captured during the observation window; include all groups needed for the hypothesis under test, such as `software(...)`, `electronics(...)`, `softwareProducerOffices(...)`, `softwareConsumerOffices(...)`, and `softwareConsumerBuyerState(...)` when present. If the claim is about office-demand response, preserve `officeDemand(...)` instead of paraphrasing it away. When buyer-lifecycle or zero-weight virtual-resolution behavior is part of the claim, preserve any emitted `softwareConsumerBuyerState(...)` subfields that separate corrective versus vanilla buyers, short-gap versus persistent buyerless states, and virtual-resolution summaries instead of collapsing them into prose. When the claim is an in-window divergence between demand recovery and continuing consumer stalls, it is acceptable to preserve two or more labeled snapshots from the same bounded run instead of only the final endpoint counters
 - `evidence_summary`: the short factual summary of what was observed
 - `confidence`: low, medium, or high
 - `confounders`: known uncertainties, competing explanations, or `none known`; use this for uncertainty that is not already represented directly by counters or metadata
@@ -105,7 +105,7 @@ Treat `selected_no_resource_buyer` as too broad to interpret on its own; pair it
 
 When the active question is whether a selected software need stayed below threshold long enough to justify or explain the corrective buyer pass, preserve `detail_type=softwareBuyerTimingProbe` as supplemental artifact material. Use it to distinguish short same-sample cadence gaps from repeated below-threshold windows, but do not let it replace the scheduled observation-window anchor, copied counters, or helper-rich `softwareOfficeStates` excerpts.
 
-When the active question is whether software-office distress actually affected office demand, keep `officeDemand(...)` together with the software counters. Treat demand movement as something to observe directly, not something implied by `softwareConsumerOffices.efficiencyZero` or `softwareInputZero` alone.
+When the active question is whether software-office distress actually affected office demand, keep `officeDemand(...)` together with the software counters. Treat demand movement as something to observe directly, not something implied by `softwareConsumerOffices.efficiencyZero` or `softwareInputZero` alone. When the same bounded run contains both recovery and lingering stalls, preserve labeled earlier and later counter snapshots plus at least one stalled or recovered consumer excerpt rather than flattening the run into one prose sentence.
 
 If the interpretation relies on code reading, separate what came from vanilla decompiled game code from what came from this mod's code. Vanilla decompile is the source of truth for base-game trade lifecycle and virtual-resource handling; mod code explains instrumentation, local patches, and any deviations that belong in `patch_state`.
 
@@ -195,7 +195,7 @@ Use short stable labels instead of free-form titles where possible. Current exam
 - `software_demand_mismatch`
 - `software_track_unclear`
 
-`software_demand_mismatch` is the preferred label when software-office distress is present but office-demand counters stay flat or rise, or when the expected software-to-demand relationship does not appear.
+`software_demand_mismatch` is the preferred label when software-office distress is present but office-demand counters stay flat or rise, or when the expected software-to-demand relationship does not appear. Use it both for steady mismatch and for in-window recovery cases where office demand rebounds while many software consumers still remain stalled.
 
 These labels are working categories, not proof of root cause.
 Keep them symptom-based rather than cause-based. Do not introduce presumed root-cause labels such as `electronics_shortage`.

--- a/.github/software-investigation-workflow.md
+++ b/.github/software-investigation-workflow.md
@@ -170,6 +170,7 @@ Mixed-cause interpretations are allowed. Record them explicitly instead of forci
 - when buyerless or pre-path states remain unexplained, prefer adding or preserving reason / age instrumentation before introducing behavior-changing experimental patches
 - widespread consumer-side `efficiency=0`, `lackResources=0`, or `softwareInputZero=true` does not by itself prove office demand will fall
 - if software-consumer distress persists while `officeDemand(...)` stays flat or rises, record that as contradictory to the original direct software-to-demand assumption
+- if `officeDemand(...)` recovers while `selectedNoResourceBuyer` stays near zero but `selected_resource_buyer_no_path` / `pathPending` remain elevated, record that as split evidence: demand recovery can coexist with software-fulfillment latency
 - keep root-cause interpretation in `confounders`, `notes`, or the umbrella summary rather than inventing root-cause `symptom_classification` labels
 
 ## Instrumentation Priority For Ambiguous Buyer States
@@ -191,7 +192,7 @@ This keeps instrumentation work and fix work separate, which makes later compari
 
 Use day count as the primary rule for reusable windows:
 
-- `1 day`: screening or mechanism-check capture; keep it raw unless the hypothesis is intentionally about an in-window transition only
+- `1 day`: screening or mechanism-check capture; keep it raw unless the hypothesis is intentionally about an in-window transition only, for example office-demand recovery diverging from ongoing software-consumer stalls in the same run
 - `2 days`: minimum reusable bounded window for a promoted evidence entry when the main question is short-horizon virtual-resource behavior on a tightly matched save lineage
 - `3 days`: default release-gate or comparison-grade bounded window
 - `5 days`: preferred only when same-lineage buyer-lifecycle or persistence interpretation is still materially ambiguous after the shorter window
@@ -311,7 +312,7 @@ Use the checkpoint that matches the active question. Do not force every investig
 - question: does software-consumer distress align with lower office demand, no material demand shift, or rising demand?
 - hold constant: same game/mod/settings except the variable under test, comparable observation window, no unrelated city change large enough to dominate office demand
 - primary evidence: `officeDemand(...)`, `softwareConsumerOffices(...)`, and relevant `softwareEvidenceDiagnostics detail(...)` lines with `detail_type=softwareOfficeStates`
-- interpretation note: treat strong consumer distress with flat or rising `officeDemand(...)` as contradictory to the original direct-demand assumption unless another direct demand mechanism is separately evidenced
+- interpretation note: treat strong consumer distress with flat or rising `officeDemand(...)` as contradictory to the original direct-demand assumption unless another direct demand mechanism is separately evidenced; when buyerless counts stay near zero at the same time, treat that as demand recovery plus fulfillment latency rather than as a solved software track
 - invalid when: office-demand counters were not preserved, unrelated interventions dominated city state, or the demand claim was inferred only from software counters
 
 ### 8. Software Need Selection Vs Buyer Lifecycle State

--- a/NoOfficeDemandFix/MachineParsedLogContract.cs
+++ b/NoOfficeDemandFix/MachineParsedLogContract.cs
@@ -26,6 +26,8 @@ namespace NoOfficeDemandFix
         public const string SoftwareTradeLifecycleDetailType = "softwareTradeLifecycle";
         public const string SoftwareVirtualResolutionProbeDetailType = "softwareVirtualResolutionProbe";
         public const string SoftwareBuyerTimingProbeDetailType = "softwareBuyerTimingProbe";
+        public const string OfficeDemandInternalsDetailType = "officeDemandInternals";
+        public const string SoftwareSellerResolutionProbeDetailType = "softwareSellerResolutionProbe";
         public const string VirtualOfficeBuyerFixProbePrefix = "virtualOfficeBuyerFixProbe ";
 
         public static string FormatObservationWindow(

--- a/NoOfficeDemandFix/Mod.cs
+++ b/NoOfficeDemandFix/Mod.cs
@@ -44,6 +44,8 @@ namespace NoOfficeDemandFix
             updateSystem.UpdateAfter<OfficeAIHotfixSystem, OfficeAISystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateBefore<OfficeAIHotfixSystem, ProcessingCompanySystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<OfficeDemandDiagnosticsSystem, IndustrialDemandSystem>(SystemUpdatePhase.GameSimulation);
+            updateSystem.UpdateAfter<OfficeDemandDiagnosticsSystem, OfficeAIHotfixSystem>(SystemUpdatePhase.GameSimulation);
+            updateSystem.UpdateBefore<OfficeDemandDiagnosticsSystem, CityProductionStatisticSystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateAfter<VirtualOfficeResourceBuyerFixSystem, BuyingCompanySystem>(SystemUpdatePhase.GameSimulation);
             updateSystem.UpdateBefore<VirtualOfficeResourceBuyerFixSystem, ResourceBuyerSystem>(SystemUpdatePhase.GameSimulation);
             // Run performance telemetry in LateUpdate so metrics are captured after simulation completes,
@@ -53,6 +55,8 @@ namespace NoOfficeDemandFix
             m_Setting = new Setting(this);
             AssetDatabase.global.LoadSettings(nameof(NoOfficeDemandFix), m_Setting, new Setting(this));
             Settings = m_Setting;
+            IndustrialDemandDiagnosticsProbePatch.Reset();
+            OutsideConnectionVirtualSellerFixPatch.ResetDetailedRequestProbes();
 
             GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(m_Setting));
             m_Setting.RegisterInOptionsUI();
@@ -80,6 +84,8 @@ namespace NoOfficeDemandFix
             log.Info(nameof(OnDispose));
             PerformanceTelemetryCollector.FlushActiveRun();
             Settings = null;
+            IndustrialDemandDiagnosticsProbePatch.Reset();
+            OutsideConnectionVirtualSellerFixPatch.ResetDetailedRequestProbes();
 
             if (m_Harmony != null)
             {

--- a/NoOfficeDemandFix/Patches/IndustrialDemandDiagnosticsProbePatch.cs
+++ b/NoOfficeDemandFix/Patches/IndustrialDemandDiagnosticsProbePatch.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Game.Economy;
+using Game.Simulation;
+using HarmonyLib;
+using Unity.Collections;
+using Unity.Jobs;
+
+namespace NoOfficeDemandFix.Patches
+{
+    [HarmonyPatch(typeof(IndustrialDemandSystem), "OnUpdate")]
+    internal static class IndustrialDemandDiagnosticsProbePatch
+    {
+        internal readonly struct OfficeResourceDemandEntry
+        {
+            public OfficeResourceDemandEntry(
+                Resource resource,
+                int resourceDemand,
+                int buildingDemand,
+                int companyDemand,
+                bool companyDemandKnown,
+                int freeProperties,
+                bool freePropertiesKnown)
+            {
+                Resource = resource;
+                ResourceDemand = resourceDemand;
+                BuildingDemand = buildingDemand;
+                CompanyDemand = companyDemand;
+                CompanyDemandKnown = companyDemandKnown;
+                FreeProperties = freeProperties;
+                FreePropertiesKnown = freePropertiesKnown;
+            }
+
+            public Resource Resource { get; }
+            public int ResourceDemand { get; }
+            public int BuildingDemand { get; }
+            public int CompanyDemand { get; }
+            public bool CompanyDemandKnown { get; }
+            public int FreeProperties { get; }
+            public bool FreePropertiesKnown { get; }
+        }
+
+        internal readonly struct OfficeDemandProbeSnapshot
+        {
+            public OfficeDemandProbeSnapshot(
+                bool captureAvailable,
+                bool captureComplete,
+                string captureStatus,
+                int simulationFrame,
+                OfficeResourceDemandEntry[] officeResources)
+            {
+                CaptureAvailable = captureAvailable;
+                CaptureComplete = captureComplete;
+                CaptureStatus = captureStatus ?? string.Empty;
+                SimulationFrame = simulationFrame;
+                OfficeResources = officeResources ?? Array.Empty<OfficeResourceDemandEntry>();
+            }
+
+            public bool CaptureAvailable { get; }
+            public bool CaptureComplete { get; }
+            public string CaptureStatus { get; }
+            public int SimulationFrame { get; }
+            public OfficeResourceDemandEntry[] OfficeResources { get; }
+        }
+
+        private static readonly object s_SnapshotLock = new object();
+        private static readonly FieldInfo s_IndustrialCompanyDemandsField =
+            AccessTools.Field(typeof(IndustrialDemandSystem), "m_IndustrialCompanyDemands");
+        private static readonly FieldInfo s_FreePropertiesField =
+            AccessTools.Field(typeof(IndustrialDemandSystem), "m_FreeProperties");
+
+        private static OfficeDemandProbeSnapshot s_LastSnapshot;
+        private static bool s_RuntimeFailureLogged;
+        private static Resource[] s_OfficeResources;
+
+        internal static bool TryGetLatestSnapshot(out OfficeDemandProbeSnapshot snapshot)
+        {
+            lock (s_SnapshotLock)
+            {
+                snapshot = s_LastSnapshot;
+                return snapshot.CaptureAvailable;
+            }
+        }
+
+        internal static void Reset()
+        {
+            lock (s_SnapshotLock)
+            {
+                s_LastSnapshot = default;
+            }
+
+            s_RuntimeFailureLogged = false;
+        }
+
+        private static void Postfix(IndustrialDemandSystem __instance)
+        {
+            if (Mod.Settings == null || !Mod.Settings.EnableDemandDiagnostics || !Mod.Settings.VerboseLogging)
+            {
+                return;
+            }
+
+            try
+            {
+                CaptureSnapshot(__instance);
+            }
+            catch (Exception ex)
+            {
+                if (s_RuntimeFailureLogged)
+                {
+                    return;
+                }
+
+                Mod.log.Error($"Industrial demand diagnostics probe failed while capturing office-demand internals. Continuing without the supplemental office-demand detail. {ex}");
+                s_RuntimeFailureLogged = true;
+            }
+        }
+
+        private static void CaptureSnapshot(IndustrialDemandSystem system)
+        {
+            NativeArray<int> resourceDemands = system.GetResourceDemands(out JobHandle resourceDemandDeps);
+            resourceDemandDeps.Complete();
+
+            NativeArray<int> buildingDemands = system.GetBuildingDemands(out JobHandle buildingDemandDeps);
+            buildingDemandDeps.Complete();
+
+            bool hasCompanyDemands = TryGetNativeArray(system, s_IndustrialCompanyDemandsField, out NativeArray<int> companyDemands);
+            bool hasFreeProperties = TryGetNativeArray(system, s_FreePropertiesField, out NativeArray<int> freeProperties);
+
+            Resource[] officeResources = GetOfficeResources();
+            OfficeResourceDemandEntry[] officeResourceEntries = new OfficeResourceDemandEntry[officeResources.Length];
+            for (int i = 0; i < officeResources.Length; i++)
+            {
+                Resource resource = officeResources[i];
+                int resourceIndex = EconomyUtils.GetResourceIndex(resource);
+                int resourceDemand = TryGetArrayValue(resourceDemands, resourceIndex, out int resourceDemandValue)
+                    ? resourceDemandValue
+                    : 0;
+                int buildingDemand = TryGetArrayValue(buildingDemands, resourceIndex, out int buildingDemandValue)
+                    ? buildingDemandValue
+                    : 0;
+                int companyDemandValue = 0;
+                bool companyDemandKnown = hasCompanyDemands && TryGetArrayValue(companyDemands, resourceIndex, out companyDemandValue);
+                int freePropertiesValue = 0;
+                bool freePropertiesKnown = hasFreeProperties && TryGetArrayValue(freeProperties, resourceIndex, out freePropertiesValue);
+                officeResourceEntries[i] = new OfficeResourceDemandEntry(
+                    resource,
+                    resourceDemand,
+                    buildingDemand,
+                    companyDemandKnown ? companyDemandValue : 0,
+                    companyDemandKnown,
+                    freePropertiesKnown ? freePropertiesValue : 0,
+                    freePropertiesKnown);
+            }
+
+            SimulationSystem simulationSystem = system.World?.GetExistingSystemManaged<SimulationSystem>();
+            int simulationFrame = simulationSystem != null ? (int)simulationSystem.frameIndex : -1;
+            bool captureComplete = hasCompanyDemands && hasFreeProperties;
+            string captureStatus = captureComplete
+                ? "ok"
+                : hasCompanyDemands || hasFreeProperties
+                    ? "partial_missing_private_field"
+                    : "missing_private_fields";
+
+            lock (s_SnapshotLock)
+            {
+                s_LastSnapshot = new OfficeDemandProbeSnapshot(
+                    captureAvailable: true,
+                    captureComplete: captureComplete,
+                    captureStatus: captureStatus,
+                    simulationFrame: simulationFrame,
+                    officeResources: officeResourceEntries);
+            }
+        }
+
+        private static bool TryGetNativeArray(IndustrialDemandSystem system, FieldInfo field, out NativeArray<int> value)
+        {
+            value = default;
+            if (field == null)
+            {
+                return false;
+            }
+
+            object fieldValue = field.GetValue(system);
+            if (fieldValue is not NativeArray<int> nativeArray)
+            {
+                return false;
+            }
+
+            value = nativeArray;
+            return nativeArray.IsCreated;
+        }
+
+        private static bool TryGetArrayValue(NativeArray<int> values, int index, out int value)
+        {
+            value = 0;
+            if (!values.IsCreated || index < 0 || index >= values.Length)
+            {
+                return false;
+            }
+
+            value = values[index];
+            return true;
+        }
+
+        private static Resource[] GetOfficeResources()
+        {
+            if (s_OfficeResources != null)
+            {
+                return s_OfficeResources;
+            }
+
+            List<Resource> officeResources = new List<Resource>();
+            Array resources = Enum.GetValues(typeof(Resource));
+            for (int i = 0; i < resources.Length; i++)
+            {
+                if (resources.GetValue(i) is not Resource resource || resource == Resource.NoResource)
+                {
+                    continue;
+                }
+
+                if (EconomyUtils.IsOfficeResource(resource))
+                {
+                    officeResources.Add(resource);
+                }
+            }
+
+            officeResources.Sort();
+            s_OfficeResources = officeResources.ToArray();
+            return s_OfficeResources;
+        }
+    }
+}

--- a/NoOfficeDemandFix/Patches/IndustrialDemandOfficeBaselinePatch.cs
+++ b/NoOfficeDemandFix/Patches/IndustrialDemandOfficeBaselinePatch.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using Game.Simulation;
 using HarmonyLib;
+using Unity.Collections;
 
 namespace NoOfficeDemandFix.Patches
 {
@@ -11,6 +12,33 @@ namespace NoOfficeDemandFix.Patches
     public static class IndustrialDemandOfficeBaselinePatch
     {
         private static bool s_ActivationLogged;
+        private static bool s_DebugSnapshotFailureLogged;
+        private static readonly FieldInfo s_FreePropertiesField = AccessTools.Field(typeof(IndustrialDemandSystem), "m_FreeProperties");
+        private static readonly FieldInfo s_LastOfficeBuildingDemandField = AccessTools.Field(typeof(IndustrialDemandSystem), "m_LastOfficeBuildingDemand");
+        private static readonly FieldInfo s_LastOfficeCompanyDemandField = AccessTools.Field(typeof(IndustrialDemandSystem), "m_LastOfficeCompanyDemand");
+
+        public readonly struct OfficeDemandDebugSnapshot
+        {
+            public OfficeDemandDebugSnapshot(
+                bool hasFreeProperties,
+                int[] freePropertiesByResource,
+                int lastOfficeCompanyDemand,
+                int lastOfficeBuildingDemand)
+            {
+                HasFreeProperties = hasFreeProperties;
+                FreePropertiesByResource = freePropertiesByResource ?? Array.Empty<int>();
+                LastOfficeCompanyDemand = lastOfficeCompanyDemand;
+                LastOfficeBuildingDemand = lastOfficeBuildingDemand;
+            }
+
+            public bool HasFreeProperties { get; }
+
+            public int[] FreePropertiesByResource { get; }
+
+            public int LastOfficeCompanyDemand { get; }
+
+            public int LastOfficeBuildingDemand { get; }
+        }
 
         public static bool Prepare()
         {
@@ -25,6 +53,43 @@ namespace NoOfficeDemandFix.Patches
             }
 
             return patchEnabled;
+        }
+
+        public static bool TryCaptureDebugSnapshot(IndustrialDemandSystem system, out OfficeDemandDebugSnapshot snapshot)
+        {
+            snapshot = default;
+            if (system == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                bool hasFreeProperties = false;
+                int[] freePropertiesByResource = Array.Empty<int>();
+                if (s_FreePropertiesField != null && s_FreePropertiesField.GetValue(system) is NativeArray<int> freeProperties && freeProperties.IsCreated)
+                {
+                    freePropertiesByResource = freeProperties.ToArray();
+                    hasFreeProperties = true;
+                }
+
+                snapshot = new OfficeDemandDebugSnapshot(
+                    hasFreeProperties,
+                    freePropertiesByResource,
+                    ReadIntField(s_LastOfficeCompanyDemandField, system, system.officeCompanyDemand),
+                    ReadIntField(s_LastOfficeBuildingDemandField, system, system.officeBuildingDemand));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (!s_DebugSnapshotFailureLogged)
+                {
+                    Mod.log.Error($"Industrial demand office debug snapshot capture failed. Continuing without private demand-field diagnostics. {ex}");
+                    s_DebugSnapshotFailureLogged = true;
+                }
+
+                return false;
+            }
         }
 
         public static MethodBase TargetMethod()
@@ -64,5 +129,16 @@ namespace NoOfficeDemandFix.Patches
                 Mod.log.Error("Industrial demand office baseline direct patch did not find the expected 1.5f constant in IndustrialDemandSystem.UpdateIndustrialDemandJob.Execute.");
             }
         }
+
+        private static int ReadIntField(FieldInfo field, object instance, int fallback)
+        {
+            if (field == null)
+            {
+                return fallback;
+            }
+
+            return field.GetValue(instance) is int value ? value : fallback;
+        }
     }
+
 }

--- a/NoOfficeDemandFix/Patches/OutsideConnectionVirtualSellerFixPatch.cs
+++ b/NoOfficeDemandFix/Patches/OutsideConnectionVirtualSellerFixPatch.cs
@@ -48,6 +48,7 @@ namespace NoOfficeDemandFix.Patches
         private static int s_TotalInactiveOutsideConnections;
         private static int s_ProbeSampleLogsEmitted;
         private static readonly HashSet<Resource> s_ObservedRequestedResourcesPrefilter = new HashSet<Resource>();
+        private static readonly Dictionary<Entity, OfficeImportProbeSnapshot> s_LastOfficeImportProbeSnapshots = new Dictionary<Entity, OfficeImportProbeSnapshot>();
         private static EntityQuery s_OutsideConnectionSellerQuery;
         private static World s_OutsideConnectionSellerQueryWorld;
 
@@ -87,6 +88,86 @@ namespace NoOfficeDemandFix.Patches
             public int MissingStoredResourcePairs { get; }
             public int InactiveOutsideConnections { get; }
             public string RequestedResourcesPrefilter { get; }
+        }
+
+        public readonly struct OfficeImportProbeSnapshot
+        {
+            public OfficeImportProbeSnapshot(
+                int simulationFrame,
+                Resource resource,
+                int requestedAmount,
+                int totalOutsideConnectionSellers,
+                int missingStoredResourcePairs,
+                int inactiveOutsideConnections,
+                int availableCandidateCount,
+                int zeroOrNegativeStockSellerCount,
+                int topAvailableStock,
+                bool appendedOutsideConnectionCandidates)
+            {
+                SimulationFrame = simulationFrame;
+                Resource = resource;
+                RequestedAmount = requestedAmount;
+                TotalOutsideConnectionSellers = totalOutsideConnectionSellers;
+                MissingStoredResourcePairs = missingStoredResourcePairs;
+                InactiveOutsideConnections = inactiveOutsideConnections;
+                AvailableCandidateCount = availableCandidateCount;
+                ZeroOrNegativeStockSellerCount = zeroOrNegativeStockSellerCount;
+                TopAvailableStock = topAvailableStock;
+                AppendedOutsideConnectionCandidates = appendedOutsideConnectionCandidates;
+            }
+
+            public int SimulationFrame { get; }
+            public Resource Resource { get; }
+            public int RequestedAmount { get; }
+            public int TotalOutsideConnectionSellers { get; }
+            public int MissingStoredResourcePairs { get; }
+            public int InactiveOutsideConnections { get; }
+            public int AvailableCandidateCount { get; }
+            public int ZeroOrNegativeStockSellerCount { get; }
+            public int TopAvailableStock { get; }
+            public bool AppendedOutsideConnectionCandidates { get; }
+        }
+
+        private readonly struct SoftwareOutsideConnectionProbeAggregate
+        {
+            public SoftwareOutsideConnectionProbeAggregate(
+                int totalOutsideConnectionSellers,
+                int missingStoredResourcePairs,
+                int inactiveOutsideConnections,
+                int availableCandidateCount,
+                int zeroOrNegativeStockSellerCount,
+                int topAvailableStock)
+            {
+                TotalOutsideConnectionSellers = totalOutsideConnectionSellers;
+                MissingStoredResourcePairs = missingStoredResourcePairs;
+                InactiveOutsideConnections = inactiveOutsideConnections;
+                AvailableCandidateCount = availableCandidateCount;
+                ZeroOrNegativeStockSellerCount = zeroOrNegativeStockSellerCount;
+                TopAvailableStock = topAvailableStock;
+            }
+
+            public int TotalOutsideConnectionSellers { get; }
+            public int MissingStoredResourcePairs { get; }
+            public int InactiveOutsideConnections { get; }
+            public int AvailableCandidateCount { get; }
+            public int ZeroOrNegativeStockSellerCount { get; }
+            public int TopAvailableStock { get; }
+        }
+
+        public static bool TryGetLatestOfficeImportProbeSnapshot(Entity seekerEntity, Resource resource, out OfficeImportProbeSnapshot snapshot)
+        {
+            if (resource != Resource.Software)
+            {
+                snapshot = default;
+                return false;
+            }
+
+            return s_LastOfficeImportProbeSnapshots.TryGetValue(seekerEntity, out snapshot);
+        }
+
+        public static void ResetDetailedRequestProbes()
+        {
+            s_LastOfficeImportProbeSnapshots.Clear();
         }
 
         public static MethodBase TargetMethod()
@@ -190,6 +271,7 @@ namespace NoOfficeDemandFix.Patches
             s_TotalInactiveOutsideConnections = 0;
             s_ProbeSampleLogsEmitted = 0;
             s_ObservedRequestedResourcesPrefilter.Clear();
+            s_LastOfficeImportProbeSnapshots.Clear();
         }
 
         private static int CountOfficeImportCandidatesPrefilter(in PathfindSetupSystem.SetupData setupData)
@@ -245,6 +327,7 @@ namespace NoOfficeDemandFix.Patches
             }
 
             appendedRequestCount = officeImportRequests.Length;
+            MaybeCaptureDetailedRequestProbes(system, officeImportRequests, requestedResources, resourceRequestRanges);
 
             JobHandle jobHandle = new AppendOutsideConnectionOfficeImportTargetsJob
             {
@@ -463,6 +546,191 @@ namespace NoOfficeDemandFix.Patches
                 missingStoredResourcePairs,
                 inactiveOutsideConnections,
                 FormatResourceSet(requestedResourcesPrefilter));
+        }
+
+        private static void MaybeCaptureDetailedRequestProbes(
+            PathfindSetupSystem system,
+            NativeArray<OfficeImportRequest> officeImportRequests,
+            NativeArray<Resource> requestedResources,
+            NativeArray<ResourceRequestRange> resourceRequestRanges)
+        {
+            if (Mod.Settings == null || !Mod.Settings.EnableDemandDiagnostics || !Mod.Settings.VerboseLogging)
+            {
+                return;
+            }
+
+            int softwareResourceIndex = -1;
+            for (int i = 0; i < requestedResources.Length; i++)
+            {
+                if (requestedResources[i] == Resource.Software)
+                {
+                    softwareResourceIndex = i;
+                    break;
+                }
+            }
+
+            if (softwareResourceIndex < 0)
+            {
+                return;
+            }
+
+            ResourceRequestRange requestRange = resourceRequestRanges[softwareResourceIndex];
+            if (requestRange.Count <= 0)
+            {
+                return;
+            }
+
+            SimulationSystem simulationSystem = system.World?.GetExistingSystemManaged<SimulationSystem>();
+            int simulationFrame = simulationSystem != null ? (int)simulationSystem.frameIndex : -1;
+            SoftwareOutsideConnectionProbeAggregate aggregate = CaptureSoftwareOutsideConnectionProbeAggregate(system);
+            for (int requestOffset = 0; requestOffset < requestRange.Count; requestOffset++)
+            {
+                OfficeImportRequest request = officeImportRequests[requestRange.StartIndex + requestOffset];
+                s_LastOfficeImportProbeSnapshots[request.SeekerEntity] = new OfficeImportProbeSnapshot(
+                    simulationFrame,
+                    Resource.Software,
+                    request.RequestedAmount,
+                    aggregate.TotalOutsideConnectionSellers,
+                    aggregate.MissingStoredResourcePairs,
+                    aggregate.InactiveOutsideConnections,
+                    aggregate.AvailableCandidateCount,
+                    aggregate.ZeroOrNegativeStockSellerCount,
+                    aggregate.TopAvailableStock,
+                    aggregate.AvailableCandidateCount > 0);
+            }
+        }
+
+        private static SoftwareOutsideConnectionProbeAggregate CaptureSoftwareOutsideConnectionProbeAggregate(PathfindSetupSystem system)
+        {
+            EntityQuery query = GetOutsideConnectionSellerQuery(system);
+            if (query.IsEmptyIgnoreFilter)
+            {
+                return default;
+            }
+
+            EntityManager entityManager = system.EntityManager;
+            int totalOutsideConnectionSellers = 0;
+            int missingStoredResourcePairs = 0;
+            int inactiveOutsideConnections = 0;
+            int availableCandidateCount = 0;
+            int zeroOrNegativeStockSellerCount = 0;
+            int topAvailableStock = 0;
+
+            using NativeArray<Entity> sellerEntities = query.ToEntityArray(Allocator.Temp);
+            using NativeArray<PrefabRef> sellerPrefabs = query.ToComponentDataArray<PrefabRef>(Allocator.Temp);
+            for (int entityIndex = 0; entityIndex < sellerEntities.Length; entityIndex++)
+            {
+                Entity sellerEntity = sellerEntities[entityIndex];
+                totalOutsideConnectionSellers++;
+
+                if (entityManager.HasComponent<BuildingComponent>(sellerEntity) &&
+                    BuildingUtils.CheckOption(entityManager.GetComponentData<BuildingComponent>(sellerEntity), BuildingOption.Inactive))
+                {
+                    inactiveOutsideConnections++;
+                    continue;
+                }
+
+                Entity prefab = sellerPrefabs[entityIndex].m_Prefab;
+                if (!entityManager.HasComponent<StorageCompanyData>(prefab))
+                {
+                    continue;
+                }
+
+                StorageCompanyData storageCompanyData = entityManager.GetComponentData<StorageCompanyData>(prefab);
+                if ((storageCompanyData.m_StoredResources & Resource.Software) != Resource.NoResource)
+                {
+                    continue;
+                }
+
+                missingStoredResourcePairs++;
+
+                if (!entityManager.HasBuffer<Game.Economy.Resources>(sellerEntity))
+                {
+                    zeroOrNegativeStockSellerCount++;
+                    continue;
+                }
+
+                int stock = EconomyUtils.GetResources(Resource.Software, entityManager.GetBuffer<Game.Economy.Resources>(sellerEntity, isReadOnly: true));
+                int buyingLoad = GetBuyingTruckLoad(entityManager, sellerEntity, Resource.Software);
+                int availableAmount = stock - buyingLoad;
+                if (availableAmount > 0)
+                {
+                    availableCandidateCount++;
+                    topAvailableStock = Math.Max(topAvailableStock, availableAmount);
+                }
+                else
+                {
+                    zeroOrNegativeStockSellerCount++;
+                }
+            }
+
+            return new SoftwareOutsideConnectionProbeAggregate(
+                totalOutsideConnectionSellers,
+                missingStoredResourcePairs,
+                inactiveOutsideConnections,
+                availableCandidateCount,
+                zeroOrNegativeStockSellerCount,
+                topAvailableStock);
+        }
+
+        private static int GetBuyingTruckLoad(EntityManager entityManager, Entity sellerEntity, Resource resource)
+        {
+            int amount = 0;
+            if (!entityManager.HasBuffer<GuestVehicle>(sellerEntity))
+            {
+                return amount;
+            }
+
+            DynamicBuffer<GuestVehicle> guestVehicles = entityManager.GetBuffer<GuestVehicle>(sellerEntity, isReadOnly: true);
+            for (int i = 0; i < guestVehicles.Length; i++)
+            {
+                amount += GetVehicleBuyingLoad(entityManager, guestVehicles[i].m_Vehicle, resource);
+            }
+
+            return amount;
+        }
+
+        private static int GetVehicleBuyingLoad(EntityManager entityManager, Entity vehicle, Resource resource)
+        {
+            if (!entityManager.HasComponent<DeliveryTruckComponent>(vehicle))
+            {
+                return 0;
+            }
+
+            int amount = 0;
+            DeliveryTruckComponent truck = entityManager.GetComponentData<DeliveryTruckComponent>(vehicle);
+            if (truck.m_Resource == resource && (truck.m_State & DeliveryTruckFlags.Buying) != 0)
+            {
+                amount += truck.m_Amount;
+            }
+
+            if (!entityManager.HasBuffer<LayoutElement>(vehicle))
+            {
+                return amount;
+            }
+
+            DynamicBuffer<LayoutElement> layout = entityManager.GetBuffer<LayoutElement>(vehicle, isReadOnly: true);
+            for (int i = 0; i < layout.Length; i++)
+            {
+                Entity layoutVehicle = layout[i].m_Vehicle;
+                if (layoutVehicle == vehicle)
+                {
+                    continue;
+                }
+
+                if (!entityManager.HasComponent<DeliveryTruckComponent>(layoutVehicle))
+                {
+                    continue;
+                }
+
+                DeliveryTruckComponent layoutTruck = entityManager.GetComponentData<DeliveryTruckComponent>(layoutVehicle);
+                if (layoutTruck.m_Resource == resource && (layoutTruck.m_State & DeliveryTruckFlags.Buying) != 0)
+                {
+                    amount += layoutTruck.m_Amount;
+                }
+            }
+
+            return amount;
         }
 
         private static EntityQuery GetOutsideConnectionSellerQuery(PathfindSetupSystem system)

--- a/NoOfficeDemandFix/Setting.cs
+++ b/NoOfficeDemandFix/Setting.cs
@@ -109,7 +109,7 @@ namespace NoOfficeDemandFix
                 { m_Setting.GetOptionDescLocaleID(nameof(Setting.EnableOutsideConnectionVirtualSellerFix)), "Experimental software import seller correction. Takes effect on the next game launch by letting office virtual-resource imports consider outside connections in a narrow fallback case. It does not modify cargo or storage definitions." },
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.EnableVirtualOfficeResourceBuyerFix)), "Enable software import buyer timing correction" },
-                { m_Setting.GetOptionDescLocaleID(nameof(Setting.EnableVirtualOfficeResourceBuyerFix)), "Experimental software import buyer timing correction. Adds a narrow fallback ResourceBuyer for zero-weight office inputs when a company is below the vanilla low-stock threshold but no buyer, path, trip, or current trading state exists yet." },
+                { m_Setting.GetOptionDescLocaleID(nameof(Setting.EnableVirtualOfficeResourceBuyerFix)), "Experimental software import buyer timing correction. Adds a narrow fallback ResourceBuyer for zero-weight office inputs when a company is below the vanilla low-stock threshold but no buyer, path, trip, or same-resource current trading state exists yet." },
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.EnableOfficeDemandDirectPatch)), "Restore pre-1.5.6f1 office demand baseline" },
                 { m_Setting.GetOptionDescLocaleID(nameof(Setting.EnableOfficeDemandDirectPatch)), "The 1.5.6f1 hotfix raises office demand by increasing the office resource-demand baseline inside IndustrialDemandSystem. Turn this on before launch when you need the pre-hotfix baseline for like-for-like comparisons, and consistent behavior across runs." },

--- a/NoOfficeDemandFix/Systems/OfficeDemandDiagnosticsSystem.cs
+++ b/NoOfficeDemandFix/Systems/OfficeDemandDiagnosticsSystem.cs
@@ -17,6 +17,7 @@ using Game.Simulation;
 using Game.Tools;
 using Game.Vehicles;
 using Game.Zones;
+using NoOfficeDemandFix.Patches;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
@@ -36,8 +37,12 @@ namespace NoOfficeDemandFix.Systems
         private const int kMaxDiagnosticsSamplesPerDay = 8;
         private const int kDiagnosticsDisabledPollInterval = 8;
         private const float kNotificationCostLimit = 5f;
+        private const uint kVanillaBuyerUpdateInterval = 256u;
+        private const int kVanillaBuyerUpdateGroupCount = 16;
         private const int kResourceLowStockAmount = 4000;
         private const int kResourceMinimumRequestAmount = 2000;
+        private const string kCompactDetailFormatVersion = "compact_v2";
+        private const string kVerboseDetailPrefix = "softwareEvidenceVerbose detail(";
         private const string kTraceNeedNotSelected = "need_not_selected";
         private const string kTraceSelectedNoResourceBuyer = "selected_no_resource_buyer";
         private const string kTraceSelectedResourceBuyerNoPath = "selected_resource_buyer_no_path";
@@ -48,7 +53,6 @@ namespace NoOfficeDemandFix.Systems
         private const string kTraceSelectedCurrentTradingPresent = "selected_current_trading_present";
         private const string kTraceNeedCleared = "need_cleared";
         private const string kTraceTransitionUnobserved = "unobserved";
-
         private struct FactorEntry
         {
             public int Index;
@@ -144,6 +148,8 @@ namespace NoOfficeDemandFix.Systems
             public int OfficeCompanyDemand;
             public int EmptyBuildingsFactor;
             public int BuildingDemandFactor;
+            public int LocalDemandFactor;
+            public bool LocalDemandFactorKnown;
             public int FreeOfficeProperties;
             public int FreeSoftwareOfficeProperties;
             public int FreeOfficePropertiesInOccupiedBuildings;
@@ -162,6 +168,21 @@ namespace NoOfficeDemandFix.Systems
             public int SoftwareDemand;
             public int SoftwareProductionCompanies;
             public int SoftwarePropertylessCompanies;
+            public int SoftwareTotalSellableInCity;
+            public int SoftwareIndustrialConsumption;
+            public int SoftwareIndustrialConsumptionAccumulator;
+            public int SoftwareLocalSellerCount;
+            public int SoftwareLocalSellerInactiveExcludedCount;
+            public int SoftwareLocalSellerStock;
+            public int SoftwareLocalSellerBuyingLoad;
+            public int SoftwareLocalSellerAvailableStockNet;
+            public int SoftwareLocalSellerPositiveAvailableStock;
+            public int SoftwareLocalSellerPositiveAvailableCount;
+            public int SoftwareLocalSellerNonPositiveAvailableCount;
+            public int SoftwareLocalSellerEligibleCount;
+            public int SoftwareLocalSellerEligibleAtFullRequestCount;
+            public int SoftwareLocalSellerEligibleAvailableStock;
+            public int SoftwareLocalSellerMaxAvailableStock;
             public int ElectronicsProduction;
             public int ElectronicsDemand;
             public int ElectronicsProductionCompanies;
@@ -187,6 +208,9 @@ namespace NoOfficeDemandFix.Systems
             public int SoftwareConsumerCurrentTradingPresent;
             public int SoftwareConsumerSelectedNoBuyerShortGap;
             public int SoftwareConsumerSelectedNoBuyerPersistent;
+            public int SoftwareConsumerSelectedNoBuyerMissedVanillaPass;
+            public int SoftwareConsumerSelectedNoBuyerMissedMultipleVanillaPasses;
+            public int SoftwareConsumerSelectedNoBuyerMaxMissedVanillaPasses;
             public int SoftwareConsumerSelectedRequestNoPathShortGap;
             public int SoftwareConsumerSelectedRequestNoPathPersistent;
             public int SoftwareConsumerVirtualResolvedThisWindow;
@@ -197,9 +221,11 @@ namespace NoOfficeDemandFix.Systems
             public string FreeSoftwareOfficePropertyDetails;
             public string OnMarketOfficePropertyDetails;
             public string SoftwareOfficeDetails;
+            public string OfficeDemandInternalsDetails;
             public string SoftwareTradeLifecycleDetails;
             public string SoftwareVirtualResolutionProbeDetails;
             public string SoftwareBuyerTimingProbeDetails;
+            public string SoftwareSellerResolutionProbeDetails;
             public ObservationDetailCapture DetailCapture;
         }
 
@@ -267,6 +293,10 @@ namespace NoOfficeDemandFix.Systems
             public bool BuyerSeenThisWindow;
             public int LastBuyerSeenSampleAge;
             public string NoBuyerReason;
+            public int CompanyUpdateFrame;
+            public int CurrentVanillaBuyerUpdateFrame;
+            public int FramesUntilNextVanillaBuyerPass;
+            public int EstimatedMissedVanillaBuyerPasses;
             public int SelectedNoBuyerConsecutiveWindows;
             public int SelectedRequestNoPathConsecutiveWindows;
             public int BelowThresholdConsecutiveWindows;
@@ -302,7 +332,10 @@ namespace NoOfficeDemandFix.Systems
             public bool HasLastPathSeenSampleIndex;
             public int LastVirtualResolutionSampleIndex;
             public bool HasLastVirtualResolutionSampleIndex;
+            public uint LastObservedSimulationFrame;
+            public bool HasLastObservedSimulationFrame;
             public int SelectedNoBuyerConsecutiveWindows;
+            public int SelectedNoBuyerEstimatedMissedVanillaPasses;
             public int SelectedRequestNoPathConsecutiveWindows;
             public int BelowThresholdConsecutiveWindows;
         }
@@ -387,6 +420,71 @@ namespace NoOfficeDemandFix.Systems
             public SoftwareConsumerDiagnosticState SoftwareConsumerState;
         }
 
+        private readonly struct SoftwareOfficeDetailGroupKey : IEquatable<SoftwareOfficeDetailGroupKey>
+        {
+            public SoftwareOfficeDetailGroupKey(
+                Entity prefab,
+                bool isProducer,
+                bool isConsumer,
+                string classification,
+                bool softwareInputZero,
+                bool efficiencyZero,
+                bool lackResourcesZero)
+            {
+                Prefab = prefab;
+                IsProducer = isProducer;
+                IsConsumer = isConsumer;
+                Classification = classification ?? string.Empty;
+                SoftwareInputZero = softwareInputZero;
+                EfficiencyZero = efficiencyZero;
+                LackResourcesZero = lackResourcesZero;
+            }
+
+            public Entity Prefab { get; }
+            public bool IsProducer { get; }
+            public bool IsConsumer { get; }
+            public string Classification { get; }
+            public bool SoftwareInputZero { get; }
+            public bool EfficiencyZero { get; }
+            public bool LackResourcesZero { get; }
+
+            public bool Equals(SoftwareOfficeDetailGroupKey other)
+            {
+                return Prefab.Equals(other.Prefab) &&
+                       IsProducer == other.IsProducer &&
+                       IsConsumer == other.IsConsumer &&
+                       string.Equals(Classification, other.Classification, StringComparison.Ordinal) &&
+                       SoftwareInputZero == other.SoftwareInputZero &&
+                       EfficiencyZero == other.EfficiencyZero &&
+                       LackResourcesZero == other.LackResourcesZero;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is SoftwareOfficeDetailGroupKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(
+                    Prefab,
+                    IsProducer,
+                    IsConsumer,
+                    Classification,
+                    SoftwareInputZero,
+                    EfficiencyZero,
+                    LackResourcesZero);
+            }
+        }
+
+        private struct SoftwareOfficeDetailGroup
+        {
+            public SoftwareOfficeDetailGroupKey Key;
+            public SoftwareOfficeDetailCandidate Representative;
+            public int Count;
+            public int Priority;
+        }
+
         private struct SoftwareTradeLifecycleDetailCandidate
         {
             public Entity Company;
@@ -417,19 +515,37 @@ namespace NoOfficeDemandFix.Systems
             public bool HasEfficiency;
             public float Efficiency;
             public float LackResources;
+            public int Priority;
+            public SoftwareConsumerDiagnosticState SoftwareConsumerState;
+        }
+
+        private struct SoftwareSellerResolutionProbeDetailCandidate
+        {
+            public Entity Company;
+            public Entity CompanyPrefab;
+            public Entity Property;
+            public IndustrialProcessData ProcessData;
+            public bool HasEfficiency;
+            public float Efficiency;
+            public float LackResources;
+            public int Priority;
             public SoftwareConsumerDiagnosticState SoftwareConsumerState;
         }
 
         private sealed class ObservationDetailCapture
         {
-            public readonly List<SoftwareOfficeDetailCandidate> SoftwareOfficeDetailCandidates =
-                new List<SoftwareOfficeDetailCandidate>(kMaxDetailEntries);
+            public readonly List<SoftwareOfficeDetailGroup> SoftwareOfficeDetailGroups =
+                new List<SoftwareOfficeDetailGroup>(kMaxDetailEntries);
+            public readonly Dictionary<SoftwareOfficeDetailGroupKey, int> SoftwareOfficeDetailGroupIndices =
+                new Dictionary<SoftwareOfficeDetailGroupKey, int>(kMaxDetailEntries);
             public readonly List<SoftwareTradeLifecycleDetailCandidate> SoftwareTradeLifecycleDetailCandidates =
                 new List<SoftwareTradeLifecycleDetailCandidate>(kMaxDetailEntries);
             public readonly List<SoftwareVirtualResolutionProbeDetailCandidate> SoftwareVirtualResolutionProbeDetailCandidates =
                 new List<SoftwareVirtualResolutionProbeDetailCandidate>(kMaxDetailEntries);
             public readonly List<SoftwareBuyerTimingProbeDetailCandidate> SoftwareBuyerTimingProbeDetailCandidates =
                 new List<SoftwareBuyerTimingProbeDetailCandidate>(kMaxDetailEntries);
+            public readonly List<SoftwareSellerResolutionProbeDetailCandidate> SoftwareSellerResolutionProbeDetailCandidates =
+                new List<SoftwareSellerResolutionProbeDetailCandidate>(kMaxDetailEntries);
         }
 
         [BurstCompile]
@@ -719,6 +835,7 @@ namespace NoOfficeDemandFix.Systems
         private TimeSystem m_TimeSystem;
         private IndustrialDemandSystem m_IndustrialDemandSystem;
         private CountCompanyDataSystem m_CountCompanyDataSystem;
+        private CityProductionStatisticSystem m_CityProductionStatisticSystem;
         private SignaturePropertyMarketGuardSystem m_SignaturePropertyMarketGuardSystem;
         private PrefabSystem m_PrefabSystem;
         private ResourceSystem m_ResourceSystem;
@@ -753,6 +870,7 @@ namespace NoOfficeDemandFix.Systems
             m_TimeSystem = World.GetOrCreateSystemManaged<TimeSystem>();
             m_IndustrialDemandSystem = World.GetOrCreateSystemManaged<IndustrialDemandSystem>();
             m_CountCompanyDataSystem = World.GetOrCreateSystemManaged<CountCompanyDataSystem>();
+            m_CityProductionStatisticSystem = World.GetOrCreateSystemManaged<CityProductionStatisticSystem>();
             m_SignaturePropertyMarketGuardSystem = World.GetOrCreateSystemManaged<SignaturePropertyMarketGuardSystem>();
             m_PrefabSystem = World.GetOrCreateSystemManaged<PrefabSystem>();
             m_ResourceSystem = World.GetOrCreateSystemManaged<ResourceSystem>();
@@ -943,6 +1061,18 @@ namespace NoOfficeDemandFix.Systems
                     FormatDiagnosticCounters(snapshot),
                     snapshot.TopFactors));
 
+            if (!string.IsNullOrEmpty(snapshot.OfficeDemandInternalsDetails))
+            {
+                Mod.log.Info(
+                    MachineParsedLogContract.FormatDetail(
+                        m_SessionId,
+                        m_RunSequence,
+                        snapshot.Day,
+                        snapshot.SampleIndex,
+                        MachineParsedLogContract.OfficeDemandInternalsDetailType,
+                        snapshot.OfficeDemandInternalsDetails));
+            }
+
             if (!string.IsNullOrEmpty(snapshot.FreeSoftwareOfficePropertyDetails))
             {
                 Mod.log.Info(
@@ -1003,6 +1133,18 @@ namespace NoOfficeDemandFix.Systems
                         snapshot.SoftwareVirtualResolutionProbeDetails));
             }
 
+            if (!string.IsNullOrEmpty(snapshot.SoftwareSellerResolutionProbeDetails))
+            {
+                Mod.log.Info(
+                    MachineParsedLogContract.FormatDetail(
+                        m_SessionId,
+                        m_RunSequence,
+                        snapshot.Day,
+                        snapshot.SampleIndex,
+                        MachineParsedLogContract.SoftwareSellerResolutionProbeDetailType,
+                        snapshot.SoftwareSellerResolutionProbeDetails));
+            }
+
             if (!string.IsNullOrEmpty(snapshot.SoftwareBuyerTimingProbeDetails))
             {
                 Mod.log.Info(
@@ -1015,7 +1157,13 @@ namespace NoOfficeDemandFix.Systems
                         snapshot.SoftwareBuyerTimingProbeDetails));
             }
 
+            if (settingsState.VerboseLogging)
+            {
+                EmitVerboseObservationDetails(snapshot);
+            }
+
             EmitVirtualOfficeBuyerProbeSummary(snapshot);
+            OutsideConnectionVirtualSellerFixPatch.ResetDetailedRequestProbes();
 
             m_RunObservationCount = sampleCount;
             m_LastObservedSampleIndex = snapshot.SampleIndex;
@@ -1035,10 +1183,18 @@ namespace NoOfficeDemandFix.Systems
 
             JobHandle companyDeps;
             CountCompanyDataSystem.IndustrialCompanyDatas industrialCompanyDatas = m_CountCompanyDataSystem.GetIndustrialCompanyDatas(out companyDeps);
-            companyDeps.Complete();
+            NativeArray<int> totalSellableInCity = m_CountCompanyDataSystem.GetTotalSellableInCity(out JobHandle totalSellableDeps);
+            JobHandle.CombineDependencies(companyDeps, totalSellableDeps).Complete();
+
+            JobHandle cityUsageDeps;
+            NativeArray<int> industrialUsageAccumulator = m_CityProductionStatisticSystem.GetCityResourceUsageAccumulator(
+                CityProductionStatisticSystem.CityResourceUsage.Consumer.Industrial,
+                out cityUsageDeps);
+            cityUsageDeps.Complete();
 
             int softwareIndex = EconomyUtils.GetResourceIndex(Resource.Software);
             int electronicsIndex = EconomyUtils.GetResourceIndex(Resource.Electronics);
+            bool localDemandFactorKnown = TryGetDemandFactorValue(officeFactors, "LocalDemand", out int localDemandFactor);
             DiagnosticSnapshot snapshot = new DiagnosticSnapshot
             {
                 Day = day,
@@ -1050,10 +1206,17 @@ namespace NoOfficeDemandFix.Systems
                 OfficeCompanyDemand = m_IndustrialDemandSystem.officeCompanyDemand,
                 EmptyBuildingsFactor = officeFactors[(int)DemandFactor.EmptyBuildings],
                 BuildingDemandFactor = officeFactors[(int)DemandFactor.BuildingDemand],
+                LocalDemandFactor = localDemandFactor,
+                LocalDemandFactorKnown = localDemandFactorKnown,
                 SoftwareProduction = industrialCompanyDatas.m_Production[softwareIndex],
                 SoftwareDemand = industrialCompanyDatas.m_Demand[softwareIndex],
                 SoftwareProductionCompanies = industrialCompanyDatas.m_ProductionCompanies[softwareIndex],
                 SoftwarePropertylessCompanies = industrialCompanyDatas.m_ProductionPropertyless[softwareIndex],
+                SoftwareTotalSellableInCity = totalSellableInCity[softwareIndex],
+                SoftwareIndustrialConsumption = m_CityProductionStatisticSystem.GetCityResourceUsages(
+                    CityProductionStatisticSystem.CityResourceUsage.Consumer.Industrial,
+                    Resource.Software),
+                SoftwareIndustrialConsumptionAccumulator = industrialUsageAccumulator[softwareIndex],
                 ElectronicsProduction = industrialCompanyDatas.m_Production[electronicsIndex],
                 ElectronicsDemand = industrialCompanyDatas.m_Demand[electronicsIndex],
                 ElectronicsProductionCompanies = industrialCompanyDatas.m_ProductionCompanies[electronicsIndex],
@@ -1078,15 +1241,19 @@ namespace NoOfficeDemandFix.Systems
 
             if (!verboseLogging)
             {
+                snapshot.OfficeDemandInternalsDetails = string.Empty;
                 snapshot.SoftwareTradeLifecycleDetails = string.Empty;
                 snapshot.SoftwareVirtualResolutionProbeDetails = string.Empty;
                 snapshot.SoftwareBuyerTimingProbeDetails = string.Empty;
+                snapshot.SoftwareSellerResolutionProbeDetails = string.Empty;
                 return;
             }
 
+            snapshot.OfficeDemandInternalsDetails = RenderOfficeDemandInternalsDetails(snapshot);
             snapshot.SoftwareTradeLifecycleDetails = RenderSoftwareTradeLifecycleDetails(snapshot.DetailCapture);
             snapshot.SoftwareVirtualResolutionProbeDetails = RenderSoftwareVirtualResolutionProbeDetails(snapshot.DetailCapture);
             snapshot.SoftwareBuyerTimingProbeDetails = RenderSoftwareBuyerTimingProbeDetails(snapshot.DetailCapture);
+            snapshot.SoftwareSellerResolutionProbeDetails = RenderSoftwareSellerResolutionProbeDetails(snapshot.DetailCapture);
         }
 
         private void CountFreeOfficeProperties(ref DiagnosticSnapshot snapshot)
@@ -1254,8 +1421,50 @@ namespace NoOfficeDemandFix.Systems
                     continue;
                 }
 
+                bool sellerInactive = EntityManager.HasComponent<Building>(propertyRenter.m_Property) &&
+                                      BuildingUtils.CheckOption(EntityManager.GetComponentData<Building>(propertyRenter.m_Property), BuildingOption.Inactive);
+
                 int softwareInputStock = isConsumer ? GetCompanyResourceAmount(company, Resource.Software) : 0;
                 SoftwareConsumerDiagnosticState softwareConsumerState = default;
+                if (isProducer)
+                {
+                    if (sellerInactive)
+                    {
+                        snapshot.SoftwareLocalSellerInactiveExcludedCount++;
+                    }
+                    else
+                    {
+                        int outputStock = GetCompanyResourceAmount(company, processData.m_Output.m_Resource);
+                        int buyingLoad = GetCompanyBuyingLoad(company, processData.m_Output.m_Resource);
+                        int availableStock = outputStock - buyingLoad;
+                        snapshot.SoftwareLocalSellerCount++;
+                        snapshot.SoftwareLocalSellerStock += outputStock;
+                        snapshot.SoftwareLocalSellerBuyingLoad += buyingLoad;
+                        snapshot.SoftwareLocalSellerAvailableStockNet += availableStock;
+                        snapshot.SoftwareLocalSellerMaxAvailableStock = Math.Max(snapshot.SoftwareLocalSellerMaxAvailableStock, availableStock);
+                        if (availableStock > 0)
+                        {
+                            snapshot.SoftwareLocalSellerPositiveAvailableCount++;
+                            snapshot.SoftwareLocalSellerPositiveAvailableStock += availableStock;
+                        }
+                        else
+                        {
+                            snapshot.SoftwareLocalSellerNonPositiveAvailableCount++;
+                        }
+
+                        if (availableStock >= kResourceMinimumRequestAmount)
+                        {
+                            snapshot.SoftwareLocalSellerEligibleCount++;
+                            snapshot.SoftwareLocalSellerEligibleAvailableStock += availableStock;
+                        }
+
+                        if (availableStock >= kResourceLowStockAmount)
+                        {
+                            snapshot.SoftwareLocalSellerEligibleAtFullRequestCount++;
+                        }
+                    }
+                }
+
                 if (isConsumer)
                 {
                     softwareConsumerState = GetSoftwareConsumerDiagnosticState(company, prefabMetadata, snapshot.Day, snapshot.SampleIndex);
@@ -1315,6 +1524,20 @@ namespace NoOfficeDemandFix.Systems
                         {
                             snapshot.SoftwareConsumerSelectedNoBuyerShortGap++;
                         }
+
+                        if (softwareConsumerState.Acquisition.EstimatedMissedVanillaBuyerPasses >= 1)
+                        {
+                            snapshot.SoftwareConsumerSelectedNoBuyerMissedVanillaPass++;
+                        }
+
+                        if (softwareConsumerState.Acquisition.EstimatedMissedVanillaBuyerPasses >= 2)
+                        {
+                            snapshot.SoftwareConsumerSelectedNoBuyerMissedMultipleVanillaPasses++;
+                        }
+
+                        snapshot.SoftwareConsumerSelectedNoBuyerMaxMissedVanillaPasses = Math.Max(
+                            snapshot.SoftwareConsumerSelectedNoBuyerMaxMissedVanillaPasses,
+                            softwareConsumerState.Acquisition.EstimatedMissedVanillaBuyerPasses);
                     }
 
                     if (string.Equals(softwareConsumerState.Trace.CurrentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal))
@@ -1394,8 +1617,8 @@ namespace NoOfficeDemandFix.Systems
                     (isConsumer && ShouldCaptureConsumerOfficeDetail(softwareConsumerState)))
                 {
                     EnsureObservationDetailCapture(ref snapshot, ref detailCapture);
-                    TryAddCandidate(
-                        detailCapture.SoftwareOfficeDetailCandidates,
+                    AddSoftwareOfficeDetailCandidate(
+                        detailCapture,
                         new SoftwareOfficeDetailCandidate
                         {
                             Company = company,
@@ -1454,7 +1677,7 @@ namespace NoOfficeDemandFix.Systems
                     ShouldCaptureBuyerTimingProbe(softwareConsumerState))
                 {
                     EnsureObservationDetailCapture(ref snapshot, ref detailCapture);
-                    TryAddCandidate(
+                    TryAddBuyerTimingProbeCandidate(
                         detailCapture.SoftwareBuyerTimingProbeDetailCandidates,
                         new SoftwareBuyerTimingProbeDetailCandidate
                         {
@@ -1465,6 +1688,28 @@ namespace NoOfficeDemandFix.Systems
                             HasEfficiency = hasEfficiency,
                             Efficiency = efficiency,
                             LackResources = lackResources,
+                            Priority = GetBuyerTimingProbePriority(softwareConsumerState, hasEfficiency, efficiency, lackResources),
+                            SoftwareConsumerState = softwareConsumerState
+                        });
+                }
+
+                if (verboseLogging &&
+                    isConsumer &&
+                    ShouldCaptureSellerResolutionProbe(softwareConsumerState, snapshot.Day, snapshot.SampleIndex))
+                {
+                    EnsureObservationDetailCapture(ref snapshot, ref detailCapture);
+                    TryAddSellerResolutionProbeCandidate(
+                        detailCapture.SoftwareSellerResolutionProbeDetailCandidates,
+                        new SoftwareSellerResolutionProbeDetailCandidate
+                        {
+                            Company = company,
+                            CompanyPrefab = prefabRef.m_Prefab,
+                            Property = propertyRenter.m_Property,
+                            ProcessData = processData,
+                            HasEfficiency = hasEfficiency,
+                            Efficiency = efficiency,
+                            LackResources = lackResources,
+                            Priority = GetSellerResolutionProbePriority(softwareConsumerState, snapshot.Day, snapshot.SampleIndex),
                             SoftwareConsumerState = softwareConsumerState
                         });
                 }
@@ -1512,36 +1757,269 @@ namespace NoOfficeDemandFix.Systems
             candidates.Add(candidate);
         }
 
+        private static void TryAddBuyerTimingProbeCandidate(List<SoftwareBuyerTimingProbeDetailCandidate> candidates, SoftwareBuyerTimingProbeDetailCandidate candidate)
+        {
+            int insertIndex = candidates.Count;
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (candidate.Priority > candidates[i].Priority)
+                {
+                    insertIndex = i;
+                    break;
+                }
+            }
+
+            if (insertIndex >= kMaxDetailEntries && candidates.Count >= kMaxDetailEntries)
+            {
+                return;
+            }
+
+            if (insertIndex < candidates.Count)
+            {
+                candidates.Insert(insertIndex, candidate);
+            }
+            else if (candidates.Count < kMaxDetailEntries)
+            {
+                candidates.Add(candidate);
+            }
+
+            if (candidates.Count > kMaxDetailEntries)
+            {
+                candidates.RemoveAt(candidates.Count - 1);
+            }
+        }
+
+        private static void TryAddSellerResolutionProbeCandidate(List<SoftwareSellerResolutionProbeDetailCandidate> candidates, SoftwareSellerResolutionProbeDetailCandidate candidate)
+        {
+            int insertIndex = candidates.Count;
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (candidate.Priority > candidates[i].Priority)
+                {
+                    insertIndex = i;
+                    break;
+                }
+            }
+
+            if (insertIndex >= kMaxDetailEntries && candidates.Count >= kMaxDetailEntries)
+            {
+                return;
+            }
+
+            if (insertIndex < candidates.Count)
+            {
+                candidates.Insert(insertIndex, candidate);
+            }
+            else if (candidates.Count < kMaxDetailEntries)
+            {
+                candidates.Add(candidate);
+            }
+
+            if (candidates.Count > kMaxDetailEntries)
+            {
+                candidates.RemoveAt(candidates.Count - 1);
+            }
+        }
+
+        private static void AddSoftwareOfficeDetailCandidate(ObservationDetailCapture detailCapture, SoftwareOfficeDetailCandidate candidate)
+        {
+            SoftwareOfficeDetailGroupKey key = BuildSoftwareOfficeDetailGroupKey(candidate);
+            if (detailCapture.SoftwareOfficeDetailGroupIndices.TryGetValue(key, out int existingIndex))
+            {
+                SoftwareOfficeDetailGroup existingGroup = detailCapture.SoftwareOfficeDetailGroups[existingIndex];
+                existingGroup.Count++;
+                detailCapture.SoftwareOfficeDetailGroups[existingIndex] = existingGroup;
+                return;
+            }
+
+            detailCapture.SoftwareOfficeDetailGroupIndices.Add(key, detailCapture.SoftwareOfficeDetailGroups.Count);
+            detailCapture.SoftwareOfficeDetailGroups.Add(new SoftwareOfficeDetailGroup
+            {
+                Key = key,
+                Representative = candidate,
+                Count = 1,
+                Priority = GetSoftwareOfficeDetailPriority(candidate)
+            });
+        }
+
+        private static SoftwareOfficeDetailGroupKey BuildSoftwareOfficeDetailGroupKey(SoftwareOfficeDetailCandidate candidate)
+        {
+            bool efficiencyZero = candidate.HasEfficiency && candidate.Efficiency <= 0f;
+            bool lackResourcesZero = candidate.HasEfficiency && candidate.LackResources <= 0f;
+            string classification = candidate.IsConsumer
+                ? candidate.SoftwareConsumerState.Trace.CurrentClassification
+                : string.Empty;
+            return new SoftwareOfficeDetailGroupKey(
+                candidate.CompanyPrefab,
+                candidate.IsProducer,
+                candidate.IsConsumer,
+                classification,
+                candidate.SoftwareInputZero,
+                efficiencyZero,
+                lackResourcesZero);
+        }
+
+        private static int GetSoftwareOfficeDetailPriority(SoftwareOfficeDetailCandidate candidate)
+        {
+            int priority = 0;
+            if (candidate.HasEfficiency && candidate.Efficiency <= 0f)
+            {
+                priority += 16;
+            }
+
+            if (candidate.HasEfficiency && candidate.LackResources <= 0f)
+            {
+                priority += 8;
+            }
+
+            if (candidate.SoftwareInputZero)
+            {
+                priority += 4;
+            }
+
+            if (candidate.IsConsumer)
+            {
+                if (string.Equals(candidate.SoftwareConsumerState.Trace.CurrentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal))
+                {
+                    priority += 3;
+                }
+                else if (string.Equals(candidate.SoftwareConsumerState.Trace.CurrentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal))
+                {
+                    priority += 2;
+                }
+                else if (string.Equals(candidate.SoftwareConsumerState.Trace.CurrentClassification, kTraceSelectedPathPending, StringComparison.Ordinal))
+                {
+                    priority += 1;
+                }
+            }
+
+            return priority;
+        }
+
         private string RenderSoftwareOfficeDetails(ObservationDetailCapture detailCapture)
         {
-            if (detailCapture == null || detailCapture.SoftwareOfficeDetailCandidates.Count == 0)
+            if (detailCapture == null || detailCapture.SoftwareOfficeDetailGroups.Count == 0)
             {
                 return string.Empty;
             }
 
+            List<SoftwareOfficeDetailGroup> groups = new List<SoftwareOfficeDetailGroup>(detailCapture.SoftwareOfficeDetailGroups);
+            groups.Sort(static (left, right) =>
+            {
+                int compare = right.Priority.CompareTo(left.Priority);
+                if (compare != 0)
+                {
+                    return compare;
+                }
+
+                compare = right.Count.CompareTo(left.Count);
+                if (compare != 0)
+                {
+                    return compare;
+                }
+
+                compare = left.Representative.CompanyPrefab.Index.CompareTo(right.Representative.CompanyPrefab.Index);
+                if (compare != 0)
+                {
+                    return compare;
+                }
+
+                return left.Representative.Property.Index.CompareTo(right.Representative.Property.Index);
+            });
+
+            int shownGroupCount = groups.Count;
+            if (shownGroupCount > kMaxDetailEntries)
+            {
+                shownGroupCount = Math.Max(1, kMaxDetailEntries - 1);
+            }
+
             StringBuilder details = null;
             int detailCount = 0;
-            for (int i = 0; i < detailCapture.SoftwareOfficeDetailCandidates.Count; i++)
+            for (int i = 0; i < shownGroupCount; i++)
             {
-                SoftwareOfficeDetailCandidate candidate = detailCapture.SoftwareOfficeDetailCandidates[i];
+                SoftwareOfficeDetailGroup group = groups[i];
+                SoftwareOfficeDetailCandidate candidate = group.Representative;
+                string detail = DescribeCompactSoftwareOffice(
+                    candidate.Company,
+                    candidate.CompanyPrefab,
+                    candidate.Property,
+                    candidate.ProcessData,
+                    candidate.IsProducer,
+                    candidate.IsConsumer,
+                    candidate.SoftwareInputZero,
+                    candidate.HasEfficiency,
+                    candidate.Efficiency,
+                    candidate.LackResources,
+                    candidate.SoftwareConsumerState);
+                detail += $", sk={group.Count}, so={Math.Max(0, group.Count - 1)}";
                 AppendDetail(
                     ref details,
                     ref detailCount,
-                    DescribeSoftwareOffice(
-                        candidate.Company,
-                        candidate.CompanyPrefab,
-                        candidate.Property,
-                        candidate.ProcessData,
-                        candidate.IsProducer,
-                        candidate.IsConsumer,
-                        candidate.SoftwareInputZero,
-                        candidate.HasEfficiency,
-                        candidate.Efficiency,
-                        candidate.LackResources,
-                        candidate.SoftwareConsumerState));
+                    detail);
+            }
+
+            if (groups.Count > shownGroupCount)
+            {
+                int omittedKinds = groups.Count - shownGroupCount;
+                int omittedCases = 0;
+                for (int i = shownGroupCount; i < groups.Count; i++)
+                {
+                    omittedCases += groups[i].Count;
+                }
+
+                AppendDetail(
+                    ref details,
+                    ref detailCount,
+                    $"fmt={kCompactDetailFormatVersion}, summary(kind=grouped_office_states, omittedKinds={omittedKinds}, omittedCases={omittedCases})");
             }
 
             return details == null ? string.Empty : details.ToString();
+        }
+
+        private string RenderOfficeDemandInternalsDetails(DiagnosticSnapshot snapshot)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("fmt=").Append(kCompactDetailFormatVersion);
+            builder.Append(", ocd=").Append(snapshot.OfficeCompanyDemand);
+            builder.Append(", obd=").Append(snapshot.OfficeBuildingDemand);
+            builder.Append(", ebf=").Append(snapshot.EmptyBuildingsFactor);
+            builder.Append(", bdf=").Append(snapshot.BuildingDemandFactor);
+            builder.Append(", ldf=");
+            builder.Append(snapshot.LocalDemandFactorKnown ? snapshot.LocalDemandFactor.ToString(CultureInfo.InvariantCulture) : "na");
+            builder.Append(", fp=").Append(snapshot.FreeOfficeProperties);
+            builder.Append(", mp=").Append(snapshot.OnMarketOfficeProperties);
+            builder.Append(", av=").Append(snapshot.ActivelyVacantOfficeProperties);
+            builder.Append(", scp=").Append(snapshot.SoftwareConsumerOfficePropertylessCompanies);
+            builder.Append(", facTop=[").Append(snapshot.TopFactors).Append(']');
+
+            if (IndustrialDemandOfficeBaselinePatch.TryCaptureDebugSnapshot(m_IndustrialDemandSystem, out IndustrialDemandOfficeBaselinePatch.OfficeDemandDebugSnapshot baselineDebugSnapshot))
+            {
+                builder.Append(", base(ok=1,ocd=").Append(baselineDebugSnapshot.LastOfficeCompanyDemand);
+                builder.Append(",obd=").Append(baselineDebugSnapshot.LastOfficeBuildingDemand).Append(')');
+            }
+            else
+            {
+                builder.Append(", base(ok=0,ocd=na,obd=na)");
+            }
+
+            if (!IndustrialDemandDiagnosticsProbePatch.TryGetLatestSnapshot(out IndustrialDemandDiagnosticsProbePatch.OfficeDemandProbeSnapshot probeSnapshot))
+            {
+                builder.Append(", probe(ok=0,status=na,fa=na)");
+                return builder.ToString();
+            }
+
+            int currentSimulationFrame = (int)m_SimulationSystem.frameIndex;
+            builder.Append(", probe(ok=1,done=").Append(CompactBool(probeSnapshot.CaptureComplete));
+            builder.Append(",status=").Append(probeSnapshot.CaptureStatus);
+            builder.Append(",fa=");
+            builder.Append(probeSnapshot.SimulationFrame >= 0
+                ? Math.Max(0, currentSimulationFrame - probeSnapshot.SimulationFrame).ToString(CultureInfo.InvariantCulture)
+                : "na");
+            builder.Append(')');
+            builder.Append(", ors=[");
+            AppendCompactOfficeDemandInternalsEntries(builder, probeSnapshot.OfficeResources);
+            builder.Append(']');
+            return builder.ToString();
         }
 
         private string RenderSoftwareTradeLifecycleDetails(ObservationDetailCapture detailCapture)
@@ -1557,7 +2035,7 @@ namespace NoOfficeDemandFix.Systems
             {
                 SoftwareTradeLifecycleDetailCandidate candidate = detailCapture.SoftwareTradeLifecycleDetailCandidates[i];
                 string detail = candidate.IsProducer
-                    ? DescribeProducerTradeLifecycle(
+                    ? DescribeCompactProducerTradeLifecycle(
                         candidate.Company,
                         candidate.CompanyPrefab,
                         candidate.Property,
@@ -1565,7 +2043,7 @@ namespace NoOfficeDemandFix.Systems
                         candidate.HasEfficiency,
                         candidate.Efficiency,
                         candidate.LackResources)
-                    : DescribeConsumerTradeLifecycle(
+                    : DescribeCompactConsumerTradeLifecycle(
                         candidate.Company,
                         candidate.CompanyPrefab,
                         candidate.Property,
@@ -1578,6 +2056,29 @@ namespace NoOfficeDemandFix.Systems
             }
 
             return details == null ? string.Empty : details.ToString();
+        }
+
+        private static void AppendCompactOfficeDemandInternalsEntries(
+            StringBuilder builder,
+            IReadOnlyList<IndustrialDemandDiagnosticsProbePatch.OfficeResourceDemandEntry> entries)
+        {
+            for (int i = 0; i < entries.Count; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append("; ");
+                }
+
+                IndustrialDemandDiagnosticsProbePatch.OfficeResourceDemandEntry entry = entries[i];
+                builder.Append(entry.Resource)
+                    .Append("{rd=").Append(entry.ResourceDemand)
+                    .Append(",cd=")
+                    .Append(entry.CompanyDemandKnown ? entry.CompanyDemand.ToString(CultureInfo.InvariantCulture) : "na")
+                    .Append(",bd=").Append(entry.BuildingDemand)
+                    .Append(",fp=")
+                    .Append(entry.FreePropertiesKnown ? entry.FreeProperties.ToString(CultureInfo.InvariantCulture) : "na")
+                    .Append('}');
+            }
         }
 
         private string RenderSoftwareVirtualResolutionProbeDetails(ObservationDetailCapture detailCapture)
@@ -1620,7 +2121,7 @@ namespace NoOfficeDemandFix.Systems
                 AppendDetail(
                     ref details,
                     ref detailCount,
-                    DescribeSoftwareBuyerTimingProbe(
+                    DescribeCompactSoftwareBuyerTimingProbe(
                         candidate.Company,
                         candidate.CompanyPrefab,
                         candidate.Property,
@@ -1632,6 +2133,193 @@ namespace NoOfficeDemandFix.Systems
             }
 
             return details == null ? string.Empty : details.ToString();
+        }
+
+        private string RenderSoftwareSellerResolutionProbeDetails(ObservationDetailCapture detailCapture)
+        {
+            if (detailCapture == null || detailCapture.SoftwareSellerResolutionProbeDetailCandidates.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            StringBuilder details = null;
+            int detailCount = 0;
+            for (int i = 0; i < detailCapture.SoftwareSellerResolutionProbeDetailCandidates.Count; i++)
+            {
+                SoftwareSellerResolutionProbeDetailCandidate candidate = detailCapture.SoftwareSellerResolutionProbeDetailCandidates[i];
+                AppendDetail(
+                    ref details,
+                    ref detailCount,
+                    DescribeCompactSoftwareSellerResolutionProbe(
+                        candidate.Company,
+                        candidate.CompanyPrefab,
+                        candidate.Property,
+                        candidate.ProcessData,
+                        candidate.HasEfficiency,
+                        candidate.Efficiency,
+                        candidate.LackResources,
+                        candidate.SoftwareConsumerState));
+            }
+
+            return details == null ? string.Empty : details.ToString();
+        }
+
+        private string DescribeCompactSoftwareOffice(
+            Entity company,
+            Entity companyPrefab,
+            Entity property,
+            IndustrialProcessData processData,
+            bool isProducer,
+            bool isConsumer,
+            bool softwareInputZero,
+            bool hasEfficiency,
+            float efficiency,
+            float lackResources,
+            SoftwareConsumerDiagnosticState softwareConsumerState)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("fmt=").Append(kCompactDetailFormatVersion);
+            builder.Append(", role=").Append(GetSoftwareOfficeRoleLabel(isProducer, isConsumer));
+            builder.Append(", c=").Append(FormatEntity(company));
+            builder.Append(", pf=").Append(GetCompactPrefabLabel(companyPrefab));
+            builder.Append(", pr=").Append(FormatEntity(property));
+            builder.Append(", out=").Append(processData.m_Output.m_Resource).Append(':').Append(GetCompanyResourceAmount(company, processData.m_Output.m_Resource));
+            AppendCompactCompanyResourceState(builder, company, "i1", processData.m_Input1.m_Resource);
+            AppendCompactCompanyResourceState(builder, company, "i2", processData.m_Input2.m_Resource);
+            if (isConsumer)
+            {
+                builder.Append(", siz=").Append(CompactBool(softwareInputZero));
+                AppendCompactNeedState(builder, softwareConsumerState.Need);
+                AppendCompactAcquisitionSummary(builder, softwareConsumerState.Acquisition, softwareConsumerState.Trace.CurrentClassification);
+            }
+            else if (EntityManager.HasComponent<ResourceBuyer>(company))
+            {
+                ResourceBuyer buyer = EntityManager.GetComponentData<ResourceBuyer>(company);
+                builder.Append(", ab=").Append(buyer.m_ResourceNeeded).Append(':').Append(buyer.m_AmountNeeded);
+            }
+
+            AppendCompactMetric(builder, "eff", hasEfficiency, efficiency);
+            AppendCompactMetric(builder, "lr", hasEfficiency, lackResources);
+            return builder.ToString();
+        }
+
+        private string DescribeCompactProducerTradeLifecycle(
+            Entity company,
+            Entity companyPrefab,
+            Entity property,
+            IndustrialProcessData processData,
+            bool hasEfficiency,
+            float efficiency,
+            float lackResources)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("fmt=").Append(kCompactDetailFormatVersion);
+            builder.Append(", role=producer");
+            builder.Append(", c=").Append(FormatEntity(company));
+            builder.Append(", pf=").Append(GetCompactPrefabLabel(companyPrefab));
+            builder.Append(", pr=").Append(FormatEntity(property));
+            builder.Append(", cap=producer");
+            builder.Append(", out=").Append(processData.m_Output.m_Resource).Append(':').Append(GetCompanyResourceAmount(company, processData.m_Output.m_Resource));
+            AppendCompactCompanyResourceState(builder, company, "i1", processData.m_Input1.m_Resource);
+            AppendCompactCompanyResourceState(builder, company, "i2", processData.m_Input2.m_Resource);
+            if (EntityManager.HasComponent<ResourceBuyer>(company))
+            {
+                ResourceBuyer buyer = EntityManager.GetComponentData<ResourceBuyer>(company);
+                builder.Append(", ab=").Append(buyer.m_ResourceNeeded).Append(':').Append(buyer.m_AmountNeeded);
+            }
+
+            AppendCompactMetric(builder, "eff", hasEfficiency, efficiency);
+            AppendCompactMetric(builder, "lr", hasEfficiency, lackResources);
+            return builder.ToString();
+        }
+
+        private string DescribeCompactConsumerTradeLifecycle(
+            Entity company,
+            Entity companyPrefab,
+            Entity property,
+            IndustrialProcessData processData,
+            bool hasEfficiency,
+            float efficiency,
+            float lackResources,
+            SoftwareConsumerDiagnosticState softwareConsumerState)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("fmt=").Append(kCompactDetailFormatVersion);
+            builder.Append(", role=consumer");
+            builder.Append(", c=").Append(FormatEntity(company));
+            builder.Append(", pf=").Append(GetCompactPrefabLabel(companyPrefab));
+            builder.Append(", pr=").Append(FormatEntity(property));
+            builder.Append(", cap=transition");
+            builder.Append(", out=").Append(processData.m_Output.m_Resource).Append(':').Append(GetCompanyResourceAmount(company, processData.m_Output.m_Resource));
+            AppendCompactCompanyResourceState(builder, company, "i1", processData.m_Input1.m_Resource);
+            AppendCompactCompanyResourceState(builder, company, "i2", processData.m_Input2.m_Resource);
+            AppendCompactTransitionSummary(builder, softwareConsumerState.Trace);
+            AppendCompactNeedState(builder, softwareConsumerState.Need);
+            AppendCompactAcquisitionSummary(builder, softwareConsumerState.Acquisition, softwareConsumerState.Trace.CurrentClassification);
+            AppendCompactResourceTripSummary(builder, "trip", softwareConsumerState.Acquisition);
+            AppendCompactMetric(builder, "eff", hasEfficiency, efficiency);
+            AppendCompactMetric(builder, "lr", hasEfficiency, lackResources);
+            return builder.ToString();
+        }
+
+        private string DescribeCompactSoftwareBuyerTimingProbe(
+            Entity company,
+            Entity companyPrefab,
+            Entity property,
+            IndustrialProcessData processData,
+            bool hasEfficiency,
+            float efficiency,
+            float lackResources,
+            SoftwareConsumerDiagnosticState softwareConsumerState)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("fmt=").Append(kCompactDetailFormatVersion);
+            builder.Append(", role=consumer");
+            builder.Append(", c=").Append(FormatEntity(company));
+            builder.Append(", pf=").Append(GetCompactPrefabLabel(companyPrefab));
+            builder.Append(", pr=").Append(FormatEntity(property));
+            builder.Append(", cap=buyer_timing");
+            builder.Append(", cls=").Append(string.IsNullOrEmpty(softwareConsumerState.Trace.CurrentClassification) ? kTraceNeedNotSelected : softwareConsumerState.Trace.CurrentClassification);
+            builder.Append(", out=").Append(processData.m_Output.m_Resource).Append(':').Append(GetCompanyResourceAmount(company, processData.m_Output.m_Resource));
+            AppendCompactCompanyResourceState(builder, company, "i1", processData.m_Input1.m_Resource);
+            AppendCompactCompanyResourceState(builder, company, "i2", processData.m_Input2.m_Resource);
+            AppendCompactNeedState(builder, softwareConsumerState.Need);
+            AppendCompactAcquisitionSummary(builder, softwareConsumerState.Acquisition, softwareConsumerState.Trace.CurrentClassification, includeWindowCounters: true);
+            AppendCompactBuyerFixWindowSummary(builder, company);
+            AppendCompactBuyerFixEligibilitySummary(builder, company, Resource.Software);
+            AppendCompactMetric(builder, "eff", hasEfficiency, efficiency);
+            AppendCompactMetric(builder, "lr", hasEfficiency, lackResources);
+            return builder.ToString();
+        }
+
+        private string DescribeCompactSoftwareSellerResolutionProbe(
+            Entity company,
+            Entity companyPrefab,
+            Entity property,
+            IndustrialProcessData processData,
+            bool hasEfficiency,
+            float efficiency,
+            float lackResources,
+            SoftwareConsumerDiagnosticState softwareConsumerState)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("fmt=").Append(kCompactDetailFormatVersion);
+            builder.Append(", role=consumer");
+            builder.Append(", c=").Append(FormatEntity(company));
+            builder.Append(", pf=").Append(GetCompactPrefabLabel(companyPrefab));
+            builder.Append(", pr=").Append(FormatEntity(property));
+            builder.Append(", cap=seller_resolution");
+            builder.Append(", cls=").Append(string.IsNullOrEmpty(softwareConsumerState.Trace.CurrentClassification) ? kTraceNeedNotSelected : softwareConsumerState.Trace.CurrentClassification);
+            builder.Append(", rs=").Append(GetSellerResolutionStatusLabel(softwareConsumerState));
+            builder.Append(", out=").Append(processData.m_Output.m_Resource).Append(':').Append(GetCompanyResourceAmount(company, processData.m_Output.m_Resource));
+            AppendCompactCompanyResourceState(builder, company, "i1", processData.m_Input1.m_Resource);
+            AppendCompactCompanyResourceState(builder, company, "i2", processData.m_Input2.m_Resource);
+            AppendCompactNeedState(builder, softwareConsumerState.Need);
+            AppendCompactAcquisitionSummary(builder, softwareConsumerState.Acquisition, softwareConsumerState.Trace.CurrentClassification, includeWindowCounters: true, includeAges: true);
+            AppendCompactOutsideConnectionSellerProbeSummary(builder, company, Resource.Software);
+            AppendCompactMetric(builder, "eff", hasEfficiency, efficiency);
+            AppendCompactMetric(builder, "lr", hasEfficiency, lackResources);
+            return builder.ToString();
         }
 
         private string DescribeSoftwareOffice(Entity company, Entity companyPrefab, Entity property, IndustrialProcessData processData, bool isProducer, bool isConsumer, bool softwareInputZero, bool hasEfficiency, float efficiency, float lackResources, SoftwareConsumerDiagnosticState softwareConsumerState)
@@ -1731,6 +2419,81 @@ namespace NoOfficeDemandFix.Systems
                    string.Equals(state.Trace.CurrentClassification, kTraceSelectedCurrentTradingPresent, StringComparison.Ordinal);
         }
 
+        private static int GetBuyerTimingProbePriority(SoftwareConsumerDiagnosticState state, bool hasEfficiency, float efficiency, float lackResources)
+        {
+            int priority = string.Equals(state.Trace.CurrentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal)
+                ? 1_000_000
+                : string.Equals(state.Trace.CurrentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal)
+                    ? 900_000
+                    : string.Equals(state.Trace.CurrentClassification, kTraceSelectedPathPending, StringComparison.Ordinal)
+                        ? 800_000
+                        : string.Equals(state.Trace.CurrentClassification, kTraceSelectedTripPresent, StringComparison.Ordinal)
+                            ? 700_000
+                            : 600_000;
+
+            priority += Math.Min(999, state.Acquisition.EstimatedMissedVanillaBuyerPasses) * 1_000;
+            priority += Math.Min(999, state.Acquisition.SelectedNoBuyerConsecutiveWindows) * 100;
+            priority += Math.Min(999, state.Acquisition.SelectedRequestNoPathConsecutiveWindows) * 10;
+
+            if (state.Need.Stock == 0)
+            {
+                priority += 25;
+            }
+
+            if (hasEfficiency && efficiency <= 0f)
+            {
+                priority += 5;
+            }
+
+            if (hasEfficiency && lackResources <= 0f)
+            {
+                priority += 5;
+            }
+
+            return priority;
+        }
+
+        private static bool ShouldCaptureSellerResolutionProbe(SoftwareConsumerDiagnosticState state, int day, int sampleIndex)
+        {
+            if (state.Acquisition.VirtualResolvedThisWindow)
+            {
+                return true;
+            }
+
+            if (ShouldCaptureConsumerTradeLifecycle(state, day, sampleIndex))
+            {
+                return true;
+            }
+
+            return string.Equals(state.Trace.CurrentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal) ||
+                   string.Equals(state.Trace.CurrentClassification, kTraceSelectedPathPending, StringComparison.Ordinal);
+        }
+
+        private static int GetSellerResolutionProbePriority(SoftwareConsumerDiagnosticState state, int day, int sampleIndex)
+        {
+            int priority = state.Acquisition.VirtualResolvedThisWindow
+                ? 950_000
+                : string.Equals(state.Trace.CurrentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal)
+                    ? 900_000
+                    : string.Equals(state.Trace.CurrentClassification, kTraceSelectedPathPending, StringComparison.Ordinal)
+                        ? 800_000
+                        : 700_000;
+
+            if (ShouldCaptureConsumerTradeLifecycle(state, day, sampleIndex))
+            {
+                priority += 10_000;
+            }
+
+            priority += Math.Min(999, state.Acquisition.SelectedRequestNoPathConsecutiveWindows) * 100;
+            priority += Math.Min(999, state.Acquisition.BelowThresholdConsecutiveWindows) * 10;
+            if (state.Need.Stock == 0)
+            {
+                priority += 25;
+            }
+
+            return priority;
+        }
+
         private string DescribeConsumerTradeLifecycle(
             Entity company,
             Entity companyPrefab,
@@ -1772,6 +2535,84 @@ namespace NoOfficeDemandFix.Systems
             builder.Append(", lackResources=");
             AppendMetricValue(builder, hasEfficiency, lackResources);
             return builder.ToString();
+        }
+
+        private string DescribeSoftwareSellerResolutionProbe(
+            Entity company,
+            Entity companyPrefab,
+            Entity property,
+            IndustrialProcessData processData,
+            bool hasEfficiency,
+            float efficiency,
+            float lackResources,
+            SoftwareConsumerDiagnosticState softwareConsumerState)
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.Append("role=consumer");
+            builder.Append(", company=").Append(FormatEntity(company));
+            builder.Append(", prefab=").Append(GetPrefabLabel(companyPrefab));
+            builder.Append(", property=").Append(FormatEntity(property));
+            builder.Append(", capture=seller_resolution_probe");
+            builder.Append(", currentClassification=").Append(string.IsNullOrEmpty(softwareConsumerState.Trace.CurrentClassification) ? kTraceNeedNotSelected : softwareConsumerState.Trace.CurrentClassification);
+            builder.Append(", resolutionStatus=").Append(GetSellerResolutionStatusLabel(softwareConsumerState));
+            builder.Append(", output=").Append(processData.m_Output.m_Resource);
+            builder.Append(", outputStock=").Append(GetCompanyResourceAmount(company, processData.m_Output.m_Resource));
+            AppendCompanyResourceState(builder, company, "input1", processData.m_Input1.m_Resource);
+            AppendCompanyResourceState(builder, company, "input2", processData.m_Input2.m_Resource);
+            AppendSoftwareNeedState(builder, softwareConsumerState.Need);
+            AppendSoftwareTradeCostState(builder, softwareConsumerState.TradeCost);
+            AppendSoftwareAcquisitionState(builder, softwareConsumerState.Acquisition, softwareConsumerState.Trace.CurrentClassification);
+            builder.Append(", selectedNoBuyerConsecutiveWindows=").Append(softwareConsumerState.Acquisition.SelectedNoBuyerConsecutiveWindows);
+            builder.Append(", selectedRequestNoPathConsecutiveWindows=").Append(softwareConsumerState.Acquisition.SelectedRequestNoPathConsecutiveWindows);
+            builder.Append(", belowThresholdConsecutiveWindows=").Append(softwareConsumerState.Acquisition.BelowThresholdConsecutiveWindows);
+            builder.Append(", recoveredThisObservation=").Append(softwareConsumerState.Acquisition.VirtualResolvedThisWindow);
+            builder.Append(", lastBuyerSeenSampleAge=").Append(softwareConsumerState.Acquisition.LastBuyerSeenSampleAge >= 0 ? softwareConsumerState.Acquisition.LastBuyerSeenSampleAge.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastPathSeenSampleAge=").Append(softwareConsumerState.Acquisition.LastPathSeenSampleAge >= 0 ? softwareConsumerState.Acquisition.LastPathSeenSampleAge.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastVirtualResolutionSampleAge=").Append(softwareConsumerState.Acquisition.LastVirtualResolutionSampleAge >= 0 ? softwareConsumerState.Acquisition.LastVirtualResolutionSampleAge.ToString(CultureInfo.InvariantCulture) : "n/a");
+            AppendBuyingCompanyState(builder, company);
+            if (TryGetPathSeller(softwareConsumerState, out Entity pathSeller))
+            {
+                AppendSellerSnapshot(builder, "pathSeller", pathSeller, Resource.Software);
+            }
+
+            if (TryGetLastTradePartner(company, out Entity lastTradePartner))
+            {
+                AppendSellerSnapshot(builder, "lastTradePartnerSeller", lastTradePartner, Resource.Software);
+            }
+
+            AppendOutsideConnectionSellerProbeState(builder, company, Resource.Software);
+            builder.Append(", efficiency=");
+            AppendMetricValue(builder, hasEfficiency, efficiency);
+            builder.Append(", lackResources=");
+            AppendMetricValue(builder, hasEfficiency, lackResources);
+            return builder.ToString();
+        }
+
+        private static string GetSellerResolutionStatusLabel(SoftwareConsumerDiagnosticState state)
+        {
+            if (state.Acquisition.VirtualResolvedThisWindow)
+            {
+                return "recovered_this_window";
+            }
+
+            if (string.Equals(state.Trace.CurrentClassification, kTraceSelectedPathPending, StringComparison.Ordinal))
+            {
+                return "path_pending_without_resolution";
+            }
+
+            if (string.Equals(state.Trace.CurrentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal))
+            {
+                return "buyer_only_no_path";
+            }
+
+            if (IsNeedClearedAfterSelected(state.Trace))
+            {
+                return "need_cleared_after_selected";
+            }
+
+            return string.IsNullOrEmpty(state.Trace.CurrentClassification)
+                ? kTraceTransitionUnobserved
+                : state.Trace.CurrentClassification;
         }
 
         private string DescribeProducerTradeLifecycle(
@@ -1863,6 +2704,8 @@ namespace NoOfficeDemandFix.Systems
             AppendSoftwareNeedState(builder, softwareConsumerState.Need);
             AppendSoftwareTradeCostState(builder, softwareConsumerState.TradeCost);
             AppendSoftwareAcquisitionState(builder, softwareConsumerState.Acquisition, softwareConsumerState.Trace.CurrentClassification);
+            AppendBuyerFixWindowState(builder, company);
+            AppendBuyerFixQueryEligibilityState(builder, company, Resource.Software);
             AppendResourceTripState(builder, "softwareTripState", softwareConsumerState.Acquisition);
             AppendBuyingCompanyState(builder, company);
             if (TryGetPathSeller(softwareConsumerState, out Entity pathSeller))
@@ -1880,6 +2723,378 @@ namespace NoOfficeDemandFix.Systems
             builder.Append(", lackResources=");
             AppendMetricValue(builder, hasEfficiency, lackResources);
             return builder.ToString();
+        }
+
+        private void AppendBuyerFixWindowState(StringBuilder builder, Entity company)
+        {
+            builder.Append(", buyerFixWindow(");
+            VirtualOfficeResourceBuyerFixSystem buyerFixSystem = World.GetExistingSystemManaged<VirtualOfficeResourceBuyerFixSystem>();
+            if (buyerFixSystem == null || !buyerFixSystem.TryGetCompanyProbeWindowSnapshot(company, out VirtualOfficeResourceBuyerFixSystem.CompanyProbeWindowSnapshot snapshot))
+            {
+                builder.Append("seenThisObservation=False");
+                builder.Append(", seenChangedQueryCount=0");
+                builder.Append(", seenFullSweepCount=0");
+                builder.Append(", lastSeenPass=none");
+                builder.Append(", lastSeenFrameAge=n/a");
+                builder.Append(", overrideCount=0");
+                builder.Append(", lastOverridePass=none");
+                builder.Append(", lastOverrideFrameAge=n/a");
+                builder.Append(", lastOverrideAmount=n/a");
+                builder.Append(", lastOverrideShortfall=n/a");
+                builder.Append(", lastOverrideStock=n/a");
+                builder.Append(", lastOverrideBuyingLoad=n/a");
+                builder.Append(", lastOverrideTripNeededAmount=n/a");
+                builder.Append(", lastOverrideEffectiveStock=n/a");
+                builder.Append(", lastOverrideThreshold=n/a");
+                builder.Append(')');
+                return;
+            }
+
+            uint currentSimulationFrame = m_SimulationSystem.frameIndex;
+            builder.Append("seenThisObservation=True");
+            builder.Append(", seenChangedQueryCount=").Append(snapshot.SeenChangedQueryCount);
+            builder.Append(", seenFullSweepCount=").Append(snapshot.SeenFullSweepCount);
+            builder.Append(", lastSeenPass=").Append(VirtualOfficeResourceBuyerFixSystem.GetPassKindLabel(snapshot.LastSeenViaFullSweep));
+            builder.Append(", lastSeenFrameAge=");
+            builder.Append(snapshot.LastSeenFrame >= 0 ? Math.Max(0, (int)currentSimulationFrame - snapshot.LastSeenFrame).ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", overrideCount=").Append(snapshot.OverrideCount);
+            builder.Append(", lastOverridePass=");
+            builder.Append(snapshot.OverrideCount > 0 ? VirtualOfficeResourceBuyerFixSystem.GetPassKindLabel(snapshot.LastOverrideViaFullSweep) : "none");
+            builder.Append(", lastOverrideFrameAge=");
+            builder.Append(snapshot.LastOverrideFrame >= 0 ? Math.Max(0, (int)currentSimulationFrame - snapshot.LastOverrideFrame).ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideAmount=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideAmount.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideShortfall=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideShortfall.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideStock=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideStock.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideBuyingLoad=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideBuyingLoad.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideTripNeededAmount=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideTripNeededAmount.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideEffectiveStock=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideEffectiveStock.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", lastOverrideThreshold=");
+            builder.Append(snapshot.OverrideCount > 0 ? snapshot.LastOverrideThreshold.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(')');
+        }
+
+        private void AppendBuyerFixQueryEligibilityState(StringBuilder builder, Entity company, Resource selectedResource)
+        {
+            bool hasBuyingCompany = EntityManager.HasComponent<BuyingCompany>(company);
+            bool hasPropertyRenter = EntityManager.HasComponent<PropertyRenter>(company);
+            bool hasResourcesBuffer = EntityManager.HasBuffer<Resources>(company);
+            bool hasCitizenTripNeededBuffer = EntityManager.HasBuffer<CitizenTripNeeded>(company);
+            int tripNeededBufferLength = hasCitizenTripNeededBuffer
+                ? EntityManager.GetBuffer<CitizenTripNeeded>(company, isReadOnly: true).Length
+                : 0;
+            bool hasAnyResourceBuyer = EntityManager.HasComponent<ResourceBuyer>(company);
+            ResourceBuyer anyResourceBuyer = hasAnyResourceBuyer
+                ? EntityManager.GetComponentData<ResourceBuyer>(company)
+                : default;
+            bool hasPathInformation = EntityManager.HasComponent<PathInformation>(company);
+            PathInformation pathInformation = hasPathInformation
+                ? EntityManager.GetComponentData<PathInformation>(company)
+                : default;
+            bool hasCurrentTradingBuffer = EntityManager.HasBuffer<CurrentTrading>(company);
+            int currentTradingEntryCount = 0;
+            int selectedResourceCurrentTradingEntryCount = 0;
+            if (hasCurrentTradingBuffer)
+            {
+                DynamicBuffer<CurrentTrading> currentTrading = EntityManager.GetBuffer<CurrentTrading>(company, isReadOnly: true);
+                currentTradingEntryCount = currentTrading.Length;
+                for (int i = 0; i < currentTrading.Length; i++)
+                {
+                    if (currentTrading[i].m_TradingResource == selectedResource)
+                    {
+                        selectedResourceCurrentTradingEntryCount++;
+                    }
+                }
+            }
+
+            bool hasSelectedResourceCurrentTrading = selectedResourceCurrentTradingEntryCount > 0;
+            bool eligibleNow = hasBuyingCompany &&
+                               hasPropertyRenter &&
+                               hasResourcesBuffer &&
+                               hasCitizenTripNeededBuffer &&
+                               !hasAnyResourceBuyer &&
+                               !hasPathInformation &&
+                               !hasSelectedResourceCurrentTrading;
+
+            builder.Append(", buyerFixQueryEligibility(");
+            builder.Append("eligibleNow=").Append(eligibleNow);
+            builder.Append(", selectedResource=").Append(selectedResource);
+            builder.Append(", hasBuyingCompany=").Append(hasBuyingCompany);
+            builder.Append(", hasPropertyRenter=").Append(hasPropertyRenter);
+            builder.Append(", hasResourcesBuffer=").Append(hasResourcesBuffer);
+            builder.Append(", hasCitizenTripNeededBuffer=").Append(hasCitizenTripNeededBuffer);
+            builder.Append(", tripNeededBufferLength=").Append(tripNeededBufferLength);
+            builder.Append(", hasAnyResourceBuyer=").Append(hasAnyResourceBuyer);
+            builder.Append(", anyResourceBuyerResource=");
+            builder.Append(hasAnyResourceBuyer ? anyResourceBuyer.m_ResourceNeeded.ToString() : "none");
+            builder.Append(", anyResourceBuyerAmount=");
+            builder.Append(hasAnyResourceBuyer ? anyResourceBuyer.m_AmountNeeded.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", hasPathInformation=").Append(hasPathInformation);
+            builder.Append(", pathInfoState=");
+            builder.Append(hasPathInformation ? pathInformation.m_State.ToString() : "none");
+            builder.Append(", hasCurrentTradingBuffer=").Append(hasCurrentTradingBuffer);
+            builder.Append(", currentTradingEntryCount=").Append(currentTradingEntryCount);
+            builder.Append(", selectedResourceCurrentTradingEntryCount=").Append(selectedResourceCurrentTradingEntryCount);
+            builder.Append(", excludedBy=").Append(GetBuyerFixQueryExclusionReasonLabel(
+                hasBuyingCompany,
+                hasPropertyRenter,
+                hasResourcesBuffer,
+                hasCitizenTripNeededBuffer,
+                hasAnyResourceBuyer,
+                hasPathInformation,
+                hasSelectedResourceCurrentTrading));
+            builder.Append(')');
+        }
+
+        private static string GetBuyerFixQueryExclusionReasonLabel(
+            bool hasBuyingCompany,
+            bool hasPropertyRenter,
+            bool hasResourcesBuffer,
+            bool hasCitizenTripNeededBuffer,
+            bool hasAnyResourceBuyer,
+            bool hasPathInformation,
+            bool hasSelectedResourceCurrentTrading)
+        {
+            if (hasBuyingCompany &&
+                hasPropertyRenter &&
+                hasResourcesBuffer &&
+                hasCitizenTripNeededBuffer &&
+                !hasAnyResourceBuyer &&
+                !hasPathInformation &&
+                !hasSelectedResourceCurrentTrading)
+            {
+                return "none";
+            }
+
+            StringBuilder builder = new StringBuilder();
+            AppendBuyerFixExclusionReason(builder, !hasBuyingCompany, "missing_buying_company");
+            AppendBuyerFixExclusionReason(builder, !hasPropertyRenter, "missing_property_renter");
+            AppendBuyerFixExclusionReason(builder, !hasResourcesBuffer, "missing_resources_buffer");
+            AppendBuyerFixExclusionReason(builder, !hasCitizenTripNeededBuffer, "missing_trip_needed_buffer");
+            AppendBuyerFixExclusionReason(builder, hasAnyResourceBuyer, "resource_buyer_present");
+            AppendBuyerFixExclusionReason(builder, hasPathInformation, "path_information_present");
+            AppendBuyerFixExclusionReason(builder, hasSelectedResourceCurrentTrading, "same_resource_current_trading_present");
+            return builder.Length > 0 ? builder.ToString() : "unknown";
+        }
+
+        private static void AppendBuyerFixExclusionReason(StringBuilder builder, bool condition, string label)
+        {
+            if (!condition)
+            {
+                return;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append('+');
+            }
+
+            builder.Append(label);
+        }
+
+        private void AppendCompactCompanyResourceState(StringBuilder builder, Entity company, string label, Resource resource)
+        {
+            if (resource == Resource.NoResource)
+            {
+                return;
+            }
+
+            builder.Append(", ").Append(label).Append('=').Append(resource).Append(':').Append(GetCompanyResourceAmount(company, resource));
+        }
+
+        private static void AppendCompactNeedState(StringBuilder builder, SoftwareNeedState state)
+        {
+            builder.Append(", need(");
+            builder.Append("st=").Append(state.Stock);
+            builder.Append(",bl=").Append(state.BuyingLoad);
+            builder.Append(",tr=").Append(state.TripNeededAmount);
+            builder.Append(",es=").Append(state.EffectiveStock);
+            builder.Append(",th=").Append(state.Threshold);
+            builder.Append(",sel=").Append(CompactBool(state.Selected));
+            builder.Append(",exp=").Append(CompactBool(state.Expensive));
+            builder.Append(')');
+        }
+
+        private static void AppendCompactAcquisitionSummary(
+            StringBuilder builder,
+            SoftwareAcquisitionState state,
+            string classification,
+            bool includeWindowCounters = false,
+            bool includeAges = false)
+        {
+            builder.Append(", acq(");
+            builder.Append("cls=").Append(string.IsNullOrEmpty(classification) ? kTraceNeedNotSelected : classification);
+            builder.Append(",rb=").Append(CompactBool(state.ResourceBuyerPresent));
+            if (state.ResourceBuyerPresent)
+            {
+                builder.Append(",rba=").Append(state.ResourceBuyerAmount);
+            }
+
+            builder.Append(",bo=").Append(string.IsNullOrEmpty(state.BuyerOrigin) ? "u" : state.BuyerOrigin);
+            builder.Append(",pst=").Append(string.IsNullOrEmpty(state.PathStage) ? "none" : state.PathStage);
+            builder.Append(",trip=").Append(state.TripNeededCount).Append('/').Append(state.TripNeededAmount);
+            builder.Append(",trade=").Append(state.CurrentTradingCount).Append('/').Append(state.CurrentTradingAmount);
+            builder.Append(",vr=").Append(CompactBool(state.VirtualResolvedThisWindow));
+            if (state.VirtualResolvedThisWindow)
+            {
+                builder.Append(",vra=").Append(state.VirtualResolvedAmount);
+            }
+
+            if (includeWindowCounters)
+            {
+                builder.Append(",mp=").Append(state.EstimatedMissedVanillaBuyerPasses);
+                builder.Append(",nbw=").Append(state.SelectedNoBuyerConsecutiveWindows);
+                builder.Append(",npw=").Append(state.SelectedRequestNoPathConsecutiveWindows);
+                builder.Append(",btw=").Append(state.BelowThresholdConsecutiveWindows);
+            }
+
+            if (includeAges)
+            {
+                builder.Append(",ba=").Append(FormatCompactAge(state.LastBuyerSeenSampleAge));
+                builder.Append(",pa=").Append(FormatCompactAge(state.LastPathSeenSampleAge));
+                builder.Append(",va=").Append(FormatCompactAge(state.LastVirtualResolutionSampleAge));
+            }
+
+            builder.Append(')');
+        }
+
+        private static void AppendCompactTransitionSummary(StringBuilder builder, SoftwareConsumerTraceState state)
+        {
+            builder.Append(", tr(");
+            builder.Append("from=").Append(string.IsNullOrEmpty(state.LastTransitionFromLabel) ? kTraceTransitionUnobserved : state.LastTransitionFromLabel);
+            builder.Append(",to=").Append(string.IsNullOrEmpty(state.CurrentClassification) ? kTraceNeedNotSelected : state.CurrentClassification);
+            builder.Append(",d=").Append(state.LastTransitionDay == 0 ? "na" : state.LastTransitionDay.ToString(CultureInfo.InvariantCulture));
+            builder.Append(",si=").Append(state.LastTransitionSampleIndex == 0 ? "na" : state.LastTransitionSampleIndex.ToString(CultureInfo.InvariantCulture));
+            builder.Append(')');
+        }
+
+        private static void AppendCompactResourceTripSummary(StringBuilder builder, string label, SoftwareAcquisitionState state)
+        {
+            builder.Append(", ").Append(label).Append('(');
+            builder.Append("tot=").Append(state.TripNeededCount).Append('/').Append(state.TripNeededAmount);
+            builder.Append(",shop=").Append(state.ShoppingTripCount).Append('/').Append(state.ShoppingTripAmount);
+            builder.Append(",cshop=").Append(state.CompanyShoppingTripCount).Append('/').Append(state.CompanyShoppingTripAmount);
+            builder.Append(",other=").Append(state.OtherTripCount).Append('/').Append(state.OtherTripAmount);
+            builder.Append(')');
+        }
+
+        private void AppendCompactBuyerFixWindowSummary(StringBuilder builder, Entity company)
+        {
+            builder.Append(", fix(");
+            VirtualOfficeResourceBuyerFixSystem buyerFixSystem = World.GetExistingSystemManaged<VirtualOfficeResourceBuyerFixSystem>();
+            if (buyerFixSystem == null || !buyerFixSystem.TryGetCompanyProbeWindowSnapshot(company, out VirtualOfficeResourceBuyerFixSystem.CompanyProbeWindowSnapshot snapshot))
+            {
+                builder.Append("seen=0,chg=0,fs=0,ovr=0");
+                builder.Append(')');
+                return;
+            }
+
+            builder.Append("seen=1");
+            builder.Append(",chg=").Append(snapshot.SeenChangedQueryCount);
+            builder.Append(",fs=").Append(snapshot.SeenFullSweepCount);
+            builder.Append(",ovr=").Append(snapshot.OverrideCount);
+            builder.Append(",lsp=").Append(VirtualOfficeResourceBuyerFixSystem.GetPassKindLabel(snapshot.LastSeenViaFullSweep));
+            builder.Append(')');
+        }
+
+        private void AppendCompactBuyerFixEligibilitySummary(StringBuilder builder, Entity company, Resource selectedResource)
+        {
+            bool hasBuyingCompany = EntityManager.HasComponent<BuyingCompany>(company);
+            bool hasPropertyRenter = EntityManager.HasComponent<PropertyRenter>(company);
+            bool hasResourcesBuffer = EntityManager.HasBuffer<Resources>(company);
+            bool hasCitizenTripNeededBuffer = EntityManager.HasBuffer<CitizenTripNeeded>(company);
+            bool hasAnyResourceBuyer = EntityManager.HasComponent<ResourceBuyer>(company);
+            bool hasPathInformation = EntityManager.HasComponent<PathInformation>(company);
+            bool hasCurrentTradingBuffer = EntityManager.HasBuffer<CurrentTrading>(company);
+            int currentTradingEntryCount = 0;
+            int selectedResourceCurrentTradingEntryCount = 0;
+            if (hasCurrentTradingBuffer)
+            {
+                DynamicBuffer<CurrentTrading> currentTrading = EntityManager.GetBuffer<CurrentTrading>(company, isReadOnly: true);
+                currentTradingEntryCount = currentTrading.Length;
+                for (int i = 0; i < currentTrading.Length; i++)
+                {
+                    if (currentTrading[i].m_TradingResource == selectedResource)
+                    {
+                        selectedResourceCurrentTradingEntryCount++;
+                    }
+                }
+            }
+
+            bool hasSelectedResourceCurrentTrading = selectedResourceCurrentTradingEntryCount > 0;
+            bool eligibleNow = hasBuyingCompany &&
+                               hasPropertyRenter &&
+                               hasResourcesBuffer &&
+                               hasCitizenTripNeededBuffer &&
+                               !hasAnyResourceBuyer &&
+                               !hasPathInformation &&
+                               !hasSelectedResourceCurrentTrading;
+
+            builder.Append(", elig(");
+            builder.Append("ok=").Append(CompactBool(eligibleNow));
+            builder.Append(",bc=").Append(CompactBool(hasBuyingCompany));
+            builder.Append(",pr=").Append(CompactBool(hasPropertyRenter));
+            builder.Append(",res=").Append(CompactBool(hasResourcesBuffer));
+            builder.Append(",tb=").Append(CompactBool(hasCitizenTripNeededBuffer));
+            builder.Append(",rb=").Append(CompactBool(hasAnyResourceBuyer));
+            builder.Append(",pi=").Append(CompactBool(hasPathInformation));
+            builder.Append(",ct=").Append(currentTradingEntryCount);
+            builder.Append(",srct=").Append(selectedResourceCurrentTradingEntryCount);
+            builder.Append(",ex=").Append(GetBuyerFixQueryExclusionReasonLabel(
+                hasBuyingCompany,
+                hasPropertyRenter,
+                hasResourcesBuffer,
+                hasCitizenTripNeededBuffer,
+                hasAnyResourceBuyer,
+                hasPathInformation,
+                hasSelectedResourceCurrentTrading));
+            builder.Append(')');
+        }
+
+        private void AppendCompactOutsideConnectionSellerProbeSummary(StringBuilder builder, Entity company, Resource resource)
+        {
+            builder.Append(", ocsp(");
+            if (!OutsideConnectionVirtualSellerFixPatch.TryGetLatestOfficeImportProbeSnapshot(company, resource, out OutsideConnectionVirtualSellerFixPatch.OfficeImportProbeSnapshot snapshot))
+            {
+                builder.Append("seen=0,ass=no_recent_probe");
+                builder.Append(')');
+                return;
+            }
+
+            int currentSimulationFrame = (int)m_SimulationSystem.frameIndex;
+            builder.Append("seen=1");
+            builder.Append(",age=");
+            builder.Append(snapshot.SimulationFrame >= 0
+                ? Math.Max(0, currentSimulationFrame - snapshot.SimulationFrame).ToString(CultureInfo.InvariantCulture)
+                : "na");
+            builder.Append(",ass=").Append(GetOutsideConnectionSellerAssessmentLabel(snapshot));
+            builder.Append(",avail=").Append(snapshot.AvailableCandidateCount);
+            builder.Append(",zero=").Append(snapshot.ZeroOrNegativeStockSellerCount);
+            builder.Append(",top=").Append(snapshot.TopAvailableStock);
+            builder.Append(",app=").Append(snapshot.AppendedOutsideConnectionCandidates);
+            builder.Append(",miss=").Append(snapshot.MissingStoredResourcePairs);
+            builder.Append(')');
+        }
+
+        private static void AppendCompactMetric(StringBuilder builder, string label, bool hasMetric, float value)
+        {
+            builder.Append(", ").Append(label).Append('=');
+            builder.Append(hasMetric ? value.ToString("0.###", CultureInfo.InvariantCulture) : "na");
+        }
+
+        private static string FormatCompactAge(int sampleAge)
+        {
+            return sampleAge >= 0 ? sampleAge.ToString(CultureInfo.InvariantCulture) : "na";
+        }
+
+        private static char CompactBool(bool value)
+        {
+            return value ? '1' : '0';
         }
 
         private static void AppendMetricValue(StringBuilder builder, bool hasMetric, float value)
@@ -1982,6 +3197,13 @@ namespace NoOfficeDemandFix.Systems
             builder.Append(", lastBuyerSeenSampleAge=");
             builder.Append(state.LastBuyerSeenSampleAge >= 0 ? state.LastBuyerSeenSampleAge.ToString(CultureInfo.InvariantCulture) : "n/a");
             builder.Append(", noBuyerReason=").Append(string.IsNullOrEmpty(state.NoBuyerReason) ? "none" : state.NoBuyerReason);
+            builder.Append(", companyUpdateFrame=");
+            builder.Append(state.CompanyUpdateFrame >= 0 ? state.CompanyUpdateFrame.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", currentVanillaBuyerUpdateFrame=");
+            builder.Append(state.CurrentVanillaBuyerUpdateFrame >= 0 ? state.CurrentVanillaBuyerUpdateFrame.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", framesUntilNextVanillaBuyerPass=");
+            builder.Append(state.FramesUntilNextVanillaBuyerPass >= 0 ? state.FramesUntilNextVanillaBuyerPass.ToString(CultureInfo.InvariantCulture) : "n/a");
+            builder.Append(", estimatedMissedVanillaBuyerPasses=").Append(state.EstimatedMissedVanillaBuyerPasses);
             builder.Append(", selectedNoBuyerConsecutiveWindows=").Append(state.SelectedNoBuyerConsecutiveWindows);
             builder.Append(", selectedRequestNoPathConsecutiveWindows=").Append(state.SelectedRequestNoPathConsecutiveWindows);
             builder.Append(", belowThresholdConsecutiveWindows=").Append(state.BelowThresholdConsecutiveWindows);
@@ -2086,6 +3308,59 @@ namespace NoOfficeDemandFix.Systems
             }
 
             builder.Append(')');
+        }
+
+        private void AppendOutsideConnectionSellerProbeState(StringBuilder builder, Entity company, Resource resource)
+        {
+            builder.Append(", outsideConnectionSellerProbe(");
+            if (!OutsideConnectionVirtualSellerFixPatch.TryGetLatestOfficeImportProbeSnapshot(company, resource, out OutsideConnectionVirtualSellerFixPatch.OfficeImportProbeSnapshot snapshot))
+            {
+                builder.Append("seenRecently=False");
+                builder.Append(", frameAge=n/a");
+                builder.Append(", requestedAmount=n/a");
+                builder.Append(", totalOutsideConnectionSellers=n/a");
+                builder.Append(", missingStoredResourcePairs=n/a");
+                builder.Append(", inactiveOutsideConnections=n/a");
+                builder.Append(", availableCandidateCount=n/a");
+                builder.Append(", zeroOrNegativeStockSellerCount=n/a");
+                builder.Append(", topAvailableStock=n/a");
+                builder.Append(", appendedOutsideConnectionCandidates=n/a");
+                builder.Append(", assessment=no_recent_probe");
+                builder.Append(')');
+                return;
+            }
+
+            int currentSimulationFrame = (int)m_SimulationSystem.frameIndex;
+            builder.Append("seenRecently=True");
+            builder.Append(", frameAge=");
+            builder.Append(snapshot.SimulationFrame >= 0
+                ? Math.Max(0, currentSimulationFrame - snapshot.SimulationFrame).ToString(CultureInfo.InvariantCulture)
+                : "n/a");
+            builder.Append(", requestedAmount=").Append(snapshot.RequestedAmount);
+            builder.Append(", totalOutsideConnectionSellers=").Append(snapshot.TotalOutsideConnectionSellers);
+            builder.Append(", missingStoredResourcePairs=").Append(snapshot.MissingStoredResourcePairs);
+            builder.Append(", inactiveOutsideConnections=").Append(snapshot.InactiveOutsideConnections);
+            builder.Append(", availableCandidateCount=").Append(snapshot.AvailableCandidateCount);
+            builder.Append(", zeroOrNegativeStockSellerCount=").Append(snapshot.ZeroOrNegativeStockSellerCount);
+            builder.Append(", topAvailableStock=").Append(snapshot.TopAvailableStock);
+            builder.Append(", appendedOutsideConnectionCandidates=").Append(snapshot.AppendedOutsideConnectionCandidates);
+            builder.Append(", assessment=").Append(GetOutsideConnectionSellerAssessmentLabel(snapshot));
+            builder.Append(')');
+        }
+
+        private static string GetOutsideConnectionSellerAssessmentLabel(OutsideConnectionVirtualSellerFixPatch.OfficeImportProbeSnapshot snapshot)
+        {
+            if (snapshot.AvailableCandidateCount > 0)
+            {
+                return "candidates_available";
+            }
+
+            if (snapshot.ZeroOrNegativeStockSellerCount > 0)
+            {
+                return "all_zero_stock";
+            }
+
+            return "no_candidate";
         }
 
         private void AppendTradeCostSnapshot(StringBuilder builder, string label, Resource resource, Entity company)
@@ -2433,12 +3708,26 @@ namespace NoOfficeDemandFix.Systems
         private SoftwareAcquisitionState GetSoftwareAcquisitionState(Entity company)
         {
             SoftwareAcquisitionState state = default;
+            uint currentSimulationFrame = m_SimulationSystem.frameIndex;
             state.ResourceWeight = GetResourceWeight(Resource.Software);
             state.VirtualGood = state.ResourceWeight <= 0f;
             state.TripTrackingExpected = !state.VirtualGood;
             state.CurrentTradingExpected = !state.VirtualGood;
             state.PathExpected = true;
             state.CorrectiveBuyerTagged = EntityManager.HasComponent<CorrectiveSoftwareBuyerTag>(company);
+            if (TryGetCompanyUpdateFrame(company, out int companyUpdateFrame))
+            {
+                state.CompanyUpdateFrame = companyUpdateFrame;
+                state.CurrentVanillaBuyerUpdateFrame = (int)SimulationUtils.GetUpdateFrameWithInterval(currentSimulationFrame, kVanillaBuyerUpdateInterval, kVanillaBuyerUpdateGroupCount);
+                state.FramesUntilNextVanillaBuyerPass = GetFramesUntilNextVanillaBuyerPass(currentSimulationFrame, companyUpdateFrame);
+            }
+            else
+            {
+                state.CompanyUpdateFrame = -1;
+                state.CurrentVanillaBuyerUpdateFrame = -1;
+                state.FramesUntilNextVanillaBuyerPass = -1;
+            }
+
             if (TryGetResourceBuyer(company, Resource.Software, out ResourceBuyer buyer))
             {
                 state.ResourceBuyerPresent = true;
@@ -2474,6 +3763,7 @@ namespace NoOfficeDemandFix.Systems
         private SoftwareConsumerTraceState UpdateSoftwareConsumerTrace(Entity company, SoftwareNeedState needState, SoftwareAcquisitionState acquisitionState, int day, int sampleIndex, Entity currentLastTradePartner, bool hasCurrentLastTradePartnerObservation)
         {
             m_SoftwareConsumerTrace.TryGetValue(company, out SoftwareConsumerTraceState traceState);
+            uint currentSimulationFrame = m_SimulationSystem.frameIndex;
             if (traceState.HasObservedSoftwareStock)
             {
                 traceState.PreviousSoftwareStock = traceState.LastObservedSoftwareStock;
@@ -2522,9 +3812,17 @@ namespace NoOfficeDemandFix.Systems
             }
 
             string currentClassification = ClassifySoftwareConsumerState(needState, acquisitionState, traceState);
+            bool stayedSelectedNoBuyer = string.Equals(traceState.CurrentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal) &&
+                                         string.Equals(currentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal);
             traceState.BelowThresholdConsecutiveWindows = needState.Selected ? traceState.BelowThresholdConsecutiveWindows + 1 : 0;
             traceState.SelectedNoBuyerConsecutiveWindows = string.Equals(currentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal)
                 ? traceState.SelectedNoBuyerConsecutiveWindows + 1
+                : 0;
+            // Estimate missed vanilla buyer opportunities only across observed sample-to-sample no-buyer streaks.
+            traceState.SelectedNoBuyerEstimatedMissedVanillaPasses = string.Equals(currentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal)
+                ? stayedSelectedNoBuyer && traceState.HasLastObservedSimulationFrame
+                    ? traceState.SelectedNoBuyerEstimatedMissedVanillaPasses + CountVanillaBuyerPassesBetweenFrames(traceState.LastObservedSimulationFrame, currentSimulationFrame, acquisitionState.CompanyUpdateFrame)
+                    : 0
                 : 0;
             traceState.SelectedRequestNoPathConsecutiveWindows = string.Equals(currentClassification, kTraceSelectedResourceBuyerNoPath, StringComparison.Ordinal)
                 ? traceState.SelectedRequestNoPathConsecutiveWindows + 1
@@ -2538,6 +3836,8 @@ namespace NoOfficeDemandFix.Systems
             }
 
             traceState.CurrentClassification = currentClassification;
+            traceState.LastObservedSimulationFrame = currentSimulationFrame;
+            traceState.HasLastObservedSimulationFrame = true;
             m_SoftwareConsumerTrace[company] = traceState;
             return traceState;
         }
@@ -2560,6 +3860,9 @@ namespace NoOfficeDemandFix.Systems
             state.BuyerSeenThisWindow = state.ResourceBuyerPresent;
             state.BuyerOrigin = GetBuyerOriginLabel(state);
             state.LastBuyerSeenSampleAge = GetSampleAge(traceState.HasLastBuyerSeenSampleIndex, traceState.LastBuyerSeenSampleIndex, sampleIndex);
+            state.EstimatedMissedVanillaBuyerPasses = string.Equals(traceState.CurrentClassification, kTraceSelectedNoResourceBuyer, StringComparison.Ordinal)
+                ? traceState.SelectedNoBuyerEstimatedMissedVanillaPasses
+                : 0;
             state.SelectedNoBuyerConsecutiveWindows = traceState.SelectedNoBuyerConsecutiveWindows;
             state.SelectedRequestNoPathConsecutiveWindows = traceState.SelectedRequestNoPathConsecutiveWindows;
             state.BelowThresholdConsecutiveWindows = traceState.BelowThresholdConsecutiveWindows;
@@ -2584,6 +3887,13 @@ namespace NoOfficeDemandFix.Systems
                 return "none";
             }
 
+            if (state.EstimatedMissedVanillaBuyerPasses > 0)
+            {
+                return state.VirtualGood && Mod.Settings != null && Mod.Settings.EnableVirtualOfficeResourceBuyerFix
+                    ? "missed_vanilla_buyer_pass_awaiting_corrective_pass"
+                    : "missed_vanilla_buyer_pass";
+            }
+
             if (state.VirtualGood && state.LastVirtualResolutionSampleAge >= 0 && state.LastVirtualResolutionSampleAge <= 1)
             {
                 return "buyer_recently_resolved_virtual";
@@ -2600,6 +3910,84 @@ namespace NoOfficeDemandFix.Systems
         private static int GetSampleAge(bool hasValue, int lastSampleIndex, int currentSampleIndex)
         {
             return hasValue ? Math.Max(0, currentSampleIndex - lastSampleIndex) : -1;
+        }
+
+        private bool TryGetCompanyUpdateFrame(Entity company, out int updateFrameIndex)
+        {
+            if (EntityManager.HasComponent<UpdateFrame>(company))
+            {
+                updateFrameIndex = (int)EntityManager.GetSharedComponent<UpdateFrame>(company).m_Index;
+                return true;
+            }
+
+            updateFrameIndex = -1;
+            return false;
+        }
+
+        private static int GetFramesUntilNextVanillaBuyerPass(uint currentFrame, int companyUpdateFrame)
+        {
+            if (companyUpdateFrame < 0)
+            {
+                return -1;
+            }
+
+            uint currentBucket = currentFrame / kVanillaBuyerUpdateInterval;
+            uint currentGroup = currentBucket % (uint)kVanillaBuyerUpdateGroupCount;
+            uint targetGroup = (uint)companyUpdateFrame;
+            uint bucketDelta = targetGroup > currentGroup
+                ? targetGroup - currentGroup
+                : (uint)kVanillaBuyerUpdateGroupCount - (currentGroup - targetGroup);
+            if (bucketDelta == 0u)
+            {
+                bucketDelta = (uint)kVanillaBuyerUpdateGroupCount;
+            }
+
+            uint nextBuyerBucket = currentBucket + bucketDelta;
+            uint nextBuyerFrame = nextBuyerBucket * kVanillaBuyerUpdateInterval;
+            return nextBuyerFrame > currentFrame ? (int)(nextBuyerFrame - currentFrame) : 0;
+        }
+
+        private static int CountVanillaBuyerPassesBetweenFrames(uint startFrame, uint endFrame, int companyUpdateFrame)
+        {
+            if (companyUpdateFrame < 0 || endFrame <= startFrame)
+            {
+                return 0;
+            }
+
+            uint startBucket = startFrame / kVanillaBuyerUpdateInterval;
+            uint endBucket = endFrame / kVanillaBuyerUpdateInterval;
+            if (endBucket <= startBucket)
+            {
+                return 0;
+            }
+
+            return CountCongruentValuesInInclusiveRange(
+                startBucket + 1u,
+                endBucket,
+                (uint)companyUpdateFrame,
+                (uint)kVanillaBuyerUpdateGroupCount);
+        }
+
+        private static int CountCongruentValuesInInclusiveRange(uint startValue, uint endValue, uint targetRemainder, uint modulus)
+        {
+            if (startValue > endValue || modulus == 0u)
+            {
+                return 0;
+            }
+
+            uint first = startValue;
+            uint currentRemainder = first % modulus;
+            if (currentRemainder != targetRemainder)
+            {
+                first += (targetRemainder + modulus - currentRemainder) % modulus;
+            }
+
+            if (first > endValue)
+            {
+                return 0;
+            }
+
+            return 1 + (int)((endValue - first) / modulus);
         }
 
         private static string GetBuyerOriginLabel(SoftwareAcquisitionState state)
@@ -3026,6 +4414,150 @@ namespace NoOfficeDemandFix.Systems
             return builder.ToString();
         }
 
+        private static string FormatAllFactors(NativeArray<int> factors)
+        {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < factors.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                string factorName = Enum.GetName(typeof(DemandFactor), i) ?? $"factor_{i}";
+                builder.Append(factorName).Append('=').Append(factors[i]);
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool TryGetDemandFactorValue(NativeArray<int> factors, string factorName, out int value)
+        {
+            value = 0;
+            if (!Enum.TryParse(factorName, ignoreCase: false, out DemandFactor factor))
+            {
+                return false;
+            }
+
+            int index = (int)factor;
+            if ((uint)index >= (uint)factors.Length)
+            {
+                return false;
+            }
+
+            value = factors[index];
+            return true;
+        }
+
+        private static int CountOversupplySignals(DiagnosticSnapshot snapshot)
+        {
+            int count = 0;
+            if (snapshot.EmptyBuildingsFactor != 0)
+            {
+                count++;
+            }
+
+            if (snapshot.LocalDemandFactorKnown && snapshot.LocalDemandFactor != 0)
+            {
+                count++;
+            }
+
+            if (snapshot.FreeOfficeProperties > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.OnMarketOfficeProperties > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.ActivelyVacantOfficeProperties > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.StaleRenterOnMarketOfficeProperties > 0)
+            {
+                count++;
+            }
+
+            return count;
+        }
+
+        private static int CountSoftwareTrackSignals(DiagnosticSnapshot snapshot)
+        {
+            int count = 0;
+            if (snapshot.SoftwareProducerOfficeEfficiencyZero > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareProducerOfficeLackResourcesZero > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareConsumerOfficeEfficiencyZero > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareConsumerOfficeLackResourcesZero > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareConsumerOfficeSoftwareInputZero > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareConsumerSelectedNoResourceBuyer > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareConsumerSelectedRequestNoPath > 0)
+            {
+                count++;
+            }
+
+            if (snapshot.SoftwareConsumerPathPending > 0)
+            {
+                count++;
+            }
+
+            return count;
+        }
+
+        private static string FormatDemandSignalPattern(DiagnosticSnapshot snapshot)
+        {
+            int oversupplySignals = CountOversupplySignals(snapshot);
+            int softwareTrackSignals = CountSoftwareTrackSignals(snapshot);
+            if (oversupplySignals > 0 && softwareTrackSignals > 0)
+            {
+                return "mixed_oversupply_and_software_track";
+            }
+
+            if (oversupplySignals > 0)
+            {
+                return "oversupply_candidate";
+            }
+
+            if (softwareTrackSignals > 0)
+            {
+                return "software_track_candidate";
+            }
+
+            return "none_detected";
+        }
+
+        private static string FormatOptionalFactorValue(bool isKnown, int value)
+        {
+            return isKnown ? value.ToString(CultureInfo.InvariantCulture) : "n/a";
+        }
+
         private static bool IsDiagnosticsEnabled()
         {
             return Mod.Settings != null && Mod.Settings.EnableDemandDiagnostics;
@@ -3097,16 +4629,21 @@ namespace NoOfficeDemandFix.Systems
 
         private static string FormatDiagnosticCounters(DiagnosticSnapshot snapshot)
         {
+            int oversupplySignals = CountOversupplySignals(snapshot);
+            int softwareTrackSignals = CountSoftwareTrackSignals(snapshot);
             return
                 $"officeDemand(building={snapshot.OfficeBuildingDemand}, company={snapshot.OfficeCompanyDemand}, emptyBuildings={snapshot.EmptyBuildingsFactor}, buildingDemand={snapshot.BuildingDemandFactor}); " +
+                $"officeDemandSignals(unoccupiedBuildingsFactor={snapshot.EmptyBuildingsFactor}, localDemandFactorKnown={snapshot.LocalDemandFactorKnown}, localDemandFactor={FormatOptionalFactorValue(snapshot.LocalDemandFactorKnown, snapshot.LocalDemandFactor)}, freeProperties={snapshot.FreeOfficeProperties}, onMarket={snapshot.OnMarketOfficeProperties}, activelyVacant={snapshot.ActivelyVacantOfficeProperties}, staleRenterOnly={snapshot.StaleRenterOnMarketOfficeProperties}, oversupplySignalCount={oversupplySignals}, softwareTrackSignalCount={softwareTrackSignals}, pattern={FormatDemandSignalPattern(snapshot)}); " +
                 $"freeOfficeProperties(total={snapshot.FreeOfficeProperties}, software={snapshot.FreeSoftwareOfficeProperties}, inOccupiedBuildings={snapshot.FreeOfficePropertiesInOccupiedBuildings}, softwareInOccupiedBuildings={snapshot.FreeSoftwareOfficePropertiesInOccupiedBuildings}); " +
                 $"onMarketOfficeProperties(total={snapshot.OnMarketOfficeProperties}, activelyVacant={snapshot.ActivelyVacantOfficeProperties}, occupied={snapshot.OccupiedOnMarketOfficeProperties}, staleRenterOnly={snapshot.StaleRenterOnMarketOfficeProperties}); " +
                 $"phantomVacancy(signatureOccupiedOnMarketOffice={snapshot.SignatureOccupiedOnMarketOffice}, signatureOccupiedOnMarketIndustrial={snapshot.SignatureOccupiedOnMarketIndustrial}, signatureOccupiedToBeOnMarket={snapshot.SignatureOccupiedToBeOnMarket}, nonSignatureOccupiedOnMarketOffice={snapshot.NonSignatureOccupiedOnMarketOffice}, nonSignatureOccupiedOnMarketIndustrial={snapshot.NonSignatureOccupiedOnMarketIndustrial}, guardCorrections={snapshot.GuardCorrections}); " +
                 $"software(resourceProduction={snapshot.SoftwareProduction}, resourceDemand={snapshot.SoftwareDemand}, companies={snapshot.SoftwareProductionCompanies}, propertyless={snapshot.SoftwarePropertylessCompanies}); " +
+                $"softwareMarket(totalSellableInCity={snapshot.SoftwareTotalSellableInCity}, industrialSinkSmoothed={snapshot.SoftwareIndustrialConsumption}, industrialSinkAccumulator={snapshot.SoftwareIndustrialConsumptionAccumulator}); " +
+                $"softwareLocalSellers(total={snapshot.SoftwareLocalSellerCount}, inactiveExcluded={snapshot.SoftwareLocalSellerInactiveExcludedCount}, requestAmount={kResourceLowStockAmount}, requestHalfThreshold={kResourceMinimumRequestAmount}, stock={snapshot.SoftwareLocalSellerStock}, buyingLoad={snapshot.SoftwareLocalSellerBuyingLoad}, availableNet={snapshot.SoftwareLocalSellerAvailableStockNet}, availablePositive={snapshot.SoftwareLocalSellerPositiveAvailableStock}, positiveAvailableCount={snapshot.SoftwareLocalSellerPositiveAvailableCount}, nonPositiveAvailableCount={snapshot.SoftwareLocalSellerNonPositiveAvailableCount}, eligibleAt2000Count={snapshot.SoftwareLocalSellerEligibleCount}, eligibleAt4000Count={snapshot.SoftwareLocalSellerEligibleAtFullRequestCount}, eligibleAvailableStock={snapshot.SoftwareLocalSellerEligibleAvailableStock}, maxAvailableStock={snapshot.SoftwareLocalSellerMaxAvailableStock}); " +
                 $"electronics(resourceProduction={snapshot.ElectronicsProduction}, resourceDemand={snapshot.ElectronicsDemand}, companies={snapshot.ElectronicsProductionCompanies}, propertyless={snapshot.ElectronicsPropertylessCompanies}); " +
                 $"softwareProducerOffices(total={snapshot.SoftwareProducerOfficeCompanies}, propertyless={snapshot.SoftwareProducerOfficePropertylessCompanies}, efficiencyZero={snapshot.SoftwareProducerOfficeEfficiencyZero}, lackResourcesZero={snapshot.SoftwareProducerOfficeLackResourcesZero}); " +
                 $"softwareConsumerOffices(total={snapshot.SoftwareConsumerOfficeCompanies}, propertyless={snapshot.SoftwareConsumerOfficePropertylessCompanies}, efficiencyZero={snapshot.SoftwareConsumerOfficeEfficiencyZero}, lackResourcesZero={snapshot.SoftwareConsumerOfficeLackResourcesZero}, softwareInputZero={snapshot.SoftwareConsumerOfficeSoftwareInputZero}); " +
-                $"softwareConsumerBuyerState(needSelected={snapshot.SoftwareConsumerNeedSelected}, resourceBuyerPresent={snapshot.SoftwareConsumerResourceBuyerPresent}, correctiveBuyerPresent={snapshot.SoftwareConsumerCorrectiveBuyerPresent}, vanillaBuyerPresent={snapshot.SoftwareConsumerVanillaBuyerPresent}, trackingExpectedSelected={snapshot.SoftwareConsumerTrackingExpectedSelected}, selectedNoResourceBuyer={snapshot.SoftwareConsumerSelectedNoResourceBuyer}, selectedNoBuyerShortGap={snapshot.SoftwareConsumerSelectedNoBuyerShortGap}, selectedNoBuyerPersistent={snapshot.SoftwareConsumerSelectedNoBuyerPersistent}, selectedRequestNoPath={snapshot.SoftwareConsumerSelectedRequestNoPath}, selectedRequestNoPathShortGap={snapshot.SoftwareConsumerSelectedRequestNoPathShortGap}, selectedRequestNoPathPersistent={snapshot.SoftwareConsumerSelectedRequestNoPathPersistent}, pathPending={snapshot.SoftwareConsumerPathPending}, resolvedVirtualNoTrackingExpected={snapshot.SoftwareConsumerResolvedVirtualNoTrackingExpected}, resolvedNoTrackingUnexpected={snapshot.SoftwareConsumerResolvedNoTrackingUnexpected}, tripPresent={snapshot.SoftwareConsumerTripPresent}, currentTradingPresent={snapshot.SoftwareConsumerCurrentTradingPresent}, virtualResolvedThisWindow={snapshot.SoftwareConsumerVirtualResolvedThisWindow}, virtualResolvedAmount={snapshot.SoftwareConsumerVirtualResolvedAmount})";
+                $"softwareConsumerBuyerState(needSelected={snapshot.SoftwareConsumerNeedSelected}, resourceBuyerPresent={snapshot.SoftwareConsumerResourceBuyerPresent}, correctiveBuyerPresent={snapshot.SoftwareConsumerCorrectiveBuyerPresent}, vanillaBuyerPresent={snapshot.SoftwareConsumerVanillaBuyerPresent}, trackingExpectedSelected={snapshot.SoftwareConsumerTrackingExpectedSelected}, selectedNoResourceBuyer={snapshot.SoftwareConsumerSelectedNoResourceBuyer}, selectedNoBuyerShortGap={snapshot.SoftwareConsumerSelectedNoBuyerShortGap}, selectedNoBuyerPersistent={snapshot.SoftwareConsumerSelectedNoBuyerPersistent}, selectedNoBuyerMissedVanillaPass={snapshot.SoftwareConsumerSelectedNoBuyerMissedVanillaPass}, selectedNoBuyerMissedMultipleVanillaPasses={snapshot.SoftwareConsumerSelectedNoBuyerMissedMultipleVanillaPasses}, selectedNoBuyerMaxMissedVanillaPasses={snapshot.SoftwareConsumerSelectedNoBuyerMaxMissedVanillaPasses}, selectedRequestNoPath={snapshot.SoftwareConsumerSelectedRequestNoPath}, selectedRequestNoPathShortGap={snapshot.SoftwareConsumerSelectedRequestNoPathShortGap}, selectedRequestNoPathPersistent={snapshot.SoftwareConsumerSelectedRequestNoPathPersistent}, pathPending={snapshot.SoftwareConsumerPathPending}, resolvedVirtualNoTrackingExpected={snapshot.SoftwareConsumerResolvedVirtualNoTrackingExpected}, resolvedNoTrackingUnexpected={snapshot.SoftwareConsumerResolvedNoTrackingUnexpected}, tripPresent={snapshot.SoftwareConsumerTripPresent}, currentTradingPresent={snapshot.SoftwareConsumerCurrentTradingPresent}, virtualResolvedThisWindow={snapshot.SoftwareConsumerVirtualResolvedThisWindow}, virtualResolvedAmount={snapshot.SoftwareConsumerVirtualResolvedAmount})";
         }
 
         private static bool TryGetObservationTrigger(
@@ -3158,6 +4695,103 @@ namespace NoOfficeDemandFix.Systems
             buyerFixSystem.ResetProbeState();
         }
 
+        private void EmitVerboseObservationDetails(DiagnosticSnapshot snapshot)
+        {
+            ObservationDetailCapture detailCapture = snapshot.DetailCapture;
+            if (detailCapture == null)
+            {
+                return;
+            }
+
+            EmitVerboseTradeLifecycleDetails(snapshot, detailCapture);
+            EmitVerboseBuyerTimingProbeDetails(snapshot, detailCapture);
+            EmitVerboseSellerResolutionProbeDetails(snapshot, detailCapture);
+        }
+
+        private void EmitVerboseTradeLifecycleDetails(DiagnosticSnapshot snapshot, ObservationDetailCapture detailCapture)
+        {
+            for (int i = 0; i < detailCapture.SoftwareTradeLifecycleDetailCandidates.Count; i++)
+            {
+                SoftwareTradeLifecycleDetailCandidate candidate = detailCapture.SoftwareTradeLifecycleDetailCandidates[i];
+                string values = candidate.IsProducer
+                    ? DescribeProducerTradeLifecycle(
+                        candidate.Company,
+                        candidate.CompanyPrefab,
+                        candidate.Property,
+                        candidate.ProcessData,
+                        candidate.HasEfficiency,
+                        candidate.Efficiency,
+                        candidate.LackResources)
+                    : DescribeConsumerTradeLifecycle(
+                        candidate.Company,
+                        candidate.CompanyPrefab,
+                        candidate.Property,
+                        candidate.ProcessData,
+                        candidate.HasEfficiency,
+                        candidate.Efficiency,
+                        candidate.LackResources,
+                        candidate.SoftwareConsumerState);
+                Mod.log.Info(FormatVerboseDetail(
+                    snapshot.Day,
+                    snapshot.SampleIndex,
+                    MachineParsedLogContract.SoftwareTradeLifecycleDetailType + "Expanded",
+                    i,
+                    values));
+            }
+        }
+
+        private void EmitVerboseBuyerTimingProbeDetails(DiagnosticSnapshot snapshot, ObservationDetailCapture detailCapture)
+        {
+            for (int i = 0; i < detailCapture.SoftwareBuyerTimingProbeDetailCandidates.Count; i++)
+            {
+                SoftwareBuyerTimingProbeDetailCandidate candidate = detailCapture.SoftwareBuyerTimingProbeDetailCandidates[i];
+                string values = DescribeSoftwareBuyerTimingProbe(
+                    candidate.Company,
+                    candidate.CompanyPrefab,
+                    candidate.Property,
+                    candidate.ProcessData,
+                    candidate.HasEfficiency,
+                    candidate.Efficiency,
+                    candidate.LackResources,
+                    candidate.SoftwareConsumerState);
+                Mod.log.Info(FormatVerboseDetail(
+                    snapshot.Day,
+                    snapshot.SampleIndex,
+                    MachineParsedLogContract.SoftwareBuyerTimingProbeDetailType + "Expanded",
+                    i,
+                    values));
+            }
+        }
+
+        private void EmitVerboseSellerResolutionProbeDetails(DiagnosticSnapshot snapshot, ObservationDetailCapture detailCapture)
+        {
+            for (int i = 0; i < detailCapture.SoftwareSellerResolutionProbeDetailCandidates.Count; i++)
+            {
+                SoftwareSellerResolutionProbeDetailCandidate candidate = detailCapture.SoftwareSellerResolutionProbeDetailCandidates[i];
+                string values = DescribeSoftwareSellerResolutionProbe(
+                    candidate.Company,
+                    candidate.CompanyPrefab,
+                    candidate.Property,
+                    candidate.ProcessData,
+                    candidate.HasEfficiency,
+                    candidate.Efficiency,
+                    candidate.LackResources,
+                    candidate.SoftwareConsumerState);
+                Mod.log.Info(FormatVerboseDetail(
+                    snapshot.Day,
+                    snapshot.SampleIndex,
+                    MachineParsedLogContract.SoftwareSellerResolutionProbeDetailType + "Expanded",
+                    i,
+                    values));
+            }
+        }
+
+        private string FormatVerboseDetail(int observationEndDay, int observationEndSampleIndex, string detailType, int entryIndex, string values)
+        {
+            return
+                $"{kVerboseDetailPrefix}session_id={m_SessionId}, run_id={m_RunSequence}, observation_end_day={observationEndDay}, observation_end_sample_index={observationEndSampleIndex}, detail_type={detailType}, entry_index={entryIndex}, values={values})";
+        }
+
         private void ResetEvidenceSession()
         {
             m_SessionId = CreateSessionId();
@@ -3177,6 +4811,8 @@ namespace NoOfficeDemandFix.Systems
             m_SoftwareOfficePrefabCache.Clear();
             m_ResourceWeightCache.Clear();
             ResetVirtualOfficeBuyerProbeState();
+            OutsideConnectionVirtualSellerFixPatch.ResetDetailedRequestProbes();
+            IndustrialDemandDiagnosticsProbePatch.Reset();
         }
 
         private static string CreateSessionId()
@@ -3194,6 +4830,8 @@ namespace NoOfficeDemandFix.Systems
             m_DisplayedClockDay = int.MinValue;
             m_LastComputedSampleSlot = int.MinValue;
             ResetVirtualOfficeBuyerProbeState();
+            OutsideConnectionVirtualSellerFixPatch.ResetDetailedRequestProbes();
+            IndustrialDemandDiagnosticsProbePatch.Reset();
             m_LastSettingsState = settingsState;
             m_LastSettingsSnapshot = FormatSettingsSnapshot(settingsState);
             m_LastPatchState = patchState;
@@ -3390,6 +5028,12 @@ namespace NoOfficeDemandFix.Systems
             }
 
             return '"' + prefabName + "\" (" + FormatEntity(prefab) + ')';
+        }
+
+        private string GetCompactPrefabLabel(Entity prefab)
+        {
+            string prefabName = m_PrefabSystem.GetPrefabName(prefab);
+            return string.IsNullOrEmpty(prefabName) ? FormatEntity(prefab) : prefabName;
         }
 
         private static string FormatEntity(Entity entity)

--- a/NoOfficeDemandFix/Systems/VirtualOfficeResourceBuyerFixSystem.cs
+++ b/NoOfficeDemandFix/Systems/VirtualOfficeResourceBuyerFixSystem.cs
@@ -35,11 +35,14 @@ namespace NoOfficeDemandFix.Systems
         private const int kMaxProbeSampleLogs = 3;
         private const float kLowStockThresholdRatio = 0.25f;
         private const uint kFallbackSweepIntervalMask = 127u;
+        private const string kPassKindChangedQuery = "changed_query";
+        private const string kPassKindFullSweep = "full_sweep";
 
         private ResourceSystem m_ResourceSystem;
         private SimulationSystem m_SimulationSystem;
         private EntityQuery m_OfficeCompanyQuery;
         private EntityQuery m_OfficeCompanyChangedQuery;
+        private EntityQuery m_OfficeCompanyCurrentTradingChangedQuery;
         private EntityQuery m_CorrectiveBuyerBackfillQuery;
         private EntityQuery m_CorrectiveBuyerMarkerCleanupQuery;
         private EntityQuery m_CorrectiveBuyerProvenanceCleanupQuery;
@@ -48,12 +51,63 @@ namespace NoOfficeDemandFix.Systems
         private readonly Dictionary<Resource, ResourceOverrideAggregate> m_ProbeResourceAggregates = new();
         private readonly HashSet<string> m_ProbeDistinctCompanies = new();
         private readonly List<BuyerOverrideSample> m_ProbeTopSamples = new();
+        private readonly Dictionary<Entity, CompanyProbeWindowState> m_CompanyProbeWindowStates = new();
 
         private int m_ProbeTotalOverrideCount;
         private int m_ProbeClampedMinimumOverrideCount;
         private int m_ProbeAboveMinimumOverrideCount;
         private int m_ProbeMaxOverrideAmount;
         private int m_ProbeMaxShortfall;
+
+        public readonly struct CompanyProbeWindowSnapshot
+        {
+            public CompanyProbeWindowSnapshot(
+                int seenChangedQueryCount,
+                int seenFullSweepCount,
+                bool lastSeenViaFullSweep,
+                int lastSeenFrame,
+                int overrideCount,
+                bool lastOverrideViaFullSweep,
+                int lastOverrideFrame,
+                int lastOverrideAmount,
+                int lastOverrideShortfall,
+                int lastOverrideStock,
+                int lastOverrideBuyingLoad,
+                int lastOverrideTripNeededAmount,
+                int lastOverrideEffectiveStock,
+                int lastOverrideThreshold)
+            {
+                SeenChangedQueryCount = seenChangedQueryCount;
+                SeenFullSweepCount = seenFullSweepCount;
+                LastSeenViaFullSweep = lastSeenViaFullSweep;
+                LastSeenFrame = lastSeenFrame;
+                OverrideCount = overrideCount;
+                LastOverrideViaFullSweep = lastOverrideViaFullSweep;
+                LastOverrideFrame = lastOverrideFrame;
+                LastOverrideAmount = lastOverrideAmount;
+                LastOverrideShortfall = lastOverrideShortfall;
+                LastOverrideStock = lastOverrideStock;
+                LastOverrideBuyingLoad = lastOverrideBuyingLoad;
+                LastOverrideTripNeededAmount = lastOverrideTripNeededAmount;
+                LastOverrideEffectiveStock = lastOverrideEffectiveStock;
+                LastOverrideThreshold = lastOverrideThreshold;
+            }
+
+            public int SeenChangedQueryCount { get; }
+            public int SeenFullSweepCount { get; }
+            public bool LastSeenViaFullSweep { get; }
+            public int LastSeenFrame { get; }
+            public int OverrideCount { get; }
+            public bool LastOverrideViaFullSweep { get; }
+            public int LastOverrideFrame { get; }
+            public int LastOverrideAmount { get; }
+            public int LastOverrideShortfall { get; }
+            public int LastOverrideStock { get; }
+            public int LastOverrideBuyingLoad { get; }
+            public int LastOverrideTripNeededAmount { get; }
+            public int LastOverrideEffectiveStock { get; }
+            public int LastOverrideThreshold { get; }
+        }
 
         private struct BuyerOverrideProbeRecord
         {
@@ -105,6 +159,9 @@ namespace NoOfficeDemandFix.Systems
 
             [ReadOnly]
             public BufferLookup<LayoutElement> LayoutElements;
+
+            [ReadOnly]
+            public BufferLookup<CurrentTrading> CurrentTradings;
 
             [ReadOnly]
             public ResourcePrefabs ResourcePrefabs;
@@ -172,6 +229,11 @@ namespace NoOfficeDemandFix.Systems
                     }
 
                     if (HasAnyTripForResource(tripNeededBuffer, selectedResource))
+                    {
+                        continue;
+                    }
+
+                    if (HasCurrentTradingForResource(company, selectedResource))
                     {
                         continue;
                     }
@@ -260,6 +322,16 @@ namespace NoOfficeDemandFix.Systems
                     ? processData.m_Input2.m_Resource
                     : Resource.NoResource;
                 return new PrefabVirtualInputInfo(input1, input2, slotCapacity);
+            }
+
+            private bool HasCurrentTradingForResource(Entity company, Resource resource)
+            {
+                if (!CurrentTradings.HasBuffer(company))
+                {
+                    return false;
+                }
+
+                return VirtualOfficeResourceBuyerFixSystem.HasCurrentTradingForResource(CurrentTradings[company], resource);
             }
 
             private bool TrySelectVirtualOfficeInput(
@@ -419,12 +491,14 @@ namespace NoOfficeDemandFix.Systems
             m_SimulationSystem = World.GetOrCreateSystemManaged<SimulationSystem>();
             m_OfficeCompanyQuery = GetEntityQuery(CreateOfficeCompanyQueryDesc());
             m_OfficeCompanyChangedQuery = EntityManager.CreateEntityQuery(CreateOfficeCompanyQueryDesc());
+            m_OfficeCompanyCurrentTradingChangedQuery = EntityManager.CreateEntityQuery(CreateOfficeCompanyCurrentTradingChangedQueryDesc());
             m_CorrectiveBuyerBackfillQuery = GetEntityQuery(CreateCorrectiveBuyerBackfillQueryDesc());
             m_OfficeCompanyChangedQuery.SetChangedVersionFilter(new[]
             {
                 ComponentType.ReadOnly<Resources>(),
                 ComponentType.ReadOnly<CitizenTripNeeded>()
             });
+            m_OfficeCompanyCurrentTradingChangedQuery.SetChangedVersionFilter(ComponentType.ReadOnly<CurrentTrading>());
             m_CorrectiveBuyerMarkerCleanupQuery = GetEntityQuery(
                 ComponentType.ReadOnly<CorrectiveSoftwareBuyerTag>(),
                 ComponentType.Exclude<ResourceBuyer>(),
@@ -485,16 +559,71 @@ namespace NoOfficeDemandFix.Systems
                     return;
                 }
 
-                EntityQuery officeCompanyQuery = ShouldRunFallbackSweep()
-                    ? m_OfficeCompanyQuery
-                    : m_OfficeCompanyChangedQuery;
-                if (officeCompanyQuery.IsEmpty)
+                bool usedFullSweep = ShouldRunFallbackSweep();
+                if (usedFullSweep)
                 {
+                    RunBuyerOverridePass(
+                        m_OfficeCompanyQuery,
+                        usedFullSweep,
+                        diagnosticsEnabled,
+                        captureTelemetry,
+                        ref telemetryEntitiesInspected,
+                        ref telemetryRepathRequested);
                     return;
                 }
 
-                ResourcePrefabs resourcePrefabs = m_ResourceSystem.GetPrefabs();
-                bool captureProbeResults = diagnosticsEnabled;
+                RunBuyerOverridePass(
+                    m_OfficeCompanyChangedQuery,
+                    usedFullSweep,
+                    diagnosticsEnabled,
+                    captureTelemetry,
+                    ref telemetryEntitiesInspected,
+                    ref telemetryRepathRequested);
+                RunBuyerOverridePass(
+                    m_OfficeCompanyCurrentTradingChangedQuery,
+                    usedFullSweep,
+                    diagnosticsEnabled,
+                    captureTelemetry,
+                    ref telemetryEntitiesInspected,
+                    ref telemetryRepathRequested);
+            }
+            finally
+            {
+                m_LastCorrectiveBuyerTaggingEnabled = correctiveBuyerTaggingEnabled;
+
+                if (captureTelemetry)
+                {
+                    PerformanceTelemetryCollector.RecordModUpdateElapsedTicks(Stopwatch.GetTimestamp() - telemetryStart);
+                    PerformanceTelemetryCollector.RecordModActivity(telemetryEntitiesInspected, telemetryRepathRequested);
+                }
+            }
+        }
+
+        private void RunBuyerOverridePass(
+            EntityQuery officeCompanyQuery,
+            bool usedFullSweep,
+            bool diagnosticsEnabled,
+            bool captureTelemetry,
+            ref int telemetryEntitiesInspected,
+            ref int telemetryRepathRequested)
+        {
+            if (officeCompanyQuery.IsEmpty)
+            {
+                return;
+            }
+
+            ResourcePrefabs resourcePrefabs = m_ResourceSystem.GetPrefabs();
+            bool captureProbeResults = diagnosticsEnabled;
+            uint currentSimulationFrame = m_SimulationSystem.frameIndex;
+            NativeArray<Entity> queriedCompanies = default;
+
+            try
+            {
+                if (captureProbeResults)
+                {
+                    queriedCompanies = officeCompanyQuery.ToEntityArray(Allocator.Temp);
+                }
+
                 using EntityCommandBuffer commandBuffer = new EntityCommandBuffer(Allocator.TempJob);
                 using NativeQueue<BuyerOverrideProbeRecord> probeResults = new NativeQueue<BuyerOverrideProbeRecord>(Allocator.TempJob);
                 using NativeQueue<int2> chunkTelemetryResults = new NativeQueue<int2>(Allocator.TempJob);
@@ -514,6 +643,7 @@ namespace NoOfficeDemandFix.Systems
                         OwnedVehicles = GetBufferLookup<OwnedVehicle>(isReadOnly: true),
                         DeliveryTrucks = GetComponentLookup<Game.Vehicles.DeliveryTruck>(isReadOnly: true),
                         LayoutElements = GetBufferLookup<LayoutElement>(isReadOnly: true),
+                        CurrentTradings = GetBufferLookup<CurrentTrading>(isReadOnly: true),
                         ResourcePrefabs = resourcePrefabs,
                         CommandBuffer = commandBuffer.AsParallelWriter(),
                         ProbeResults = probeResults.AsParallelWriter(),
@@ -539,19 +669,17 @@ namespace NoOfficeDemandFix.Systems
                     return;
                 }
 
+                ObserveQueriedCompanies(queriedCompanies, usedFullSweep, currentSimulationFrame);
                 while (probeResults.TryDequeue(out BuyerOverrideProbeRecord probeRecord))
                 {
-                    AccumulateProbe(probeRecord);
+                    AccumulateProbe(probeRecord, usedFullSweep, currentSimulationFrame);
                 }
             }
             finally
             {
-                m_LastCorrectiveBuyerTaggingEnabled = correctiveBuyerTaggingEnabled;
-
-                if (captureTelemetry)
+                if (queriedCompanies.IsCreated)
                 {
-                    PerformanceTelemetryCollector.RecordModUpdateElapsedTicks(Stopwatch.GetTimestamp() - telemetryStart);
-                    PerformanceTelemetryCollector.RecordModActivity(telemetryEntitiesInspected, telemetryRepathRequested);
+                    queriedCompanies.Dispose();
                 }
             }
         }
@@ -660,6 +788,11 @@ namespace NoOfficeDemandFix.Systems
                 return false;
             }
 
+            if (HasCurrentTradingForResource(company, selectedResource))
+            {
+                return false;
+            }
+
             int overrideAmount = math.max(kResourceMinimumRequestAmount, threshold - effectiveStock);
             if (overrideAmount <= 0)
             {
@@ -675,6 +808,29 @@ namespace NoOfficeDemandFix.Systems
                 m_ResourceNeeded = selectedResource
             };
             return true;
+        }
+
+        private bool HasCurrentTradingForResource(Entity company, Resource resource)
+        {
+            if (!EntityManager.HasBuffer<CurrentTrading>(company))
+            {
+                return false;
+            }
+
+            return HasCurrentTradingForResource(EntityManager.GetBuffer<CurrentTrading>(company, isReadOnly: true), resource);
+        }
+
+        private static bool HasCurrentTradingForResource(DynamicBuffer<CurrentTrading> currentTrading, Resource resource)
+        {
+            for (int i = 0; i < currentTrading.Length; i++)
+            {
+                if (currentTrading[i].m_TradingResource == resource)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private PrefabVirtualInputInfo GetPrefabVirtualInputInfo(Entity prefab)
@@ -864,7 +1020,7 @@ namespace NoOfficeDemandFix.Systems
                    currentBuyer.m_Flags == provenance.Flags;
         }
 
-        private void AccumulateProbe(BuyerOverrideProbeRecord probeRecord)
+        private void AccumulateProbe(BuyerOverrideProbeRecord probeRecord, bool usedFullSweep, uint currentSimulationFrame)
         {
             if (Mod.Settings == null)
             {
@@ -881,6 +1037,7 @@ namespace NoOfficeDemandFix.Systems
             int shortfall = math.max(0, probeRecord.Threshold - probeRecord.EffectiveStock);
             string companyKey = FormatEntity(probeRecord.Company);
 
+            ObserveOverride(probeRecord, usedFullSweep, currentSimulationFrame);
             m_ProbeTotalOverrideCount++;
             m_ProbeDistinctCompanies.Add(companyKey);
 
@@ -963,11 +1120,88 @@ namespace NoOfficeDemandFix.Systems
             m_ProbeResourceAggregates.Clear();
             m_ProbeDistinctCompanies.Clear();
             m_ProbeTopSamples.Clear();
+            m_CompanyProbeWindowStates.Clear();
             m_ProbeTotalOverrideCount = 0;
             m_ProbeClampedMinimumOverrideCount = 0;
             m_ProbeAboveMinimumOverrideCount = 0;
             m_ProbeMaxOverrideAmount = 0;
             m_ProbeMaxShortfall = 0;
+        }
+
+        public bool TryGetCompanyProbeWindowSnapshot(Entity company, out CompanyProbeWindowSnapshot snapshot)
+        {
+            if (m_CompanyProbeWindowStates.TryGetValue(company, out CompanyProbeWindowState state))
+            {
+                snapshot = new CompanyProbeWindowSnapshot(
+                    state.SeenChangedQueryCount,
+                    state.SeenFullSweepCount,
+                    state.LastSeenViaFullSweep,
+                    state.LastSeenFrame,
+                    state.OverrideCount,
+                    state.LastOverrideViaFullSweep,
+                    state.LastOverrideFrame,
+                    state.LastOverrideAmount,
+                    state.LastOverrideShortfall,
+                    state.LastOverrideStock,
+                    state.LastOverrideBuyingLoad,
+                    state.LastOverrideTripNeededAmount,
+                    state.LastOverrideEffectiveStock,
+                    state.LastOverrideThreshold);
+                return true;
+            }
+
+            snapshot = default;
+            return false;
+        }
+
+        public static string GetPassKindLabel(bool viaFullSweep)
+        {
+            return viaFullSweep ? kPassKindFullSweep : kPassKindChangedQuery;
+        }
+
+        private void ObserveQueriedCompanies(NativeArray<Entity> companies, bool usedFullSweep, uint currentSimulationFrame)
+        {
+            for (int i = 0; i < companies.Length; i++)
+            {
+                CompanyProbeWindowState state = GetOrCreateCompanyProbeWindowState(companies[i]);
+                if (usedFullSweep)
+                {
+                    state.SeenFullSweepCount++;
+                }
+                else
+                {
+                    state.SeenChangedQueryCount++;
+                }
+
+                state.LastSeenViaFullSweep = usedFullSweep;
+                state.LastSeenFrame = (int)currentSimulationFrame;
+            }
+        }
+
+        private void ObserveOverride(BuyerOverrideProbeRecord probeRecord, bool usedFullSweep, uint currentSimulationFrame)
+        {
+            CompanyProbeWindowState state = GetOrCreateCompanyProbeWindowState(probeRecord.Company);
+            state.OverrideCount++;
+            state.LastOverrideViaFullSweep = usedFullSweep;
+            state.LastOverrideFrame = (int)currentSimulationFrame;
+            state.LastOverrideAmount = probeRecord.OverrideAmount;
+            state.LastOverrideShortfall = math.max(0, probeRecord.Threshold - probeRecord.EffectiveStock);
+            state.LastOverrideStock = probeRecord.Stock;
+            state.LastOverrideBuyingLoad = probeRecord.BuyingLoad;
+            state.LastOverrideTripNeededAmount = probeRecord.TripNeededAmount;
+            state.LastOverrideEffectiveStock = probeRecord.EffectiveStock;
+            state.LastOverrideThreshold = probeRecord.Threshold;
+        }
+
+        private CompanyProbeWindowState GetOrCreateCompanyProbeWindowState(Entity company)
+        {
+            if (!m_CompanyProbeWindowStates.TryGetValue(company, out CompanyProbeWindowState state))
+            {
+                state = new CompanyProbeWindowState();
+                m_CompanyProbeWindowStates.Add(company, state);
+            }
+
+            return state;
         }
 
         private void TryCaptureTopSample(BuyerOverrideSample sample)
@@ -1071,7 +1305,30 @@ namespace NoOfficeDemandFix.Systems
                 {
                     ComponentType.ReadOnly<ResourceBuyer>(),
                     ComponentType.ReadOnly<PathInformation>(),
-                    ComponentType.ReadOnly<CurrentTrading>(),
+                    ComponentType.ReadOnly<Deleted>(),
+                    ComponentType.ReadOnly<Temp>()
+                }
+            };
+        }
+
+        private static EntityQueryDesc CreateOfficeCompanyCurrentTradingChangedQueryDesc()
+        {
+            return new EntityQueryDesc
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<OfficeCompany>(),
+                    ComponentType.ReadOnly<BuyingCompany>(),
+                    ComponentType.ReadOnly<PrefabRef>(),
+                    ComponentType.ReadOnly<PropertyRenter>(),
+                    ComponentType.ReadOnly<Resources>(),
+                    ComponentType.ReadOnly<CitizenTripNeeded>(),
+                    ComponentType.ReadOnly<CurrentTrading>()
+                },
+                None = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<ResourceBuyer>(),
+                    ComponentType.ReadOnly<PathInformation>(),
                     ComponentType.ReadOnly<Deleted>(),
                     ComponentType.ReadOnly<Temp>()
                 }
@@ -1104,6 +1361,24 @@ namespace NoOfficeDemandFix.Systems
             public long TotalOverrideAmount;
             public int MaxOverrideAmount;
             public int MaxShortfall;
+        }
+
+        private sealed class CompanyProbeWindowState
+        {
+            public int SeenChangedQueryCount;
+            public int SeenFullSweepCount;
+            public bool LastSeenViaFullSweep;
+            public int LastSeenFrame = -1;
+            public int OverrideCount;
+            public bool LastOverrideViaFullSweep;
+            public int LastOverrideFrame = -1;
+            public int LastOverrideAmount;
+            public int LastOverrideShortfall;
+            public int LastOverrideStock;
+            public int LastOverrideBuyingLoad;
+            public int LastOverrideTripNeededAmount;
+            public int LastOverrideEffectiveStock;
+            public int LastOverrideThreshold;
         }
 
         private readonly struct PrefabVirtualInputInfo

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ plus a separate experimental software-troubleshooting toolset:
 - `Phantom Vacancy`: occupied properties that are still counted as market listings
 - `Office AI chunk iteration`: office stock consumption and virtual export should
   not stop at the first low-stock office in a chunk
-- office-resource / `software` instability: experimental import seller and buyer fallbacks plus optional diagnostics for remaining virtual-resource stalls
+- office-resource / `software` instability: experimental import seller and buyer fallbacks plus optional diagnostics for remaining fulfillment stalls and demand-response mismatches
 
 The current release ships the confirmed `Signature` phantom-vacancy fix and
 an always-on office AI hotfix, and also includes enabled-by-default
@@ -20,6 +20,9 @@ This release also restores the older `2x` office resource-demand baseline
 with a direct Harmony patch instead of keeping the newer vanilla `3x`
 multiplier, so office-demand comparisons remain compatible with earlier
 evidence gathered before that vanilla change.
+Recent same-lineage evidence also shows that the broader `software` track is
+not one symptom: office demand can recover while many existing software
+consumers still remain stalled at `Software(stock=0)`.
 
 ## Current Release
 
@@ -29,7 +32,7 @@ What the current code does:
 - hotfixes the vanilla office AI loop so one low-stock office no longer prevents later offices in the same chunk from consuming output and queuing virtual exports
 - restores the pre-hotfix office demand baseline for office resources with a direct Harmony patch, so office-demand comparisons stay on the older `2x` basis rather than vanilla's newer `3x`
 - includes an experimental Harmony-based outside-connection virtual seller correction that appends active outside connections reporting stock for office virtual-resource imports when the vanilla seller pass filtered them out because the prefab storage mask does not list that virtual resource
-- includes an experimental virtual office buyer timing correction that adds a narrow post-vanilla fallback buyer for zero-weight office inputs when a company still has no buyer, path, trip, or current-trading state
+- includes an experimental virtual office buyer timing correction that adds a narrow post-vanilla fallback buyer for zero-weight office inputs when a company still has no buyer, path, trip, or same-resource current-trading state
 - keeps diagnostics available for office demand, phantom vacancy, and `software` producer/consumer office state when you turn them on for troubleshooting
 - retires the earlier office-resource storage patch experiment because zero-weight office resources do not fit the current vanilla virtual-resource architecture
 
@@ -47,7 +50,7 @@ Current defaults from [Setting.cs](./NoOfficeDemandFix/Setting.cs):
 | --- | --- | --- |
 | `EnablePhantomVacancyFix` | `true` | Enables the shipped guard that removes stale market state from occupied `Signature` office and industrial properties. Applies immediately to future simulation ticks; disabling it stops future corrections but does not restore already cleaned-up market state. |
 | `EnableOutsideConnectionVirtualSellerFix` | `true` | Enables the default experimental software import seller fallback. Takes effect on the next game launch. It only appends active outside connections that already report stock for the requested office virtual-resource import but were filtered out by the prefab storage mask, and it does not change cargo or storage definitions. |
-| `EnableVirtualOfficeResourceBuyerFix` | `true` | Enables the default experimental software import buyer fallback. It adds a narrow fallback `ResourceBuyer` for zero-weight office inputs such as `Software` when a company is below the low-stock threshold but still has no buyer/path/trip/current-trading state. |
+| `EnableVirtualOfficeResourceBuyerFix` | `true` | Enables the default experimental software import buyer fallback. It adds a narrow fallback `ResourceBuyer` for zero-weight office inputs such as `Software` when a company is below the low-stock threshold but still has no buyer/path/trip/same-resource current-trading state. |
 | `EnableOfficeDemandDirectPatch` | `true` | Restores the pre-1.5.6f1 office demand baseline with the shipped direct Harmony patch. Keep it on for the current release unless you are intentionally comparing against the newer vanilla `3x` baseline. |
 | `EnableDemandDiagnostics` | `false` | Logs office-demand, phantom-vacancy, and `software` office-state details when the simulation looks suspicious. Disabled by default; turn it on for troubleshooting, or leave it off for quieter logs. |
 | `DiagnosticsSamplesPerDay` | `2` | Sets how many scheduled diagnostic samples run per displayed in-game day while diagnostics are enabled. Higher values produce denser logs. |
@@ -76,14 +79,21 @@ The safest repository-facing summary of the current release is:
 - shipped comparability rollback for the pre-hotfix office demand baseline via a direct Harmony patch
 - default experimental software import seller and buyer fallbacks; diagnostics remain available but disabled by default
 - retired office-resource storage patch experiment
-- broader software-related office/resource stalls remain under investigation
+- current evidence splits the broader software-related office/resource investigation into office-demand recovery and software-fulfillment latency
+- recent one-day same-lineage evidence shows office demand can recover while many existing software consumers still remain at `efficiency=0` with corrective buyers already present
 - office-demand/global-sales undercount remains a separate follow-up line rather than part of the current runtime corrections
 
 Current evidence does not support treating `software` producer or consumer
 distress as direct proof of lower office demand by itself. The `software` path
-remains investigational. The experimental settings only address a narrow
-outside-connection seller fallback and a narrow buyer-timing gap; they do not
-reintroduce cargo or storage physicalization.
+remains investigational across two active tracks:
+
+- `demand recovery`: why office demand stays flat, recovers, or swings during the same save lineage
+- `software fulfillment latency`: why many software-consuming offices can still remain at `efficiency=0` after a buyer has already been attached
+
+The experimental settings only address a narrow outside-connection seller
+fallback and a narrow buyer-timing gap. They do not reintroduce cargo or
+storage physicalization, and they do not claim to solve the downstream
+seller/path-resolution side of the `software` track.
 
 ## Non-Goals
 


### PR DESCRIPTION
## What changed
- Expanded `OfficeDemandDiagnosticsSystem` to emit office-demand internals, seller-resolution detail, and richer buyer-state counters for bounded software evidence runs.
- Added an industrial-demand probe plus outside-connection seller and virtual buyer observation summaries so diagnostics can separate demand recovery from software-fulfillment latency.
- Tightened the virtual office buyer fallback so it skips companies that already have same-resource `CurrentTrading`, and updated docs and raw-log automation for the new evidence fields.

## Why
- Recent same-lineage investigation showed office demand can recover while many software consumers still remain stalled, so the diagnostics stream needed to distinguish buyerless stalls, no-path stalls, and recovered-demand windows.
- Refs: #139

## How
- Captured office-resource demand internals from `IndustrialDemandSystem` and attached them to scheduled diagnostics observations together with new `softwareSellerResolutionProbe` detail lines.
- Tracked per-company buyer probe windows and estimated missed vanilla buyer passes, and suppressed the corrective buyer fallback when same-resource `CurrentTrading` already exists.
- Save impact: no save-format changes called out; this PR changes runtime diagnostics, experimental office-resource fallback behavior, and troubleshooting documentation only.

## Testing
- Build / validation:
  - `dotnet build NoOfficeDemandFix.sln`
  - `python -m pytest .github/scripts/tests/test_raw_log_automation.py`
- Manual verification:
  - Not run.
- Settings touched:
  - Existing setting descriptions only; no default changes.

## Risk / Rollback
- Risk areas:
  - Additional diagnostics and probe state can increase troubleshooting-log volume or misclassify software stall states if the new counters drift from runtime behavior.
  - The buyer fallback now treats same-resource `CurrentTrading` as sufficient activity, so false negatives would leave some offices on the vanilla path longer.
- Rollback / mitigation:
  - Revert this branch to restore the previous diagnostics contract and buyer/seller fallback behavior if triage or runtime comparisons regress.
  - Keep `EnableDemandDiagnostics` and `VerboseLogging` off outside troubleshooting runs to limit extra log churn from the new probes.

## Reviewer Checklist
- [x] Linked issue or investigation item when applicable
- [x] README or docs updated for behavior or documentation changes
- [x] Save impact called out
- [x] Verification steps are specific enough to reproduce
- [x] Risk and rollback are concrete for shipped behavior

## PR Classification (optional)
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Docs
- [ ] Chore/Maintenance
- [ ] Build/CI
- [ ] Test

Justification:
This PR tightens the experimental office-resource buyer/seller paths and expands the diagnostics needed to explain the newer demand-recovery-versus-fulfillment-latency split. The docs and raw-log tooling changes follow the same runtime evidence model.
